### PR TITLE
Prototype algorithm design to remove resize

### DIFF
--- a/include/Algorithm.h
+++ b/include/Algorithm.h
@@ -45,6 +45,7 @@ public:
   virtual void pre_work() {}
 
   Realm &realm_;
+
   stk::mesh::PartVector partVec_;
   std::vector<SupplementalAlgorithm *> supplementalAlg_;
 };

--- a/include/AlgorithmDriver.h
+++ b/include/AlgorithmDriver.h
@@ -33,6 +33,7 @@ public:
 
   Realm &realm_;
   std::map<AlgorithmType, Algorithm *> algMap_;
+  std::map<std::string, Algorithm *> algorithmMap_;
 };
 
 } // namespace nalu

--- a/include/AssembleCourantReynoldsElemAlgorithm.h
+++ b/include/AssembleCourantReynoldsElemAlgorithm.h
@@ -23,11 +23,21 @@ public:
 
   AssembleCourantReynoldsElemAlgorithm(
     Realm &realm,
-    stk::mesh::Part *part);
+    stk::mesh::Part *part, 
+    MasterElement *meSCS);
   virtual ~AssembleCourantReynoldsElemAlgorithm() {}
 
   virtual void execute();
-  
+
+  MasterElement *meSCS_;
+  const int nodesPerElement_;
+  const int numScsIp_;
+  const int *lrscv_;
+
+  const stk::mesh::BulkData *bulkData_;
+  const stk::mesh::MetaData *metaData_;
+  const int nDim_;
+
   const bool meshMotion_;
 
   VectorFieldType *velocityRTM_;
@@ -36,6 +46,12 @@ public:
   ScalarFieldType *viscosity_;
   GenericFieldType *elemReynolds_;
   GenericFieldType *elemCourant_;
+
+  // ws fields
+  std::vector<double> ws_vrtm_;
+  std::vector<double> ws_coordinates_;
+  std::vector<double> ws_density_;
+  std::vector<double> ws_viscosity_;
 };
 
 } // namespace nalu

--- a/include/ContinuityAdvElemSuppAlg.h
+++ b/include/ContinuityAdvElemSuppAlg.h
@@ -45,7 +45,6 @@ public:
   
   const stk::mesh::BulkData *bulkData_;
 
