### PR TITLE
Refactored unit-tests in UnitTestKokkosViews.C.

### DIFF
--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -66,7 +66,7 @@ void create_one_element(
    bulk.modification_begin();
 
    for (auto id : nodeIds) {
-     bulk.declare_entity(stk::topology::NODE_RANK, id);
+     bulk.declare_entity(stk::topology::NODE_RANK, id, {});
    }
    auto elem = stk::mesh::declare_element (bulk, block_1, 1, nodeIds);
    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);


### PR DESCRIPTION
This refactoring supports our design experimentation related to
element-algorithms.

* Adds two classes that mimic element-algorithms:
  TestElemAlgorithmWithVectors, TestElemAlgorithmWithViews

* Illustrates the scratch-array resizing strategy which finds max
  nodes-per-elem and num-integ-points prior to the bucket loop and
  performs max resize, making subsequent resize operations fast.

* Illustrates Kokkos views with shared-memory-views as prototyped
  by Christian in a separate repo.

* Encapsulates looping mechanisms as described in recent meeting.

* Some 'kokkos-helper' stuff (typedefs, small functions etc) are at
  the top of the file, essentially similar to the stuff that
  Christian had in the KokkosInterface.h header in his repo.

* The test 'main' functions are at the bottom of the file, this is
  where you should start reading if you are interested in exploring.