### PR TITLE
Optimizations for custom ghosting.

### DIFF
--- a/include/NonConformalManager.h
+++ b/include/NonConformalManager.h
@@ -52,7 +52,6 @@ class NonConformalManager {
   ~NonConformalManager();
 
   void initialize();
-  void manage_ghosting();
 
   Realm &realm_;
   const bool ncAlgDetailedOutput_;
@@ -60,14 +59,19 @@ class NonConformalManager {
   /* ghosting for all surface:block pair */
   stk::mesh::Ghosting *nonConformalGhosting_;
 
-  uint64_t needToGhostCount_;
- 
   stk::mesh::EntityProcVec elemsToGhost_;
   std::vector<NonConformalInfo *> nonConformalInfoVec_;
 
+  static void compute_precise_ghosting_lists(const stk::mesh::BulkData& bulk,
+                                             stk::mesh::EntityProcVec& elemsToGhost,
+                                             stk::mesh::EntityProcVec& curSendGhosts,
+                                             std::vector<stk::mesh::EntityKey>& recvGhostsToRemove);
+  private:
+
+  void manage_ghosting(std::vector<stk::mesh::EntityKey>& recvGhostsToRemove);
 };
 
+} // end nalu namespace
 } // end sierra namespace
-} // end Acon namespace
 
 #endif

--- a/src/AssembleContinuityNonConformalSolverAlgorithm.C
+++ b/src/AssembleContinuityNonConformalSolverAlgorithm.C
@@ -72,6 +72,7 @@ AssembleContinuityNonConformalSolverAlgorithm::AssembleContinuityNonConformalSol
   ghostFieldVec_.push_back(coordinates_);
   ghostFieldVec_.push_back(velocityRTM_);
   ghostFieldVec_.push_back(density_);
+  ghostFieldVec_.push_back(exposedAreaVec_);
 
   // specific algorithm options
   NonConformalAlgType algType = realm_.get_nc_alg_type();

--- a/src/AssembleMomentumNonConformalSolverAlgorithm.C
+++ b/src/AssembleMomentumNonConformalSolverAlgorithm.C
@@ -65,6 +65,7 @@ AssembleMomentumNonConformalSolverAlgorithm::AssembleMomentumNonConformalSolverA
   ghostFieldVec_.push_back(&(velocity_->field_of_state(stk::mesh::StateNP1)));
   ghostFieldVec_.push_back(diffFluxCoeff_);
   ghostFieldVec_.push_back(coordinates_);
+  ghostFieldVec_.push_back(exposedAreaVec_);
   
   // specific algorithm options
   NonConformalAlgType algType = realm_.get_nc_alg_type();