-
   // extract fields; nodal
   VectorFieldType *velocityRTM_;
   VectorFieldType *Gpdx_;

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -33,7 +33,7 @@ class MasterElement
 {
 public:
 
-  MasterElement();
+  MasterElement(std::string name="na");
   virtual ~MasterElement();
 
   virtual void determinant(
@@ -163,10 +163,14 @@ public:
   bool within_tolerance(const double & val, const double & tol);
   double vector_norm_sq(const double * vect, int len);
 
+  /* return a short name */
+  std::string name();
+
   int nDim_;
   int nodesPerElement_;
   int numIntPoints_;
   double scaleToStandardIsoFac_;
+  const std::string name_;
 
   std::vector<int> lrscv_;
   std::vector<int> ipNodeMap_;
@@ -319,7 +323,7 @@ public:
 class HexahedralP2Element : public MasterElement
 {
 public:
-  HexahedralP2Element();
+  HexahedralP2Element(std::string name);
   virtual ~HexahedralP2Element() {}
 
   void shape_fcn(double *shpfc);
@@ -916,7 +920,7 @@ public:
 class QuadrilateralP2Element : public MasterElement
 {
 public:
-  QuadrilateralP2Element();
+  QuadrilateralP2Element( std::string name );
   virtual ~QuadrilateralP2Element() {}
 
   void shape_fcn(double *shpfc);

--- a/src/Algorithm.C
+++ b/src/Algorithm.C
@@ -5,7 +5,6 @@
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 
-
 #include <Algorithm.h>
 #include <SupplementalAlgorithm.h>
 

--- a/src/AlgorithmDriver.C
+++ b/src/AlgorithmDriver.C
@@ -36,9 +36,17 @@ AlgorithmDriver::AlgorithmDriver(
 //--------------------------------------------------------------------------
 AlgorithmDriver::~AlgorithmDriver()
 {
+  // manage two types of maps; AlgorithmType
   std::map<AlgorithmType, Algorithm * >::iterator ii;
   for( ii=algMap_.begin(); ii!=algMap_.end(); ++ii ) {
     Algorithm *theAlg = ii->second;
+    delete theAlg;
+  }
+
+  // ... and string
+  std::map<std::string, Algorithm * >::iterator is;
+  for( is=algorithmMap_.begin(); is!=algorithmMap_.end(); ++is ) {
+    Algorithm *theAlg = is->second;
     delete theAlg;
   }
 }
@@ -55,6 +63,11 @@ AlgorithmDriver::execute()
   std::map<AlgorithmType, Algorithm *>::iterator it;
   for ( it = algMap_.begin(); it != algMap_.end(); ++it ) {
     it->second->execute();
+  }
+
+  std::map<std::string, Algorithm *>::iterator is;
+  for ( is = algorithmMap_.begin(); is != algorithmMap_.end(); ++is ) {
+    is->second->execute();
   }
 
   post_work();

--- a/src/AssembleCourantReynoldsElemAlgorithm.C
+++ b/src/AssembleCourantReynoldsElemAlgorithm.C
@@ -40,8 +40,16 @@ namespace nalu{
 //--------------------------------------------------------------------------
 AssembleCourantReynoldsElemAlgorithm::AssembleCourantReynoldsElemAlgorithm(
   Realm &realm,
-  stk::mesh::Part *part)
+  stk::mesh::Part *part, 
+  MasterElement *meSCS)
   : Algorithm(realm, part),
+    meSCS_(meSCS),
+    nodesPerElement_(meSCS->nodesPerElement_),
+    numScsIp_(meSCS->numIntPoints_),
+    lrscv_(meSCS->adjacentNodes()),
+    bulkData_(&realm.bulk_data()),
+    metaData_(&realm_.meta_data()),
+    nDim_(realm_.meta_data().spatial_dimension()),
     meshMotion_(realm_.does_mesh_move()),
     velocityRTM_(NULL),
     coordinates_(NULL),
@@ -51,20 +59,25 @@ AssembleCourantReynoldsElemAlgorithm::AssembleCourantReynoldsElemAlgorithm(
     elemCourant_(NULL)
 {
   // save off data
-  stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   const std::string viscName = (realm.is_turbulent())
-     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
+    ? "effective_viscosity_u" : "viscosity";
+  viscosity_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
 
   // provide for elemental fields
-  elemReynolds_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds");
-  elemCourant_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant");
+  elemReynolds_ = metaData_->get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds");
+  elemCourant_ = metaData_->get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant");
+
+  // size the workset fields
+  ws_vrtm_.resize(nodesPerElement_*nDim_);
+  ws_coordinates_.resize(nodesPerElement_*nDim_);
+  ws_density_.resize(nodesPerElement_);
+  ws_viscosity_.resize(nodesPerElement_);
 }
 
 //--------------------------------------------------------------------------
@@ -73,20 +86,14 @@ AssembleCourantReynoldsElemAlgorithm::AssembleCourantReynoldsElemAlgorithm(
 void
 AssembleCourantReynoldsElemAlgorithm::execute()
 {
-
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
-  stk::mesh::MetaData & meta_data = realm_.meta_data();
-
-  const int nDim = meta_data.spatial_dimension();
+  // pointers.
+  double *p_vrtm = &ws_vrtm_[0];
+  double *p_coordinates = &ws_coordinates_[0];
+  double *p_density = &ws_density_[0];
+  double *p_viscosity = &ws_viscosity_[0];
 
   const double dt = realm_.timeIntegrator_->get_time_step();
   const double small = 1.0e-16;
-
-  // nodal fields to gather; gather everything other than what we are assembling
-  std::vector<double> ws_vrtm;
-  std::vector<double> ws_coordinates;
-  std::vector<double> ws_density;
-  std::vector<double> ws_viscosity;
 
   // deal with state
   ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
@@ -95,7 +102,7 @@ AssembleCourantReynoldsElemAlgorithm::execute()
   double maxCR[2] = {-1.0, -1.0};
 
   // define some common selectors
-  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+  stk::mesh::Selector s_locally_owned_union = metaData_->locally_owned_part()
     & stk::mesh::selectUnion(partVec_) 
     & !(realm_.get_inactive_selector());
 
@@ -105,27 +112,7 @@ AssembleCourantReynoldsElemAlgorithm::execute()
         ib != elem_buckets.end() ; ++ib ) {
     stk::mesh::Bucket & b = **ib ;
     const stk::mesh::Bucket::size_type length   = b.size();
-
-    // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-
-    // extract master element specifics
-    const int nodesPerElement = meSCS->nodesPerElement_;
-    const int numScsIp = meSCS->numIntPoints_;
-    const int *lrscv = meSCS->adjacentNodes();
-
-    // algorithm related
-    ws_vrtm.resize(nodesPerElement*nDim);
-    ws_coordinates.resize(nodesPerElement*nDim);
-    ws_density.resize(nodesPerElement);
-    ws_viscosity.resize(nodesPerElement);
-
-    // pointers.
-    double *p_vrtm = &ws_vrtm[0];
-    double *p_coordinates = &ws_coordinates[0];
-    double *p_density = &ws_density[0];
-    double *p_viscosity = &ws_viscosity[0];
-
+    
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
       // get elem
@@ -138,11 +125,11 @@ AssembleCourantReynoldsElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = bulk_data.begin_nodes(elem);
-      int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const * node_rels = bulkData_->begin_nodes(elem);
+      int num_nodes = bulkData_->num_nodes(elem);
 
       // sanity check on num nodes
-      ThrowAssert( num_nodes == nodesPerElement );
+      ThrowAssert( num_nodes == nodesPerElement_ );
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = node_rels[ni];
@@ -156,8 +143,8 @@ AssembleCourantReynoldsElemAlgorithm::execute()
         p_viscosity[ni] = *stk::mesh::field_data(*viscosity_, node);
 
         // gather vectors
-        const int offSet = ni*nDim;
-        for ( int j = 0; j < nDim; ++j ) {
+        const int offSet = ni*nDim_;
+        for ( int j = 0; j < nDim_; ++j ) {
           p_coordinates[offSet+j] = coords[j];
           p_vrtm[offSet+j] = vrtm[j];
         }
@@ -166,17 +153,17 @@ AssembleCourantReynoldsElemAlgorithm::execute()
       // compute cfl and Re along each edge; set ip max to negative
       double eReynolds = -1.0;
       double eCourant = -1.0;
-      for ( int ip = 0; ip < numScsIp; ++ip ) {
+      for ( int ip = 0; ip < numScsIp_; ++ip ) {
 
         // left and right nodes for this ip
-        const int il = lrscv[2*ip];
-        const int ir = lrscv[2*ip+1];
+        const int il = lrscv_[2*ip];
+        const int ir = lrscv_[2*ip+1];
 
         double udotx = 0.0;
         double dxSq = 0.0;
-        for ( int j = 0; j < nDim; ++j ) {
-          double ujIp = 0.5*(p_vrtm[il*nDim+j]+p_vrtm[il*nDim+j]);
-          double dxj = p_coordinates[ir*nDim+j] - p_coordinates[il*nDim+j];
+        for ( int j = 0; j < nDim_; ++j ) {
+          double ujIp = 0.5*(p_vrtm[il*nDim_+j]+p_vrtm[il*nDim_+j]);
+          double dxj = p_coordinates[ir*nDim_+j] - p_coordinates[il*nDim_+j];
           udotx += dxj*ujIp;
           dxSq += dxj*dxj;
         }
@@ -200,15 +187,16 @@ AssembleCourantReynoldsElemAlgorithm::execute()
     }
   }
 
+  // FIXME: Tricky now since algorithms do not operate on all of the parts...
+
   // parallel max
   double g_maxCR[2]  = {};
   stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
   stk::all_reduce_max(comm, maxCR, g_maxCR, 2);
 
   // sent to realm
-  realm_.maxCourant_ = g_maxCR[0];
-  realm_.maxReynolds_ = g_maxCR[1];
-
+  realm_.maxCourant_ = std::max(realm_.maxCourant_, g_maxCR[0]);
+  realm_.maxReynolds_ = std::max(realm_.maxReynolds_, g_maxCR[1]);
 }
 
 } // namespace nalu

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -154,6 +154,7 @@
 
 // basic c++
 #include <vector>
+#include <string>
 
 namespace sierra{
 namespace nalu{
@@ -619,7 +620,9 @@ LowMachEquationSystem::solve_and_update()
 
   }
 
-  // process CFL/Reynolds
+  // process CFL/Reynolds; zero out...
+  realm_.maxCourant_ = 0.0;
+  realm_.maxReynolds_ = 0.0;
   momentumEqSys_->cflReyAlgDriver_->execute();
 }
 
@@ -958,16 +961,23 @@ MomentumEquationSystem::register_interior_algorithm(
   const AlgorithmType algType = INTERIOR;
   const AlgorithmType algMass = MASS;
 
+  // extract master element
+  MasterElement *meSCS = realm_.get_surface_master_element(part->topology());
+
+  // base names
+  const std::string baseSCSName = meSCS->name();
+  
   // non-solver CFL alg
-  std::map<AlgorithmType, Algorithm *>::iterator it
-    = cflReyAlgDriver_->algMap_.find(algType);
-  if ( it == cflReyAlgDriver_->algMap_.end() ) {
-    AssembleCourantReynoldsElemAlgorithm*theAlg
-      = new AssembleCourantReynoldsElemAlgorithm(realm_, part);
-    cflReyAlgDriver_->algMap_[algType] = theAlg;
+  const std::string cflAlgName = "cflAlgName_" + baseSCSName;
+  std::map<std::string, Algorithm *>::iterator its
+    = cflReyAlgDriver_->algorithmMap_.find(cflAlgName);
+  if ( its == cflReyAlgDriver_->algorithmMap_.end() ) {
+    AssembleCourantReynoldsElemAlgorithm *theAlg
+      = new AssembleCourantReynoldsElemAlgorithm(realm_, part, meSCS);
+    cflReyAlgDriver_->algorithmMap_[cflAlgName] = theAlg;
   }
   else {
-    it->second->partVec_.push_back(part);
+    its->second->partVec_.push_back(part);
   }
 
   VectorFieldType &velocityNp1 = velocity_->field_of_state(stk::mesh::StateNP1);

--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -27,11 +27,13 @@ namespace nalu{
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-MasterElement::MasterElement()
+MasterElement::MasterElement( 
+  std::string name)
   : nDim_(0),
     nodesPerElement_(0),
     numIntPoints_(0),
-    scaleToStandardIsoFac_(1.0)
+    scaleToStandardIsoFac_(1.0),
+    name_(name)
 {
   // nothing else
 }
@@ -79,10 +81,19 @@ MasterElement::vector_norm_sq( const double * vect, int len )
 }
 
 //--------------------------------------------------------------------------
+//-------- name ------------------------------------------------------------
+//--------------------------------------------------------------------------
+std::string
+MasterElement::name()
+{
+  return name_;
+}
+
+//--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 HexSCV::HexSCV()
-  : MasterElement()
+  : MasterElement("Hex8SCV")
 {
   nDim_ = 3;
   nodesPerElement_ = 8;
@@ -182,7 +193,7 @@ HexSCV::shape_fcn(double *shpfc)
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 HexSCS::HexSCS()
-  : MasterElement()
+  : MasterElement("HexSCS")
 {
   nDim_ = 3;
   nodesPerElement_ = 8;
@@ -1029,8 +1040,8 @@ double HexSCS::parametric_distance(const std::vector<double> &x)
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-HexahedralP2Element::HexahedralP2Element()
-  : MasterElement(),
+HexahedralP2Element::HexahedralP2Element( std::string name)
+  : MasterElement(name),
     scsDist_(std::sqrt(3.0)/3.0),
     useGLLGLL_(false),
     nodes1D_(3),
@@ -1631,7 +1642,7 @@ HexahedralP2Element::hex27_shape_deriv(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Hex27SCV::Hex27SCV()
-  : HexahedralP2Element()
+  : HexahedralP2Element("Hex27SCV")
 {
   // set up the one-dimensional quadrature rule
   set_quadrature_rule();
@@ -1787,7 +1798,7 @@ Hex27SCV::jacobian_determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Hex27SCS::Hex27SCS()
-  : HexahedralP2Element()
+  : HexahedralP2Element("Hex27SCS")
 {
   // set up the one-dimensional quadrature rule
   set_quadrature_rule();
@@ -2534,7 +2545,7 @@ void Hex27SCS::gij(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 TetSCV::TetSCV()
-  : MasterElement()
+  : MasterElement("TetSCV")
 {
   nDim_ = 3;
   nodesPerElement_ = 4;
@@ -2584,7 +2595,7 @@ void TetSCV::determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 TetSCS::TetSCS()
-  : MasterElement()
+  : MasterElement("TetSCS")
 {
   nDim_ = 3;
   nodesPerElement_ = 4;
@@ -3108,7 +3119,7 @@ TetSCS::parametric_distance(const std::vector<double> &x)
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 PyrSCV::PyrSCV()
-  : MasterElement()
+  : MasterElement("PyrSCV")
 {
   nDim_ = 3;
   nodesPerElement_ = 5;
@@ -3160,7 +3171,7 @@ void PyrSCV::determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 PyrSCS::PyrSCS()
-  : MasterElement()
+  : MasterElement("PyrSCS")
 {
   nDim_ = 3;
   nodesPerElement_ = 5;
@@ -3421,7 +3432,7 @@ PyrSCS::opposingNodes(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WedSCV::WedSCV()
-  : MasterElement()
+  : MasterElement("WedSCV")
 {
   nDim_ = 3;
   nodesPerElement_ = 6;
@@ -3472,7 +3483,7 @@ void WedSCV::determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WedSCS::WedSCS()
-  : MasterElement()
+  : MasterElement("WedSCS")
 {
   nDim_ = 3;
   nodesPerElement_ = 6;
@@ -4068,7 +4079,7 @@ WedSCS::parametric_distance(const std::vector<double> &x)
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad2DSCV::Quad2DSCV()
-  : MasterElement()
+  : MasterElement("Quad2DSCV")
 {
   nDim_ = 2;
   nodesPerElement_ = 4;
@@ -4171,7 +4182,7 @@ Quad2DSCV::quad_shape_fcn(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad2DSCS::Quad2DSCS()
-  : MasterElement()
+  : MasterElement("Quad2DSCS")
 {
   nDim_ = 2;
   nodesPerElement_ = 4;
@@ -4777,8 +4788,8 @@ Quad2DSCS::edgeAlignedArea()
 //--------------------------------------------------------------------------
 //-------- constructor------------------------------------------------------
 //--------------------------------------------------------------------------
-QuadrilateralP2Element::QuadrilateralP2Element()
-  : MasterElement(),
+QuadrilateralP2Element::QuadrilateralP2Element( std::string name )
+  : MasterElement(name),
     scsDist_(std::sqrt(3.0)/3.0),
     useGLLGLL_(false),
     nodes1D_(3),
@@ -5176,7 +5187,7 @@ QuadrilateralP2Element::quad9_shape_deriv(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad92DSCV::Quad92DSCV()
-: QuadrilateralP2Element()
+: QuadrilateralP2Element("Quad92DSCV")
 {
   // set up the one-dimensional quadrature rule
   set_quadrature_rule();
@@ -5313,7 +5324,7 @@ Quad92DSCV::jacobian_determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad92DSCS::Quad92DSCS()
-  : QuadrilateralP2Element()
+  : QuadrilateralP2Element("Quad92DSCS")
 {
   // set up the one-dimensional quadrature rule
   set_quadrature_rule();
@@ -5798,7 +5809,7 @@ Quad92DSCS::area_vector(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Tri2DSCV::Tri2DSCV()
-  : MasterElement()
+  : MasterElement("Tri2DSCV")
 {
   nDim_ = 2;
   nodesPerElement_ = 3;
@@ -5848,7 +5859,7 @@ void Tri2DSCV::determinant(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Tri2DSCS::Tri2DSCS()
-  : MasterElement()
+  : MasterElement("Tri2DSCS")
 {
   nDim_ = 2;
   nodesPerElement_ = 3;
@@ -6326,7 +6337,7 @@ Tri2DSCS::sidePcoords_to_elemPcoords(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad3DSCS::Quad3DSCS()  
-  : MasterElement(),
+  : MasterElement("Quad3DSCS"),
     elemThickness_(0.1)
 {
   nDim_ = 3;
@@ -6682,7 +6693,7 @@ Quad3DSCS::general_shape_fcn(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Quad93DSCS::Quad93DSCS()
-  : HexahedralP2Element(),
+  : HexahedralP2Element("Quad93DSCS"),
     surfaceDimension_(2)
 {
   // set up the one-dimensional quadrature rule
@@ -7210,7 +7221,7 @@ Quad93DSCS::area_vector(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Tri3DSCS::Tri3DSCS()
-  : MasterElement()
+  : MasterElement("Tri3DSCS")
 {
   nDim_ = 3;
   nodesPerElement_ = 3;
@@ -7467,7 +7478,7 @@ Tri3DSCS::general_shape_fcn(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Edge2DSCS::Edge2DSCS()
-  : MasterElement(),
+  : MasterElement("Edge2DSCS"),
     elemThickness_(0.01)
 {
   nDim_ = 2;
@@ -7647,7 +7658,7 @@ Edge2DSCS::general_shape_fcn(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 Edge32DSCS::Edge32DSCS()
-  : QuadrilateralP2Element()
+  : QuadrilateralP2Element("Edge32DSCS")
 {
   nodesPerElement_ = nodes1D_;
 


### PR DESCRIPTION
The objective of this project is to remove the usage of resize in the
algorithm::execute() in favor of a homogeneous collection of parts on which
the algorithm operates.
- Modify Algorithm class to manage a map<string, Algorithm*>
- LowMachEOS now creates a set of CourantReyAlgorithms for each
  topology,
  
  // non-solver CFL alg
  const std::string cflAlgName = "cflAlgName_" + baseSCSName;
  std::map<std::string, Algorithm *>::iterator its
    = cflReyAlgDriver_->algorithmMap_.find(cflAlgName);
  if ( its == cflReyAlgDriver_->algorithmMap_.end() ) {
    AssembleCourantReynoldsElemAlgorithm *theAlg
      = new AssembleCourantReynoldsElemAlgorithm(realm_, part, meSCS);
    cflReyAlgDriver_->algorithmMap_[cflAlgName] = theAlg;
  }
  else {
    its->second->partVec_.push_back(part);
  }

The above results in multiple algorithms (each with many potential parts)
of the same topology. The core design would be that one algorithm type
holds all of the parts which can be heterogeneous.

Notes:

a) kind of extensive - I think...
b) does this move towards the unit test approach to remove a realm?
c) Tricky... Algorithms, since they once handled all of the parts
   now operate on a possible subset of parts. As such, calls such as
   the following are tricky:

  // parallel max
  double g_maxCR[2]  = {};
  stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
  stk::all_reduce_max(comm, maxCR, g_maxCR, 2);

  // sent to realm
  realm_.maxCourant_ = g_maxCR[0];
  realm_.maxReynolds_ = g_maxCR[1];

  You see, we now need something like the following:

  // before the execute
  realm_.maxCourant_ = 0.0;
  realm_.maxReynolds_ = 0.0;
  momentumEqSys_->cflReyAlgDriver_->execute();

  // sent to realm; at the end of the Alg class
  realm_.maxCourant_ = std::max(realm_.maxCourant_, g_maxCR[0]);
  realm_.maxReynolds_ = std::max(realm_.maxReynolds_, g_maxCR[1]);

  So... Conclusion is that Algorithms can no longer be extected to
  run without an AlgorithmManager to organize the pre and post-work.
