### PR TITLE
Add a supplemental algorithm builder function

### DIFF
--- a/include/AlgTraits.h
+++ b/include/AlgTraits.h
@@ -9,6 +9,8 @@
 #ifndef AlgTraits_h
 #define AlgTraits_h
 
+#include <stk_topology/topology.hpp>
+
 namespace sierra {
 namespace nalu {
 
@@ -19,6 +21,7 @@ struct AlgTraitsHex8 {
   static constexpr int numScsIp_ = 12;
   static constexpr int numScvIp_ = 8;
   static constexpr int numGp_ = 8; // for FEM
+  static constexpr stk::topology::topology_t topo_ = stk::topology::HEX_8;
 };
 
 struct AlgTraitsTet4 {
@@ -27,6 +30,7 @@ struct AlgTraitsTet4 {
   static constexpr int numScsIp_ = 6;
   static constexpr int numScvIp_ = 4;
   static constexpr int numGp_ = 4; // for FEM
+  static constexpr stk::topology::topology_t topo_ = stk::topology::TET_4;
 };
 
 struct AlgTraitsPyr5 {
@@ -35,6 +39,7 @@ struct AlgTraitsPyr5 {
   static constexpr int numScsIp_ = 8;
   static constexpr int numScvIp_ = 5;
   static constexpr int numGp_ = 5; // for FEM
+  static constexpr stk::topology::topology_t topo_ = stk::topology::PYRAMID_5;
 };
 
 struct AlgTraitsWed6 {
@@ -43,6 +48,7 @@ struct AlgTraitsWed6 {
   static constexpr int numScsIp_ = 9;
   static constexpr int numScvIp_ = 6;
   static constexpr int numGp_ = 6; // for FEM
+  static constexpr stk::topology::topology_t topo_ = stk::topology::WEDGE_6;
 };
 
 } // namespace nalu

--- a/include/HeatCondEquationSystem.h
+++ b/include/HeatCondEquationSystem.h
@@ -82,7 +82,11 @@ public:
     EquationSystem::load(node);
     get_if_present(node, "use_collocation", collocationForViscousTerms_, false);
   }
-  
+
+  void report_invalid_supp_alg_names();
+  void report_built_supp_alg_names();
+
+
   // allow equation system to manage a projected nodal gradient
   const bool managePNG_;
 
@@ -105,6 +109,8 @@ public:
   bool isInit_;
   bool collocationForViscousTerms_;
   ProjectedNodalGradientEquationSystem *projectedNodalGradEqs_;
+
+  const std::string suppAlgTypeName_;
 };
 
 } // namespace nalu

--- a/include/ScalarDiffElemSuppAlg.h
+++ b/include/ScalarDiffElemSuppAlg.h
@@ -32,12 +32,12 @@ template<class AlgTraits>
 class ScalarDiffElemSuppAlg : public SupplementalAlgorithm
 {
 public:
+  static constexpr auto name = "CVFEM_DIFF";
 
   ScalarDiffElemSuppAlg(
     Realm &realm,
     ScalarFieldType *scalarQ,
     ScalarFieldType *diffFluxCoeff,
-    const stk::topology &theTopo,
     ElemDataRequests& dataPreReqs);
 
   virtual ~ScalarDiffElemSuppAlg() {}

--- a/include/ScalarDiffFemSuppAlg.h
+++ b/include/ScalarDiffFemSuppAlg.h
@@ -28,6 +28,7 @@ template<class AlgTraits>
 class ScalarDiffFemSuppAlg : public SupplementalAlgorithm
 {
 public:
+  static constexpr auto name = "FEM_DIFF";
 
   ScalarDiffFemSuppAlg(
     Realm &realm,

--- a/include/SupplementalAlgorithmBuilder.h
+++ b/include/SupplementalAlgorithmBuilder.h
@@ -1,0 +1,110 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef SupplementalAlgorithmBuilder_h
+#define SupplementalAlgorithmBuilder_h
+
+#include <SupplementalAlgorithm.h>
+#include <AssembleElemSolverAlgorithm.h>
+#include <EquationSystem.h>
+#include <AlgTraits.h>
+#include <SupplementalAlgorithmBuilderLog.h>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_topology/topology.hpp>
+
+#include <algorithm>
+
+namespace sierra{
+namespace nalu{
+  class Realm;
+
+  template <class T,  typename... Args>
+  void append_new_supp_alg_if_requested(
+    std::vector<std::string> algNameVec,
+    std::vector<SupplementalAlgorithm*>& algVec,
+    std::string suppAlgTypeName,
+    Args&&... args)
+  {
+    std::string name = T::name;
+
+    if (std::find(algNameVec.begin(), algNameVec.end(), name) != algNameVec.end()) {
+      auto* suppAlg = new T(std::forward<Args>(args)...);
+      ThrowRequire(suppAlg != nullptr);
+      algVec.push_back(suppAlg);
+      SuppAlgBuilderLog::self().add_built_name(suppAlgTypeName, name);
+    }
+    SuppAlgBuilderLog::self().add_valid_name(suppAlgTypeName, name);
+  }
+
+  template <template <typename> class T, typename... Args>
+  void build_topo_supp_alg_if_requested(
+    stk::topology topo,
+    const std::map<std::string, std::vector<std::string>>& algNameMap,
+    std::vector<SupplementalAlgorithm*>& algVec,
+    std::string suppAlgTypeName,
+    Args&&... args)
+  {
+    auto it = algNameMap.find(suppAlgTypeName);
+    if (it != algNameMap.end())
+    {
+      const auto& algNameVec = it->second;
+
+      switch(topo.value()) {
+        case stk::topology::HEX_8:
+          append_new_supp_alg_if_requested<T<AlgTraitsHex8>>(algNameVec, algVec, suppAlgTypeName,
+              std::forward<Args>(args)...);
+          break;
+        case stk::topology::TET_4:
+          append_new_supp_alg_if_requested<T<AlgTraitsTet4>>(algNameVec, algVec, suppAlgTypeName,
+              std::forward<Args>(args)...);
+          break;
+        case stk::topology::PYRAMID_5:
+          append_new_supp_alg_if_requested<T<AlgTraitsPyr5>>(algNameVec, algVec, suppAlgTypeName,
+              std::forward<Args>(args)...);
+          break;
+        case stk::topology::WEDGE_6:
+          append_new_supp_alg_if_requested<T<AlgTraitsWed6>>(algNameVec, algVec, suppAlgTypeName,
+              std::forward<Args>(args)...);
+          break;
+        default: break;
+      }
+    }
+  }
+
+  inline AssembleElemSolverAlgorithm& build_or_add_part_to_solver_alg(
+    EquationSystem& eqSys,
+    stk::mesh::Part& part,
+    std::map<std::string, SolverAlgorithm*>& solverAlgs)
+  {
+    const stk::topology topo = part.topology();
+    const std::string algName = "AssembleElemSolverAlg_" + topo.name();
+
+    auto itc = solverAlgs.find(algName);
+    if (itc == solverAlgs.end()) {
+      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, topo);
+      ThrowRequire(theSolverAlg != nullptr);
+
+      NaluEnv::self().naluOutputP0() << "Created the following alg: " << algName << std::endl;
+      solverAlgs.insert({algName, theSolverAlg});
+    }
+    else {
+      auto& partVec = itc->second->partVec_;
+      if (std::find(partVec.begin(), partVec.end(), &part) == partVec.end()) {
+        partVec.push_back(&part);
+      }
+    }
+
+    auto* theSolverAlg = static_cast<AssembleElemSolverAlgorithm*>(solverAlgs.at(algName));
+    ThrowRequire(theSolverAlg != nullptr);
+    return *theSolverAlg;
+  }
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/SupplementalAlgorithmBuilderLog.h
+++ b/include/SupplementalAlgorithmBuilderLog.h
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef SupplementalAlgorithmBuilderLog_h
+#define SupplementalAlgorithmBuilderLog_h
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+  class SuppAlgBuilderLog
+  {
+  public:
+    static SuppAlgBuilderLog& self();
+    SuppAlgBuilderLog(const SuppAlgBuilderLog&) = delete;
+    void operator=(const SuppAlgBuilderLog&) = delete;
+
+    void add_valid_name(std::string suppAlgTypeName, std::string name);
+    void add_built_name(std::string suppAlgTypeName, std::string name);
+
+    bool print_invalid_supp_alg_names(
+      std::string suppAlgTypeName,
+      const std::map<std::string, std::vector<std::string>>& inputFileNames );
+
+    void print_valid_supp_alg_names(std::string suppAlgTypeName);
+    void print_built_supp_alg_names(std::string suppAlgTypeName);
+
+    std::set<std::string> valid_supp_alg_names(std::string suppAlgTypeName);
+    std::set<std::string> built_supp_alg_names(std::string suppAlgTypeName);
+  private:
+    SuppAlgBuilderLog() = default;
+
+    std::map<std::string, std::set<std::string>> validSuppAlgNames_;
+    std::map<std::string, std::set<std::string>> builtSuppAlgNames_;
+  };
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/user_functions/SteadyThermal3dContactSrcElemSuppAlg.h
+++ b/include/user_functions/SteadyThermal3dContactSrcElemSuppAlg.h
@@ -32,10 +32,10 @@ template<class IntAlgTraits>
 class SteadyThermal3dContactSrcElemSuppAlg : public SupplementalAlgorithm
 {
 public:
+  static constexpr auto name = "steady_3d_thermal";
 
   SteadyThermal3dContactSrcElemSuppAlg(
     Realm &realm,
-    const stk::topology &theTopo,
     ElemDataRequests& dataPreReqs);
 
   virtual ~SteadyThermal3dContactSrcElemSuppAlg() {}

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -52,6 +52,8 @@
 
 // template for supp algs
 #include <AlgTraits.h>
+#include <SupplementalAlgorithmBuilder.h>
+#include <SupplementalAlgorithmBuilderLog.h>
 
 // supp algs
 #include <ScalarDiffElemSuppAlg.h>
@@ -116,7 +118,8 @@ HeatCondEquationSystem::HeatCondEquationSystem(
     assembleNodalGradAlgDriver_(new AssembleNodalGradAlgorithmDriver(realm_, "temperature", "dtdx")),
     isInit_(true),
     collocationForViscousTerms_(false),
-    projectedNodalGradEqs_(NULL)
+    projectedNodalGradEqs_(NULL),
+    suppAlgTypeName_("temperature")
 {
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("temperature");
@@ -264,7 +267,29 @@ HeatCondEquationSystem::register_element_fields(
     stk::mesh::put_field(*intersectedElement, *part, sizeOfElemField);
   }
 }
+//--------------------------------------------------------------------------
+void
+HeatCondEquationSystem::report_invalid_supp_alg_names()
+{
+  bool noInvalidNamesFound = SuppAlgBuilderLog::self().print_invalid_supp_alg_names(
+    suppAlgTypeName_, realm_.solutionOptions_->elemSrcTermsMap_
+  );
 
+  if (!noInvalidNamesFound) {
+    SuppAlgBuilderLog::self().print_valid_supp_alg_names(suppAlgTypeName_);
+
+    std::string msg =
+        "Invalid supplemental algorithms name(s) for " + suppAlgTypeName_ + ". See log for details.";
+
+    throw std::runtime_error(msg);
+  }
+}
+//--------------------------------------------------------------------------
+void
+HeatCondEquationSystem::report_built_supp_alg_names()
+{
+  SuppAlgBuilderLog::self().print_built_supp_alg_names(suppAlgTypeName_);
+}
 //--------------------------------------------------------------------------
 //-------- register_interior_algorithm -------------------------------------
 //--------------------------------------------------------------------------
@@ -355,113 +380,34 @@ HeatCondEquationSystem::register_interior_algorithm(
     //========================================================================================
     if ( realm_.realmUsesEdges_ )
       throw std::runtime_error("HeatCondElem::Error can not use supplemental design for an edge-based scheme");
-    
+
     // extract topo from part
     stk::topology partTopo = part->topology();
-    std::string partTopoName = partTopo.name();
-    NaluEnv::self().naluOutputP0() << "The name of this part is " << partTopoName << std::endl;
-    
-    // find this algorithm with the following name
-    const std::string algName = "AssembleElemSolverAlg_" + partTopoName;
-    std::map<std::string, SolverAlgorithm *>::iterator itc
-      = solverAlgDriver_->solverAlgorithmMap_.find(algName);
-    if ( itc == solverAlgDriver_->solverAlgorithmMap_.end() ) {
-      // new the algorithm and add it
-      AssembleElemSolverAlgorithm *theSolverAlg = new AssembleElemSolverAlgorithm(realm_, part, this, partTopo);
-      solverAlgDriver_->solverAlgorithmMap_[algName] = theSolverAlg;
+    NaluEnv::self().naluOutputP0() << "The name of this part is " << partTopo.name() << std::endl;
 
-      NaluEnv::self().naluOutputP0() << "Created the following alg: " << algName << std::endl;
+    auto& solverAlgMap = solverAlgDriver_->solverAlgorithmMap_;
+    auto& reqSuppAlgNameMap = realm_.solutionOptions_->elemSrcTermsMap_;
+    AssembleElemSolverAlgorithm& solverAlg = build_or_add_part_to_solver_alg(*this, *part, solverAlgMap);
+    ElemDataRequests& dataPreReqs = solverAlg.dataNeededBySuppAlgs_;
+    std::vector<SupplementalAlgorithm*>& suppAlgVec = solverAlg.supplementalAlg_;
 
-      // look for fully integrated source terms; these need to call through element_execute()
-      std::map<std::string, std::vector<std::string> >::iterator isrc 
-        = realm_.solutionOptions_->elemSrcTermsMap_.find("temperature");
-      if ( isrc != realm_.solutionOptions_->elemSrcTermsMap_.end() ) {
-        
-        if ( realm_.realmUsesEdges_ )
-          throw std::runtime_error("HeatCondElemSrcTerms::Error can not use element source terms for an edge-based scheme");
-        
-        std::vector<std::string> mapNameVec = isrc->second;
+    build_topo_supp_alg_if_requested<SteadyThermal3dContactSrcElemSuppAlg>(
+      partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+      realm_, dataPreReqs
+    );
 
-        ElemDataRequests& dataPreReqs = theSolverAlg->dataNeededBySuppAlgs_;
+    build_topo_supp_alg_if_requested<ScalarDiffElemSuppAlg>(
+      partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+      realm_, temperature_, thermalCond_, dataPreReqs
+    );
 
-        for (size_t k = 0; k < mapNameVec.size(); ++k ) {
-          std::string sourceName = mapNameVec[k];
-          switch (partTopo.value()) {
-          case stk::topology::HEX_8:
-            if (sourceName == "steady_3d_thermal" ) {
-              SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsHex8> *suppAlg 
-                = new SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsHex8>(realm_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else if (sourceName == "CVFEM_DIFF" ) { 
-              ScalarDiffElemSuppAlg<AlgTraitsHex8> *suppAlg 
-                = new ScalarDiffElemSuppAlg<AlgTraitsHex8>(realm_, temperature_, thermalCond_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else if ( sourceName == "FEM_DIFF" ) {
-              ScalarDiffFemSuppAlg<AlgTraitsHex8> *suppAlg 
-                = new ScalarDiffFemSuppAlg<AlgTraitsHex8>(realm_, temperature_, thermalCond_);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else {
-              throw std::runtime_error("HeatCondElemSuppSrcTerms::Error Source term is not supported: " + sourceName);
-            }
-            break; 
-          case stk::topology::TET_4:
-            if (sourceName == "steady_3d_thermal" ) {
-              SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsTet4> *suppAlg 
-                = new SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsTet4>(realm_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else if (sourceName == "CVFEM_DIFF" ) {
-              ScalarDiffElemSuppAlg<AlgTraitsTet4> *suppAlg 
-                = new ScalarDiffElemSuppAlg<AlgTraitsTet4>(realm_, temperature_, thermalCond_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else {
-              throw std::runtime_error("HeatCondElemSuppSrcTerms::Error Source term is not supported: " + sourceName);
-              }
-            break;
-          case stk::topology::PYRAMID_5:
-            if (sourceName == "steady_3d_thermal" ) {
-              SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsPyr5> *suppAlg 
-                = new SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsPyr5>(realm_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else if (sourceName == "CVFEM_DIFF" ) {
-              ScalarDiffElemSuppAlg<AlgTraitsPyr5> *suppAlg 
-                = new ScalarDiffElemSuppAlg<AlgTraitsPyr5>(realm_, temperature_, thermalCond_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else {
-              throw std::runtime_error("HeatCondElemSuppSrcTerms::Error Source term is not supported: " + sourceName);
-            }
-            break;
-          case stk::topology::WEDGE_6:
-            if (sourceName == "steady_3d_thermal" ) {
-              SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsWed6> *suppAlg 
-                = new SteadyThermal3dContactSrcElemSuppAlg<AlgTraitsWed6>(realm_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else if (sourceName == "CVFEM_DIFF" ) {
-              ScalarDiffElemSuppAlg<AlgTraitsWed6> *suppAlg 
-                = new ScalarDiffElemSuppAlg<AlgTraitsWed6>(realm_, temperature_, thermalCond_, partTopo, dataPreReqs);
-              theSolverAlg->supplementalAlg_.push_back(suppAlg);
-            }
-            else {
-              throw std::runtime_error("HeatCondElemSuppSrcTerms::Error Source term is not supported: " + sourceName);
-            }
-            break;
-          default:
-            throw std::runtime_error("Unsupported topology type for supp alg; only 3D p1 supported");
-          }
-          NaluEnv::self().naluOutputP0() << "HeatCondSuppElemSrcTerms::added() " << sourceName << std::endl;
-        }
-      }
-    }
-    else {
-      itc->second->partVec_.push_back(part);
-    }
+    build_topo_supp_alg_if_requested<ScalarDiffFemSuppAlg>(
+      partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+      realm_, temperature_, thermalCond_
+    );
+
+    report_invalid_supp_alg_names();
+    report_built_supp_alg_names();
   }
 
   // time term; nodally lumped

--- a/src/ScalarDiffElemSuppAlg.C
+++ b/src/ScalarDiffElemSuppAlg.C
@@ -44,14 +44,13 @@ ScalarDiffElemSuppAlg<AlgTraits>::ScalarDiffElemSuppAlg(
   Realm &realm,
   ScalarFieldType *scalarQ,
   ScalarFieldType *diffFluxCoeff,
-  const stk::topology &theTopo,
   ElemDataRequests& dataPreReqs)
   : SupplementalAlgorithm(realm),
     bulkData_(&realm.bulk_data()),
     scalarQ_(scalarQ),
     diffFluxCoeff_(diffFluxCoeff),
     coordinates_(NULL),
-    lrscv_(realm.get_surface_master_element(theTopo)->adjacentNodes()),
+    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     ws_shape_function_("ws_shape_function", AlgTraits::numScsIp_, AlgTraits::nodesPerElement_)
 {
   // save off fields
@@ -59,7 +58,7 @@ ScalarDiffElemSuppAlg<AlgTraits>::ScalarDiffElemSuppAlg(
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(theTopo);
+  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&ws_shape_function_(0,0));
   
   // add master elements

--- a/src/ScalarDiffFemSuppAlg.C
+++ b/src/ScalarDiffFemSuppAlg.C
@@ -45,6 +45,8 @@ ScalarDiffFemSuppAlg<AlgTraits>::ScalarDiffFemSuppAlg(
     meFEM_(new Hex8FEM()),
     ipWeight_(&meFEM_->weights_[0])
 {
+  ThrowRequireMsg(AlgTraits::topo_ == stk::topology::HEX_8, std::string(name) + " only available for hexes currently");
+
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");

--- a/src/SupplementalAlgorithmBuilderLog.C
+++ b/src/SupplementalAlgorithmBuilderLog.C
@@ -1,0 +1,130 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <SupplementalAlgorithmBuilderLog.h>
+#include <NaluEnv.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+
+namespace sierra{
+namespace nalu{
+//--------------------------------------------------------------------------
+SuppAlgBuilderLog&
+SuppAlgBuilderLog::self()
+{
+  static SuppAlgBuilderLog instance;
+  return instance;
+}
+//--------------------------------------------------------------------------
+void
+SuppAlgBuilderLog::add_valid_name(std::string suppAlgTypeName, std::string name)
+{
+  validSuppAlgNames_[suppAlgTypeName].insert(name);
+}
+//--------------------------------------------------------------------------
+void
+SuppAlgBuilderLog::add_built_name(std::string suppAlgTypeName, std::string name)
+{
+  builtSuppAlgNames_[suppAlgTypeName].insert(name);
+}
+//--------------------------------------------------------------------------
+bool
+SuppAlgBuilderLog::print_invalid_supp_alg_names(
+  std::string suppAlgTypeName,
+  const std::map<std::string, std::vector<std::string>>& srcTermsMap )
+{
+  auto it = srcTermsMap.find(suppAlgTypeName);
+  if (it == srcTermsMap.end()) {
+    return false;
+  }
+  const std::vector<std::string>& inputFileNames = it->second;
+  const std::set<std::string> implementedSuppAlgNames = valid_supp_alg_names(suppAlgTypeName);
+
+  std::vector<std::string> badNames;
+  for (const auto& inputFileName : inputFileNames) {
+    if (implementedSuppAlgNames.find(inputFileName) == implementedSuppAlgNames.end()) {
+      badNames.push_back(inputFileName);
+    }
+  }
+
+  for (const auto& name : badNames) {
+    NaluEnv::self().naluOutputP0() << "Error: No Supplemental Algorithm with name `"
+                                   << name
+                                   << "' implemented"
+                                   << std::endl;
+  }
+
+  bool isOK = badNames.empty();
+
+  return isOK;
+}
+//--------------------------------------------------------------------------
+void
+SuppAlgBuilderLog::print_valid_supp_alg_names(std::string suppAlgTypeName )
+{
+  const auto implementedSuppAlgNames = valid_supp_alg_names(suppAlgTypeName);
+
+  std::string msgList = "";
+  for (const auto& name : implementedSuppAlgNames) {
+    msgList += "`" + name + "', ";
+  }
+  msgList = msgList.substr(0, msgList.size()-2);
+
+  NaluEnv::self().naluOutputP0()
+      << "Valid Supplemental Algorithm names for "
+      << suppAlgTypeName
+      << " are "
+      << msgList
+      << "."
+      << std::endl;
+}
+//--------------------------------------------------------------------------
+void
+SuppAlgBuilderLog::print_built_supp_alg_names(std::string suppAlgTypeName)
+{
+  const auto builtSuppAlgNames = built_supp_alg_names(suppAlgTypeName);
+
+  std::string msgList = "";
+  for (const auto& name : builtSuppAlgNames) {
+    msgList += "`" + name + "', ";
+  }
+  msgList = msgList.substr(0, msgList.size()-2);
+
+  NaluEnv::self().naluOutputP0()
+      << "Built Supplemental Algortihms for "
+      << suppAlgTypeName
+      << " are "
+      << msgList
+      << "."
+      << std::endl;
+}
+//--------------------------------------------------------------------------
+std::set<std::string>
+SuppAlgBuilderLog::valid_supp_alg_names(std::string suppAlgTypeName)
+{
+  auto it = validSuppAlgNames_.find(suppAlgTypeName);
+  if (it == validSuppAlgNames_.end()) {
+    return std::set<std::string>();
+  }
+  return it->second;
+}
+//--------------------------------------------------------------------------
+std::set<std::string>
+SuppAlgBuilderLog::built_supp_alg_names(std::string suppAlgTypeName)
+{
+  auto it = builtSuppAlgNames_.find(suppAlgTypeName);
+  if (it == builtSuppAlgNames_.end()) {
+    return std::set<std::string>();
+  }
+  return it->second;
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
@@ -42,12 +42,11 @@ namespace nalu{
 template<class AlgTraits>
 SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSuppAlg(
   Realm &realm,
-  const stk::topology &theTopo,
   ElemDataRequests& dataPreReqs)
   : SupplementalAlgorithm(realm),
     bulkData_(&realm.bulk_data()),
     coordinates_(NULL),
-    ipNodeMap_(realm.get_volume_master_element(theTopo)->ipNodeMap()),
+    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap()),
     a_(1.0),
     k_(1.0),
     pi_(std::acos(-1.0)),
@@ -59,7 +58,7 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSu
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // compute shape function; possibly push this to dataPreReqs?
-  MasterElement *meSCV = realm.get_volume_master_element(theTopo);
+  MasterElement *meSCV = realm.get_volume_master_element(AlgTraits::topo_);
   meSCV->shape_fcn(&ws_shape_function_(0,0));
 
   // add master elements


### PR DESCRIPTION
Cleans up some of the logic around building the new templated supplemental algorithm.

* Need to add a "name" to the supplemental algorithm to use the builder function.  The name is what the user will specify in the input file to activate the supplemental algorithm.

* Logs the name of whatever supplemental algorithm that is built (or might be built) by the builder.  So we can output a list of available supplemental algorithms for a particular physics type.