### PR TITLE
Further refactoring and correcting of the elem-alg unit-tests.

### DIFF
--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -25,6 +25,7 @@ TEST(BasicKokkos, discover_execution_space)
 #endif
         std::cout << "Default execution space info: ";
         Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+        std::cout<<"\n concurrency: "<<Kokkos::DefaultExecutionSpace::concurrency()<<std::endl;
 
         std::cout << std::endl;
     }


### PR DESCRIPTION
The version of the element-algorithm that uses std::vectors for
scratch arrays (TestElemAlgorithmWithVectors) can not execute correctly
in true multi-threaded mode since the vectors can't feasibly be
allocated on a per-thread basis.
Thus, this version of the element-algorithm is now restricted to
explicitly *not* run multi-threaded.

The version of the element-algorithm that uses Kokkos::views for
scratch arrays (TestElemAlgorithmWithViews) now executes correctly
in true multi-threaded mode (OpenMP). It uses the SharedMemView
construct that Christian had prototyped. Unfortunately this means
that it can not use the loop-encapsulation mechanism outlined in
recent slides.

A new version of the element-algorithm has now been added
(TestElementAlgorithmWithTemplate) which uses a templated kernel
function for the inner-loop-body, meaning that scratch arrays are
automatic arrays allocated at compile time. Thus no resize operations
are needed. This works in multi-threaded mode, and is the
fastest of the 3 approaches, by a small margin.