### PR TITLE
Fix unit-tests so they build on nvidia/cuda.

### DIFF
--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -25,7 +25,6 @@ TEST(BasicKokkos, discover_execution_space)
 #endif
         std::cout << "Default execution space info: ";
         Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
-        std::cout<<"\n concurrency: "<<Kokkos::DefaultExecutionSpace::concurrency()<<std::endl;
 
         std::cout << std::endl;
     }
@@ -35,12 +34,12 @@ TEST(BasicKokkos, simple_views_1D)
 {
     const double tolerance = 0.0000001;
     const size_t N = 10;
-    Kokkos::View<double*>::HostMirror host_view1D("host_view1D", N);
+    Kokkos::View<double*> device_view1D("device_view1D", N);
+    Kokkos::View<double*>::HostMirror host_view1D = Kokkos::create_mirror_view(device_view1D);
     for(size_t i=0; i<N; ++i) {
         host_view1D(i) = i+1;
     }
 
-    Kokkos::View<double*> device_view1D = Kokkos::create_mirror_view(host_view1D);
     Kokkos::deep_copy(device_view1D, host_view1D);
 
     Kokkos::View<double*>::HostMirror host_view1D_2("host_view1D_2", N);
@@ -56,14 +55,14 @@ TEST(BasicKokkos, simple_views_2D)
     const double tolerance = 0.0000001;
     const size_t N = 10;
     const size_t M = 20;
-    Kokkos::View<double**>::HostMirror host_view2D("host_view2D", N, M);
+    Kokkos::View<double**> device_view2D("device_view2D", N, M);
+    Kokkos::View<double**>::HostMirror host_view2D = Kokkos::create_mirror_view(device_view2D);
     for(size_t i=0; i<N; ++i) {
         for(size_t j=0; j<M; ++j) {
             host_view2D(i,j) = i+j+1;
         }
     }
 
-    Kokkos::View<double**> device_view2D = Kokkos::create_mirror_view(host_view2D);
     Kokkos::deep_copy(device_view2D, host_view2D);
 
     Kokkos::View<double**>::HostMirror host_view2D_2("host_view2D_2", N, M);
@@ -76,12 +75,13 @@ TEST(BasicKokkos, simple_views_2D)
     }
 }
 
-TEST(BasicKokkos, parallel_for)
+void run_parallel_for_test()
 {
     const double tolerance = 0.0000001;
     const size_t N = 10;
     const size_t M = 20;
-    Kokkos::View<double**>::HostMirror host_view2D("host_view2D", N, M);
+    Kokkos::View<double**> device_view2D("host_view2D", N, M);
+    Kokkos::View<double**>::HostMirror host_view2D = Kokkos::create_mirror_view(device_view2D);
 
     for(size_t i=0; i<N; ++i) {
         for(size_t j=0; j<M; ++j) {
@@ -89,7 +89,6 @@ TEST(BasicKokkos, parallel_for)
         }
     }
 
-    Kokkos::View<double**> device_view2D = Kokkos::create_mirror_view(host_view2D);
     Kokkos::deep_copy(device_view2D, host_view2D);
 
 //Important note: when the 'host' and 'device' share the same memory space, (as is the case for OpenMP),
@@ -115,12 +114,18 @@ TEST(BasicKokkos, parallel_for)
     }
 }
 
-TEST(BasicKokkos, nested_parallel_for_thread_teams)
+TEST(BasicKokkos, parallel_for)
+{
+    run_parallel_for_test();
+}
+
+void run_nested_parallel_for_thread_teams_test()
 {
     const double tolerance = 0.0000001;
     const size_t N = 8;
     const size_t M = 8;
-    Kokkos::View<double**>::HostMirror host_view2D("host_view2D", N, M);
+    Kokkos::View<double**> device_view2D("device_view2D", N, M);
+    Kokkos::View<double**>::HostMirror host_view2D = Kokkos::create_mirror_view(device_view2D);
 
     for(size_t i=0; i<N; ++i) {
         for(size_t j=0; j<M; ++j) {
@@ -128,7 +133,6 @@ TEST(BasicKokkos, nested_parallel_for_thread_teams)
         }
     }
 
-    Kokkos::View<double**> device_view2D = Kokkos::create_mirror_view(host_view2D);
     Kokkos::deep_copy(device_view2D, host_view2D);
 
     typedef Kokkos::Schedule<Kokkos::Dynamic> DynamicScheduleType;
@@ -140,7 +144,7 @@ TEST(BasicKokkos, nested_parallel_for_thread_teams)
     Kokkos::parallel_for(Kokkos::TeamPolicy<Kokkos::DefaultExecutionSpace>(N, Kokkos::AUTO),
         KOKKOS_LAMBDA(const TeamHandleType& team) {
             size_t i = team.league_rank();
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(team, (size_t)0, M), KOKKOS_LAMBDA(const size_t& j) {
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(team, (size_t)0, M), [&](const size_t& j) {
                 device_view2D(i, j) *= 2;
             });
         });
@@ -157,5 +161,10 @@ TEST(BasicKokkos, nested_parallel_for_thread_teams)
             EXPECT_NEAR(host_result(i,j), host_view2D(i,j), tolerance);
         }
     }
+}
+
+TEST(BasicKokkos, nested_parallel_for_thread_teams)
+{
+    run_nested_parallel_for_thread_teams_test();
 }
 

--- a/unit_tests/UnitTestKokkosViews.C
+++ b/unit_tests/UnitTestKokkosViews.C
@@ -150,6 +150,10 @@ double quadratic(double a, const double* b, const double* H, const double* x)
   return (a + lin + 0.5*quad);
 }
 
+#ifndef KOKKOS_HAVE_CUDA
+//following tests can't run on cuda due to variety of reasons, including
+//use of std::vectors, use of MasterElement functions (defined for host), etc.
+
 double initialize_linear_scalar_field(
   const stk::mesh::BulkData& bulk,
   const VectorFieldType& coordField,
@@ -647,6 +651,9 @@ TEST_F(Hex8Mesh, indexing_views)
 
     check_discrete_laplacian(exactLaplacian);
 }
+
+//end of stuff that's ifndef'd for KOKKOS_HAVE_CUDA
+#endif
 
 }
 


### PR DESCRIPTION
The algorithm-tests in UnitTestKokkosViews.C don't run on GPU, due
to use of std::vectors, and use of MasterElements which have host-only
functions. But all unit-tests now build for cuda and the kokkos
unit-tests in UnitTestBasicKokkos.C run on cuda/GPU.