### PR TITLE
Fix compilation error in OSX

### DIFF
--- a/unit_tests/UnitTestKokkosViews.C
+++ b/unit_tests/UnitTestKokkosViews.C
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <limits>
+#include <random>
 
 #include "UnitTestUtils.h"
 


### PR DESCRIPTION
Add the necessary header file in UnitTestsKokkosViews.C to fix the
compilation error.