--- a/src/AssembleNodalGradNonConformalAlgorithm.C
+++ b/src/AssembleNodalGradNonConformalAlgorithm.C
@@ -55,6 +55,7 @@ AssembleNodalGradNonConformalAlgorithm::AssembleNodalGradNonConformalAlgorithm(
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(scalarQ_);
+  ghostFieldVec_.push_back(exposedAreaVec_);
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleNodalGradUNonConformalAlgorithm.C
+++ b/src/AssembleNodalGradUNonConformalAlgorithm.C
@@ -55,6 +55,9 @@ AssembleNodalGradUNonConformalAlgorithm::AssembleNodalGradUNonConformalAlgorithm
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(vectorQ_);
+  ghostFieldVec_.push_back(dualNodalVolume_);
+  ghostFieldVec_.push_back(exposedAreaVec_);
+  ghostFieldVec_.push_back(dqdx_);
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotNonConformalAlgorithm.C
+++ b/src/ComputeMdotNonConformalAlgorithm.C
@@ -69,6 +69,7 @@ ComputeMdotNonConformalAlgorithm::ComputeMdotNonConformalAlgorithm(
   ghostFieldVec_.push_back(coordinates_);
   ghostFieldVec_.push_back(velocityRTM_);
   ghostFieldVec_.push_back(density_);
+  ghostFieldVec_.push_back(exposedAreaVec_);
 }
 
 //--------------------------------------------------------------------------

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -330,9 +330,6 @@ NonConformalInfo::determine_elems_to_ghost()
       ThrowAssert( bulk_data.num_elements(face) == 1 );
       stk::mesh::Entity element = face_elem_rels[0];
           
-      // new element to ghost counter
-      realm_.nonConformalManager_->needToGhostCount_++;
-
       // deal with elements to push back to be ghosted; downward relations come for the ride...
       stk::mesh::EntityProc theElemPair(element, pt_proc);
       realm_.nonConformalManager_->elemsToGhost_.push_back(theElemPair);

--- a/src/NonConformalManager.C
+++ b/src/NonConformalManager.C
@@ -23,6 +23,8 @@
 
 // stk_util
 #include <stk_util/parallel/ParallelReduce.hpp>
+#include <stk_util/parallel/CommSparse.hpp>
+#include <stk_util/util/SortAndUnique.hpp>
 
 // vector and pair
 #include <vector>
@@ -43,8 +45,7 @@ NonConformalManager::NonConformalManager(
   const bool ncAlgDetailedOutput)
   : realm_(realm ),
     ncAlgDetailedOutput_(ncAlgDetailedOutput),
-    nonConformalGhosting_(NULL),
-    needToGhostCount_(0)
+    nonConformalGhosting_(NULL)
 {
   // do nothing
 }
@@ -61,6 +62,122 @@ NonConformalManager::~NonConformalManager()
     delete (*ic);
 }
 
