### PR TITLE
Basic unit-test infrastructure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,12 @@ endif()
 add_executable(${nalu_ex_name} nalu.C)
 target_link_libraries(${nalu_ex_name} nalu)
 
-add_executable(unit_tests unit_tests.C ${UNIT_TESTS_SOURCES})
-target_link_libraries(unit_tests nalu)
+set(utest_ex_name "unittestX")
+if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+   set(utest_ex_name "unittestXd")
+endif()
+
+add_executable(${utest_ex_name} unit_tests.C ${UNIT_TESTS_SOURCES})
+target_link_libraries(${utest_ex_name} nalu)
 
 MESSAGE("\nAnd CMake says...:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ add_library (nalu ${SOURCE} ${HEADER})
 target_link_libraries(nalu ${Trilinos_LIBRARIES})
 target_link_libraries(nalu ${YAML_LIBRARY})
 
+file (GLOB UNIT_TESTS_SOURCES unit_tests/*.C)
+
 set(nalu_ex_name "naluX")
 message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
@@ -108,4 +110,8 @@ endif()
 
 add_executable(${nalu_ex_name} nalu.C)
 target_link_libraries(${nalu_ex_name} nalu)
+
+add_executable(unit_tests unit_tests.C ${UNIT_TESTS_SOURCES})
+target_link_libraries(unit_tests nalu)
+
 MESSAGE("\nAnd CMake says...:")

--- a/unit_tests.C
+++ b/unit_tests.C
@@ -1,0 +1,31 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include <gtest/gtest.h>                // for InitGoogleTest, etc
+#include <mpi.h>                        // for MPI_Comm_rank, MPI_Finalize, etc
+
+#include "include/NaluEnv.h"
+
+int gl_argc = 0;
+char** gl_argv = 0;
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    //NaluEnv will call MPI_Finalize for us.
+    sierra::nalu::NaluEnv::self();
+
+    testing::InitGoogleTest(&argc, argv);
+
+    gl_argc = argc;
+    gl_argv = argv;
+
+    int returnVal = RUN_ALL_TESTS();
+
+    return returnVal;
+}
+

--- a/unit_tests/UnitTest1ElemCoordCheck.C
+++ b/unit_tests/UnitTest1ElemCoordCheck.C
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <limits>
+
+#include <stk_util/parallel/Parallel.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Bucket.hpp>
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_io/StkMeshIoBroker.hpp>
+
+void fill_mesh_1_elem_per_proc_hex8(stk::mesh::BulkData& bulk)
+{
+    int nprocs = bulk.parallel_size();
+    std::string meshSpec = "generated:1x1x"+std::to_string(nprocs);
+
+    stk::io::StkMeshIoBroker io(bulk.parallel());
+    io.set_bulk_data(bulk);
+    io.add_mesh_database(meshSpec, stk::io::READ_MESH);
+    io.create_input_mesh();
+    io.populate_bulk_data();
+}
+
+unsigned count_locally_owned_elems(const stk::mesh::BulkData& bulk)
+{
+    return stk::mesh::count_selected_entities(bulk.mesh_meta_data().locally_owned_part(),
+                                              bulk.buckets(stk::topology::ELEM_RANK));
+}
+
+void verify_elems_are_unit_cubes(const stk::mesh::BulkData& bulk)
+{
+    typedef stk::mesh::Field<double,stk::mesh::Cartesian> CoordFieldType;
+    CoordFieldType* coordField = bulk.mesh_meta_data().get_field<CoordFieldType>(stk::topology::NODE_RANK, "coordinates");
+    EXPECT_TRUE(coordField != nullptr);
+
+    stk::mesh::EntityVector elems;
+    stk::mesh::get_entities(bulk, stk::topology::ELEM_RANK, elems);
+
+    const double tolerance = std::numeric_limits<double>::epsilon();
+
+    for(stk::mesh::Entity elem : elems) {
+        double minX = 999.99, minY = 999.99, minZ = 999.99;
+        double maxX = 0, maxY = 0, maxZ = 0;
+        const stk::mesh::Entity* nodes = bulk.begin_nodes(elem);
+        unsigned numNodes = bulk.num_nodes(elem);
+        for(unsigned i=0; i<numNodes; ++i) {
+            double* nodeCoords = stk::mesh::field_data(*coordField, nodes[i]);
+            minX = std::min(minX, nodeCoords[0]);
+            minY = std::min(minY, nodeCoords[1]);
+            minZ = std::min(minZ, nodeCoords[2]);
+            maxX = std::max(maxX, nodeCoords[0]);
+            maxY = std::max(maxY, nodeCoords[1]);
+            maxZ = std::max(maxZ, nodeCoords[2]);
+        }
+
+        EXPECT_NEAR(1.0, (maxX-minX), tolerance);
+        EXPECT_NEAR(1.0, (maxY-minY), tolerance);
+        EXPECT_NEAR(1.0, (maxZ-minZ), tolerance);
+    }
+}
+
+TEST(Basic, CheckCoords1Elem)
+{
+    stk::ParallelMachine comm = MPI_COMM_WORLD;
+
+    unsigned spatialDimension = 3;
+    stk::mesh::MetaData meta(spatialDimension);
+    stk::mesh::BulkData bulk(meta, comm);
+
+    fill_mesh_1_elem_per_proc_hex8(bulk);
+
+    EXPECT_EQ(1u, count_locally_owned_elems(bulk));
+
+    verify_elems_are_unit_cubes(bulk);
+}
+

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -1,0 +1,21 @@
+#include <string>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_io/StkMeshIoBroker.hpp>
+
+namespace unit_test_utils {
+
+void fill_mesh_1_elem_per_proc_hex8(stk::mesh::BulkData& bulk)
+{
+    int nprocs = bulk.parallel_size();
+    std::string meshSpec = "generated:1x1x"+std::to_string(nprocs);
+
+    stk::io::StkMeshIoBroker io(bulk.parallel());
+    io.set_bulk_data(bulk);
+    io.add_mesh_database(meshSpec, stk::io::READ_MESH);
+    io.create_input_mesh();
+    io.populate_bulk_data();
+}
+
+}
+

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -1,0 +1,9 @@
+
+#include <stk_mesh/base/BulkData.hpp>
+
+namespace unit_test_utils {
+
+void fill_mesh_1_elem_per_proc_hex8(stk::mesh::BulkData& bulk);
+
+}
+


### PR DESCRIPTION
Demonstration unit-test creates a mesh with 1 element per processor,
verifies that each element is a unit cube by looking at nodal coordinates.