### PR TITLE
Replace old stk::mesh::skin_mesh with newer stk capability.

### DIFF
--- a/src/Realm.C
+++ b/src/Realm.C
@@ -94,7 +94,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Comm.hpp>
 #include <stk_mesh/base/CreateEdges.hpp>
-#include <stk_mesh/base/SkinMesh.hpp>
+#include <stk_mesh/base/SkinBoundary.hpp>
 
 // stk_io
 #include <stk_io/StkMeshIoBroker.hpp>
@@ -862,7 +862,7 @@ Realm::enforce_bc_on_exposed_faces()
   stk::mesh::Selector activePart = metaData_->locally_owned_part() | metaData_->globally_shared_part();
   stk::mesh::PartVector partVec;
   partVec.push_back(exposedBoundaryPart_);
-  stk::mesh::skin_mesh(*bulkData_, activePart, partVec);
+  stk::mesh::create_exposed_block_boundary_sides(*bulkData_, activePart, partVec);
 
   stk::mesh::Selector selectRule = stk::mesh::Selector(*exposedBoundaryPart_)
     & !stk::mesh::selectUnion(bcPartVec_);

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -22,6 +22,7 @@
 #include <stk_mesh/base/GetBuckets.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Selector.hpp>
+#include <stk_mesh/base/SkinBoundary.hpp>
 
 // stk_search
 #include <stk_search/CoarseSearch.hpp>
@@ -647,11 +648,12 @@ OversetManager::skin_exposed_surface_on_inactive_part()
 
   // skin the inactive part to obtain all exposed surface
   stk::mesh::Selector s_inactive = stk::mesh::Selector(*inActivePart_);
+  stk::mesh::Selector s_active = !s_inactive;
   stk::mesh::PartVector partToSkinVec;
   stk::mesh::PartVector partToPopulateVec;
   partToSkinVec.push_back(inActivePart_); // e.g. block_3
   partToPopulateVec.push_back(backgroundSurfacePart_); // e.g. surface_101
-  stk::mesh::skin_mesh(*bulkData_, s_inactive, partToPopulateVec, &s_inactive);
+  stk::mesh::create_exposed_block_boundary_sides(*bulkData_, s_inactive, partToPopulateVec, &s_active);
 
   const double end_time = NaluEnv::self().nalu_time();
 


### PR DESCRIPTION
The newer stk::mesh::create_exposed_block_boundary_sides is more
robust than skin_mesh, correctly handles a mesh which caused
skin_mesh to issue errors/warnings.