+void add_downward_relations(const stk::mesh::BulkData& bulk,
+                            std::vector<stk::mesh::EntityKey>& entityKeys)
+{
+  size_t numEntities = entityKeys.size();
+  for(size_t i=0; i<numEntities; ++i) {
+    stk::mesh::Entity ent = bulk.get_entity(entityKeys[i]);
+    if (bulk.is_valid(ent)) {
+      stk::mesh::EntityRank thisRank = bulk.entity_rank(ent);
+  
+      for(stk::mesh::EntityRank irank=stk::topology::NODE_RANK; irank<thisRank; ++irank) {
+        unsigned num = bulk.num_connectivity(ent, irank);
+        const stk::mesh::Entity* downwardEntities = bulk.begin(ent, irank);
+  
+        for(unsigned j=0; j<num; ++j) {
+          stk::mesh::EntityKey key = bulk.entity_key(downwardEntities[j]);
+          const stk::mesh::Bucket& bkt = bulk.bucket(downwardEntities[j]);
+          if (!bkt.shared()) {
+            entityKeys.push_back(key);
+          }
+        }
+      }
+    }
+  }
+}
+
+void keep_elems_not_already_ghosted(const stk::mesh::BulkData& bulk,
+                                    const stk::mesh::EntityProcVec& alreadyGhosted,
+                                    stk::mesh::EntityProcVec& elemsToGhost)
+{
+  if (!alreadyGhosted.empty()) {
+    size_t numKept = 0;
+    size_t num = elemsToGhost.size();
+    for(size_t i=0; i<num; ++i) {
+      if (!std::binary_search(alreadyGhosted.begin(), alreadyGhosted.end(), elemsToGhost[i])) {
+        elemsToGhost[numKept++] = elemsToGhost[i];
+      }
+    }
+    elemsToGhost.resize(numKept);
+  }
+}
+
+void fill_send_ghosts_to_remove_from_ghosting(const stk::mesh::EntityProcVec& curSendGhosts,
+                                        const stk::mesh::EntityProcVec& intersection,
+                                        stk::mesh::EntityProcVec& sendGhostsToRemove)
+{
+  sendGhostsToRemove.reserve(curSendGhosts.size() - intersection.size());
+  for(size_t i=0; i<curSendGhosts.size(); ++i) {
+    if (!std::binary_search(intersection.begin(), intersection.end(), curSendGhosts[i])) {
+      sendGhostsToRemove.push_back(curSendGhosts[i]);
+    }
+  }
+}
+
+void communicate_to_fill_recv_ghosts_to_remove(const stk::mesh::BulkData& bulk,
+                                               const stk::mesh::EntityProcVec& sendGhostsToRemove,
+                                               std::vector<stk::mesh::EntityKey>& recvGhostsToRemove)
+{
+  stk::CommSparse commSparse(bulk.parallel());
+  stk::pack_and_communicate(commSparse, [&]() {
+    for(const stk::mesh::EntityProc& entityProc : sendGhostsToRemove) {
+      stk::mesh::EntityKey key = bulk.entity_key(entityProc.first);
+      stk::CommBuffer& buf = commSparse.send_buffer(entityProc.second);
+      buf.pack<stk::mesh::EntityKey>(key);
+    }
+  });
+
+  int numProcs = bulk.parallel_size();
+  for(int p=0; p<numProcs; ++p) {
+    if (p == bulk.parallel_rank()) {
+      continue;
+    }
+    stk::CommBuffer& buf = commSparse.recv_buffer(p);
+    while(buf.remaining()) {
+      stk::mesh::EntityKey key;
+      buf.unpack<stk::mesh::EntityKey>(key);
+      recvGhostsToRemove.push_back(key);
+    }
+  }
+
+  add_downward_relations(bulk, recvGhostsToRemove);
+}
+
+void keep_only_elems(const stk::mesh::BulkData& bulk, stk::mesh::EntityProcVec& entityProcs)
+{
+  size_t elemCounter = 0;
+  for(size_t i=0; i<entityProcs.size(); ++i) {
+    if (bulk.entity_rank(entityProcs[i].first) == stk::topology::ELEM_RANK) {
+      entityProcs[elemCounter++] = entityProcs[i];
+    }
+  }
+  entityProcs.resize(elemCounter);
+}
+
+void
+NonConformalManager::compute_precise_ghosting_lists(const stk::mesh::BulkData& bulk,
+                                                    stk::mesh::EntityProcVec& elemsToGhost,
+                                                    stk::mesh::EntityProcVec& curSendGhosts,
+                                                    std::vector<stk::mesh::EntityKey>& recvGhostsToRemove)
+{
+  keep_only_elems(bulk, curSendGhosts);
+  stk::util::sort_and_unique(curSendGhosts);
+  stk::util::sort_and_unique(elemsToGhost);
+
+  stk::mesh::EntityProcVec intersection;
+  std::set_intersection(curSendGhosts.begin(), curSendGhosts.end(),
+                        elemsToGhost.begin(), elemsToGhost.end(),
+                        std::back_inserter(intersection));
+
+  keep_elems_not_already_ghosted(bulk, intersection, elemsToGhost);
+
+  stk::mesh::EntityProcVec sendGhostsToRemove;
+  fill_send_ghosts_to_remove_from_ghosting(curSendGhosts, intersection, sendGhostsToRemove);
+
+  communicate_to_fill_recv_ghosts_to_remove(bulk, sendGhostsToRemove, recvGhostsToRemove);
+}
+
 //--------------------------------------------------------------------------
 //-------- initialize ------------------------------------------------------
 //--------------------------------------------------------------------------
@@ -70,32 +187,46 @@ NonConformalManager::initialize()
 
   const double timeA = NaluEnv::self().nalu_time();
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
- 
-  // initialize need to ghost and elems to ghost
-  needToGhostCount_ = 0;
   elemsToGhost_.clear();
 
-  bulk_data.modification_begin();
-  
-  if ( nonConformalGhosting_ == NULL) {
-    // create new ghosting
-    std::string theGhostName = "nalu_nonConformal_ghosting";
-    nonConformalGhosting_ = &bulk_data.create_ghosting( theGhostName );
-  }
-  else {
-    bulk_data.destroy_ghosting(*nonConformalGhosting_);
-  }
-  
-  bulk_data.modification_end();
-  
-  // loop over nonConformalInfo and initialize
+  // loop over nonConformalInfo and initialize to update the elemsToGhost_ vector.
   for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
     nonConformalInfoVec_[k]->initialize();
