### PR TITLE
Add unit test for checking Hex 27 ip node relations

### DIFF
--- a/unit_tests/UnitTestHex27FaceNodeOrdering.C
+++ b/unit_tests/UnitTestHex27FaceNodeOrdering.C
@@ -53,7 +53,6 @@ void check_Hex27_creation(const stk::mesh::BulkData& bulk)
 
 void check_Hex27_face_ip_node_ordering(const stk::mesh::BulkData& bulk)
 {
-
   stk::topology hex27 = stk::topology::HEX_27;
   stk::topology quad9 = stk::topology::QUAD_9;
   sierra::nalu::Hex27SCS hexSCS;
@@ -74,7 +73,7 @@ void check_Hex27_face_ip_node_ordering(const stk::mesh::BulkData& bulk)
 
       const int* ipNodeMap = hexSCS.ipNodeMap(ordinal);
       const int* faceIpNodeMap = quadSCS.ipNodeMap();
-      for(unsigned ip = 0; ip < quadSCS.numIntPoints_; ++ip) {
+      for (int ip = 0; ip < quadSCS.numIntPoints_; ++ip) {
         const int elemIpNearestNode = ipNodeMap[ip];
         const int faceIpNearestNode = faceIpNodeMap[ip];
 
@@ -91,6 +90,9 @@ void check_Hex27_face_ip_node_ordering(const stk::mesh::BulkData& bulk)
 TEST(Hex27,creation)
 {
   stk::ParallelMachine comm = MPI_COMM_WORLD;
+  if (stk::parallel_machine_size(comm) != 1) {
+    return; // serial test
+  }
 
   unsigned spatialDimension = 3;
   stk::mesh::MetaData meta(spatialDimension);
@@ -103,6 +105,9 @@ TEST(Hex27,creation)
 TEST(Hex27, face_node_ordering)
 {
   stk::ParallelMachine comm = MPI_COMM_WORLD;
+  if (stk::parallel_machine_size(comm) != 1) {
+    return; // serial test
+  }
 
   unsigned spatialDimension = 3;
   stk::mesh::MetaData meta(spatialDimension);

--- a/unit_tests/UnitTestHex27FaceNodeOrdering.C
+++ b/unit_tests/UnitTestHex27FaceNodeOrdering.C
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <limits>
+
+#include <stk_util/parallel/Parallel.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Bucket.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+
+#include <master_element/MasterElement.h>
+
+#include "UnitTestUtils.h"
+
+namespace {
+
+void check_Hex27_creation(const stk::mesh::BulkData& bulk)
+{
+  stk::mesh::EntityVector elems;
+  stk::mesh::get_entities(bulk, stk::topology::ELEM_RANK, elems);
+  stk::topology hex27 = stk::topology::HEX_27;
+  stk::topology quad9 = stk::topology::QUADRILATERAL_9;
+
+  std::vector<std::vector<unsigned>> faceNodeOrdinals(6);
+  faceNodeOrdinals[0] = {0, 1, 5, 4,  8, 13, 16, 12, 25};
+  faceNodeOrdinals[1] = {1, 2, 6, 5,  9, 14, 17, 13, 24};
+  faceNodeOrdinals[2] = {2, 3, 7, 6, 10, 15, 18, 14, 26};
+  faceNodeOrdinals[3] = {0, 4, 7, 3, 12, 19, 15, 11, 23};
+  faceNodeOrdinals[4] = {0, 3, 2, 1, 11, 10,  9,  8, 21};
+  faceNodeOrdinals[5] = {4, 5, 6, 7, 16, 17, 18, 19, 22};
+
+  for(stk::mesh::Entity elem : elems) {
+    EXPECT_EQ(hex27, bulk.bucket(elem).topology());
+    const stk::mesh::ConnectivityOrdinal* ords = bulk.begin_face_ordinals(elem);
+    const stk::mesh::Entity* faces = bulk.begin_faces(elem);
+    const stk::mesh::Entity* elem_node_rels = bulk.begin_nodes(elem);
+
+    for (unsigned j = 0; j < bulk.num_faces(elem); ++j) {
+      stk::mesh::Entity face = faces[ords[j]];
+      EXPECT_EQ(quad9, bulk.bucket(face).topology());
+      const stk::mesh::Entity* face_node_rels = bulk.begin_nodes(face);
+
+      EXPECT_EQ(quad9.num_nodes(), bulk.num_nodes(face));
+      for (unsigned i = 0; i < bulk.num_nodes(face); ++i) {
+        stk::mesh::EntityId nodeId = bulk.identifier(face_node_rels[i]);
+
+        stk::mesh::Entity expectedNode = elem_node_rels[faceNodeOrdinals[ords[j]][i]];
+        stk::mesh::EntityId expectedNodeId = bulk.identifier(expectedNode);
+        EXPECT_EQ(expectedNodeId, nodeId);
+      }
+    }
+  }
+}
+
+void check_Hex27_face_ip_node_ordering(const stk::mesh::BulkData& bulk)
+{
+
+  stk::topology hex27 = stk::topology::HEX_27;
+  stk::topology quad9 = stk::topology::QUAD_9;
+  sierra::nalu::Hex27SCS hexSCS;
+  sierra::nalu::Quad93DSCS quadSCS;
+
+  stk::mesh::EntityVector elems;
+  stk::mesh::get_entities(bulk, stk::topology::ELEM_RANK, elems);
+  for(stk::mesh::Entity elem : elems) {
+    const stk::mesh::ConnectivityOrdinal* ords = bulk.begin_face_ordinals(elem);
+    const stk::mesh::Entity* faces = bulk.begin_faces(elem);
+    const stk::mesh::Entity* elem_node_rels = bulk.begin_nodes(elem);
+
+    EXPECT_EQ(hex27.num_faces(), bulk.num_faces(elem));
+    for (unsigned j = 0; j < bulk.num_faces(elem); ++j) {
+      const stk::mesh::ConnectivityOrdinal ordinal = ords[j];
+      stk::mesh::Entity face = faces[ordinal];
+      const stk::mesh::Entity* face_node_rels = bulk.begin_nodes(face);
+
+      const int* ipNodeMap = hexSCS.ipNodeMap(ordinal);
+      const int* faceIpNodeMap = quadSCS.ipNodeMap();
+      for(unsigned ip = 0; ip < quadSCS.numIntPoints_; ++ip) {
+        const int elemIpNearestNode = ipNodeMap[ip];
+        const int faceIpNearestNode = faceIpNodeMap[ip];
+
+        stk::mesh::EntityId elemNearestNodeId = bulk.identifier(elem_node_rels[elemIpNearestNode]);
+        stk::mesh::EntityId faceNearestNodeId = bulk.identifier(face_node_rels[faceIpNearestNode]);
+        EXPECT_EQ(elemNearestNodeId, faceNearestNodeId);
+      }
+    }
+  }
+}
+
+}//namespace
+
+TEST(Hex27,creation)
+{
+  stk::ParallelMachine comm = MPI_COMM_WORLD;
+
+  unsigned spatialDimension = 3;
+  stk::mesh::MetaData meta(spatialDimension);
+  stk::mesh::BulkData bulk(meta, comm);
+
+  unit_test_utils::create_one_hex27_element(bulk);
+  check_Hex27_creation(bulk);
+}
+
+TEST(Hex27, face_node_ordering)
+{
+  stk::ParallelMachine comm = MPI_COMM_WORLD;
+
+  unsigned spatialDimension = 3;
+  stk::mesh::MetaData meta(spatialDimension);
+  stk::mesh::BulkData bulk(meta, comm);
+
+  unit_test_utils::create_one_hex27_element(bulk);
+  check_Hex27_face_ip_node_ordering(bulk);
+}
+
+
+
+
+

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -31,7 +31,7 @@ void create_one_hex27_element(stk::mesh::BulkData& bulk)
    stk::topology hex27 = stk::topology::HEX_27;
    stk::mesh::Part& block_1 = meta.declare_part_with_topology("block_1", hex27);
 
-   stk::mesh::PartVector surfaces(6);
+   stk::mesh::PartVector surfaces(hex27.num_faces());
    stk::topology quad9 = stk::topology::QUAD_9;
    surfaces[0] = &meta.declare_part_with_topology("surface_1", quad9);
    surfaces[1] = &meta.declare_part_with_topology("surface_2", quad9);
@@ -41,7 +41,7 @@ void create_one_hex27_element(stk::mesh::BulkData& bulk)
    surfaces[5] = &meta.declare_part_with_topology("surface_6", quad9);
    meta.commit();
 
-   stk::mesh::EntityIdVector nodeIds(27);
+   stk::mesh::EntityIdVector nodeIds(hex27.num_nodes());
    std::iota(nodeIds.begin(), nodeIds.end(), 1);
 
    std::vector<unsigned> sideNodeOrdinals(quad9.num_nodes());

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -1,7 +1,13 @@
 #include <string>
 
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MetaData.hpp>
 #include <stk_io/StkMeshIoBroker.hpp>
+
+#include <stk_mesh/base/CreateFaces.hpp>
+#include <stk_mesh/base/FEMHelpers.hpp>
+
+#include <algorithm>
 
 namespace unit_test_utils {
 
@@ -15,6 +21,50 @@ void fill_mesh_1_elem_per_proc_hex8(stk::mesh::BulkData& bulk)
     io.add_mesh_database(meshSpec, stk::io::READ_MESH);
     io.create_input_mesh();
     io.populate_bulk_data();
+}
+
+void create_one_hex27_element(stk::mesh::BulkData& bulk)
+{
+  // no coords yet
+   auto& meta = bulk.mesh_meta_data();
+
+   stk::topology hex27 = stk::topology::HEX_27;
+   stk::mesh::Part& block_1 = meta.declare_part_with_topology("block_1", hex27);
+
+   stk::mesh::PartVector surfaces(6);
+   stk::topology quad9 = stk::topology::QUAD_9;
+   surfaces[0] = &meta.declare_part_with_topology("surface_1", quad9);
+   surfaces[1] = &meta.declare_part_with_topology("surface_2", quad9);
+   surfaces[2] = &meta.declare_part_with_topology("surface_3", quad9);
+   surfaces[3] = &meta.declare_part_with_topology("surface_4", quad9);
+   surfaces[4] = &meta.declare_part_with_topology("surface_5", quad9);
+   surfaces[5] = &meta.declare_part_with_topology("surface_6", quad9);
+   meta.commit();
+
+   stk::mesh::EntityIdVector nodeIds(27);
+   std::iota(nodeIds.begin(), nodeIds.end(), 1);
+
+   std::vector<unsigned> sideNodeOrdinals(quad9.num_nodes());
+
+   bulk.modification_begin();
+   {
+     for (auto id : nodeIds) {
+       bulk.declare_entity(stk::topology::NODE_RANK, id);
+     }
+     stk::mesh::Entity elem = stk::mesh::declare_element(bulk, block_1, 1, nodeIds);
+     const stk::mesh::Entity* elem_node_rels = bulk.begin_nodes(elem);
+
+     for (unsigned j = 0; j < hex27.num_faces(); ++j) {
+       stk::mesh::Entity face = bulk.declare_solo_side(j+1, {surfaces[j]});
+       hex27.side_node_ordinals(j, sideNodeOrdinals.begin());
+       for (unsigned i = 0; i < quad9.num_nodes(); ++i) {
+         const stk::mesh::Entity node = elem_node_rels[sideNodeOrdinals[i]];
+         bulk.declare_relation(face, node, i);
+       }
+       bulk.declare_relation(elem, face, j);
+     }
+   }
+   bulk.modification_end();
 }
 
 }

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -4,6 +4,7 @@
 namespace unit_test_utils {
 
 void fill_mesh_1_elem_per_proc_hex8(stk::mesh::BulkData& bulk);
+void create_one_hex27_element(stk::mesh::BulkData& bulk);
 
 }
 


### PR DESCRIPTION
Add a unit test to check that the consistency of ip face node relations are correct. This resolves #22  