+ 
+  std::vector<stk::mesh::EntityKey> recvGhostsToRemove;
+
+  if (nonConformalGhosting_ != NULL) {
+    stk::mesh::EntityProcVec currentSendGhosts;
+
+    nonConformalGhosting_->send_list(currentSendGhosts);
   
-  // manage ghosting
-  manage_ghosting();
-  
+    //We want elemsToGhost_ to only contain elements not already ghosted, and
+    //we want a list of receive-ghosts that no longer need to be ghosted.
+    compute_precise_ghosting_lists(realm_.bulk_data(), elemsToGhost_,
+                                   currentSendGhosts, recvGhostsToRemove);
+  }
+
+  // check for ghosting need
+  size_t local[2] = {elemsToGhost_.size(), recvGhostsToRemove.size()};
+  size_t global[2] = {0, 0};
+  stk::all_reduce_sum(NaluEnv::self().parallel_comm(), local, global, 2);
+
+  if (global[0] > 0 || global[1] > 0) {
+      NaluEnv::self().naluOutputP0() << "NonConformal alg will ghost a number of entities: "
+                    << global[0]<<" and remove "<<global[1]<<" entities from ghosting."  << std::endl;
+
+      manage_ghosting(recvGhostsToRemove);
+  }
+  else {
+    NaluEnv::self().naluOutputP0() << "NonConformal alg will NOT ghost entities: " << std::endl;
+  }
+
+  if (nonConformalGhosting_ != NULL) {
+    VectorFieldType *coordinates = realm_.bulk_data().mesh_meta_data().get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    std::vector<const stk::mesh::FieldBase*> fieldVec = {coordinates};
+    stk::mesh::communicate_field_data(*nonConformalGhosting_, fieldVec);
+  }
+
   // complete search
   for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
     nonConformalInfoVec_[k]->complete_search();
@@ -115,25 +246,21 @@ NonConformalManager::initialize()
 //-------- manage_ghosting -------------------------------------------------
 //--------------------------------------------------------------------------
 void
-NonConformalManager::manage_ghosting()
-{  
+NonConformalManager::manage_ghosting(std::vector<stk::mesh::EntityKey>& recvGhostsToRemove)
+{
   stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
-  // check for ghosting need
-  uint64_t g_needToGhostCount = 0;
-  stk::all_reduce_sum(NaluEnv::self().parallel_comm(), &needToGhostCount_, &g_needToGhostCount, 1);
-  if (g_needToGhostCount > 0) {
-    
-    NaluEnv::self().naluOutputP0() << "NonConformal alg will ghost a number of entities: "
-                    << g_needToGhostCount  << std::endl;
-    
-    bulk_data.modification_begin();
-    bulk_data.change_ghosting( *nonConformalGhosting_, elemsToGhost_);
-    bulk_data.modification_end();
+  bulk_data.modification_begin();
+
+  if ( nonConformalGhosting_ == NULL) {
+    // create new ghosting
+    std::string theGhostName = "nalu_nonConformal_ghosting";
+    nonConformalGhosting_ = &bulk_data.create_ghosting( theGhostName );
   }
-  else {
-    NaluEnv::self().naluOutputP0() << "NonConformal alg will NOT ghost entities: " << std::endl;
-  }
+    
+  bulk_data.change_ghosting( *nonConformalGhosting_, elemsToGhost_, recvGhostsToRemove);
+  
+  bulk_data.modification_end();
 }
 
 } // namespace nalu


### PR DESCRIPTION
Do an incremental update of entities to be ghosted, rather than
destroying and re-creating the ghosting. Also avoid a call
to mod-begin/mod-end in some cases.

These changes are shown to improve overall run-time by as much as
25% on a nightly test (dgNonConformalEdgeCylinder) and by about
7% on the cube6M problem on 256 procs of skybridge (total runtime
goes from ~46000s to ~42800s).