### PR TITLE
Incremental improvement to supp-alg data-sharing mechanism.

### DIFF
--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -39,8 +39,7 @@ struct FieldInfo {
   unsigned scalarsDim2;
 };
 
-struct FieldInfoLess
-{
+struct FieldInfoLess {
   bool operator()(const FieldInfo& lhs, const FieldInfo& rhs) const
   {
     return lhs.field->mesh_meta_data_ordinal() < rhs.field->mesh_meta_data_ordinal();
@@ -62,61 +61,13 @@ public:
     dataEnums.insert(data);
   }
 
-  void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned scalarsPerNode)
-  {
-    ThrowAssertMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+  void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned scalarsPerNode);
 
-    FieldInfo fieldInfo(&field, scalarsPerNode);
-    FieldSet::iterator iter = fields.find(fieldInfo);
-    if (iter == fields.end()) {
-      fields.insert(fieldInfo);
-    }
-    else {
-      ThrowAssertMsg(iter->scalarsDim1 == scalarsPerNode, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with scalarsPerNode=="<<scalarsPerNode<<", but previously requested with scalarsPerNode=="<<iter->scalarsDim1);
-    }
-  }
+  void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
 
-  void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
-  {
-    ThrowAssertMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+  void add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement);
 
-    FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
-    FieldSet::iterator iter = fields.find(fieldInfo);
-    if (iter == fields.end()) {
-      fields.insert(fieldInfo);
-    }
-    else {
-      ThrowAssertMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
-    }
-  }
-
-  void add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
-  {
-    ThrowAssertMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
-
-    FieldInfo fieldInfo(&field, scalarsPerElement);
-    FieldSet::iterator iter = fields.find(fieldInfo);
-    if (iter == fields.end()) {
-      fields.insert(fieldInfo);
-    }
-    else {
-      ThrowAssertMsg(iter->scalarsDim1 == scalarsPerElement, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with scalarsPerElement=="<<scalarsPerElement<<", but previously requested with scalarsPerElement=="<<iter->scalarsDim1);
-    }
-  }
-
-  void add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
-  {
-    ThrowAssertMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
-
-    FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
-    FieldSet::iterator iter = fields.find(fieldInfo);
-    if (iter == fields.end()) {
-      fields.insert(fieldInfo);
-    }
-    else {
-      ThrowAssertMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
-    }
-  }
+  void add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
 
   void add_cvfem_volume_me(MasterElement *meSCV)
   {

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -29,10 +29,14 @@ enum ELEM_DATA_NEEDED {
 
 struct FieldInfo {
   FieldInfo(const stk::mesh::FieldBase* fld, unsigned scalars)
-  : field(fld), scalarsPerEntity(scalars)
+  : field(fld), scalarsDim1(scalars), scalarsDim2(0)
+  {}
+  FieldInfo(const stk::mesh::FieldBase* fld, unsigned tensorDim1, unsigned tensorDim2)
+  : field(fld), scalarsDim1(tensorDim1), scalarsDim2(tensorDim2)
   {}
   const stk::mesh::FieldBase* field;
-  unsigned scalarsPerEntity;
+  unsigned scalarsDim1;
+  unsigned scalarsDim2;
 };
 
 struct FieldInfoLess
@@ -60,13 +64,57 @@ public:
 
   void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned scalarsPerNode)
   {
+    ThrowAssertMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+
     FieldInfo fieldInfo(&field, scalarsPerNode);
     FieldSet::iterator iter = fields.find(fieldInfo);
     if (iter == fields.end()) {
-      fields.insert(FieldInfo(&field, scalarsPerNode));
+      fields.insert(fieldInfo);
     }
     else {
-      ThrowAssertMsg(iter->scalarsPerEntity == scalarsPerNode, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with scalarsPerNode=="<<scalarsPerNode<<", but previously requested with scalarsPerNode=="<<iter->scalarsPerEntity);
+      ThrowAssertMsg(iter->scalarsDim1 == scalarsPerNode, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with scalarsPerNode=="<<scalarsPerNode<<", but previously requested with scalarsPerNode=="<<iter->scalarsDim1);
+    }
+  }
+
+  void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+  {
+    ThrowAssertMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+
+    FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
+    FieldSet::iterator iter = fields.find(fieldInfo);
+    if (iter == fields.end()) {
+      fields.insert(fieldInfo);
+    }
+    else {
+      ThrowAssertMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
+    }
+  }
+
+  void add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
+  {
+    ThrowAssertMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+    FieldInfo fieldInfo(&field, scalarsPerElement);
+    FieldSet::iterator iter = fields.find(fieldInfo);
+    if (iter == fields.end()) {
+      fields.insert(fieldInfo);
+    }
+    else {
+      ThrowAssertMsg(iter->scalarsDim1 == scalarsPerElement, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with scalarsPerElement=="<<scalarsPerElement<<", but previously requested with scalarsPerElement=="<<iter->scalarsDim1);
+    }
+  }
+
+  void add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+  {
+    ThrowAssertMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+    FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
+    FieldSet::iterator iter = fields.find(fieldInfo);
+    if (iter == fields.end()) {
+      fields.insert(fieldInfo);
+    }
+    else {
+      ThrowAssertMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
     }
   }
 

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -15,88 +15,13 @@
 #include <stk_mesh/base/BulkData.hpp>
 
 #include <ElemDataRequests.h>
-
+#include <master_element/MasterElement.h>
 #include <KokkosInterface.h>
 
 #include <set>
 
 namespace sierra{
 namespace nalu{
-
-inline
-void gather_elem_node_field(const stk::mesh::FieldBase& field,
-                            int numNodes,
-                            const stk::mesh::Entity* elemNodes,
-                            SharedMemView<double*>& shmemView)
-{
-  for(int i=0; i<numNodes; ++i) {
-    shmemView[i] = *static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
-  }
-}
-
-inline
-void gather_elem_node_tensor_field(const stk::mesh::FieldBase& field,
-                            int numNodes,
-                            int tensorDim1,
-                            int tensorDim2,
-                            const stk::mesh::Entity* elemNodes,
-                            SharedMemView<double***>& shmemView)
-{
-  for(int i=0; i<numNodes; ++i) {
-    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
-    unsigned counter = 0;
-    for(int d1=0; d1<tensorDim1; ++d1) {
-      for(int d2=0; d2<tensorDim2; ++d2) {
-        shmemView(i,d1,d2) = dataPtr[counter++];
-      }
-    }
-  }
-}
-
-inline
-void gather_elem_tensor_field(const stk::mesh::FieldBase& field,
-                              stk::mesh::Entity elem,
-                              int tensorDim1,
-                              int tensorDim2,
-                              SharedMemView<double**>& shmemView)
-{
-  const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elem));
-  unsigned counter = 0;
-  for(int d1=0; d1<tensorDim1; ++d1) {
-    for(int d2=0; d2<tensorDim2; ++d2) {
-      shmemView(d1,d2) = dataPtr[counter++];
-    }
-  }
-}
-
-inline
-void gather_elem_node_field_3D(const stk::mesh::FieldBase& field,
-                            int numNodes,
-                            const stk::mesh::Entity* elemNodes,
-                            SharedMemView<double**>& shmemView)
-{
-  for(int i=0; i<numNodes; ++i) {
-    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
-    shmemView(i,0) = dataPtr[0];
-    shmemView(i,1) = dataPtr[1];
-    shmemView(i,2) = dataPtr[2];
-  }
-}
-
-inline
-void gather_elem_node_field(const stk::mesh::FieldBase& field,
-                            int numNodes,
-                            int scalarsPerNode,
-                            const stk::mesh::Entity* elemNodes,
-                            SharedMemView<double**>& shmemView)
-{
-  for(int i=0; i<numNodes; ++i) {
-    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
-    for(int d=0; d<scalarsPerNode; ++d) {
-      shmemView(i,d) = dataPtr[d];
-    }
-  }
-}
 
 struct ViewHolder {
   virtual ~ViewHolder() {}
@@ -115,22 +40,7 @@ public:
   ScratchViews(const TeamHandleType& team,
                const stk::mesh::BulkData& bulkData,
                stk::topology topo,
-               ElemDataRequests& dataNeeded)
-  : elemNodes(nullptr), scs_areav(), dndx(), deriv(), det_j()
-  {
-    // master elements are allowed to be null if they are not required
-    MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
-    MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
-
-    int nDim = bulkData.mesh_meta_data().spatial_dimension();
-    int nodesPerElem = topo.num_nodes();
-    int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
-    int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
-
-    create_needed_field_views(team, dataNeeded, bulkData, nodesPerElem);
-
-    create_needed_master_element_views(team, dataNeeded, nDim, nodesPerElem, numScsIp, numScvIp);
-  }
+               ElemDataRequests& dataNeeded);
 
   virtual ~ScratchViews() {
     for(ViewHolder* vh : fieldViews) {
@@ -138,33 +48,17 @@ public:
     }
   }
 
-  SharedMemView<double*>& get_scratch_view_1D(const stk::mesh::FieldBase& field)
-  {
-    ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 1D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
-    ViewT<SharedMemView<double*>>* vt = static_cast<ViewT<SharedMemView<double*>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
-    return vt->view_;
-  }
+  inline
+  SharedMemView<double*>& get_scratch_view_1D(const stk::mesh::FieldBase& field);
 
-  SharedMemView<double**>& get_scratch_view_2D(const stk::mesh::FieldBase& field)
-  {
-    ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 2D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
-    ViewT<SharedMemView<double**>>* vt = static_cast<ViewT<SharedMemView<double**>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
-    return vt->view_;
-  }
+  inline
+  SharedMemView<double**>& get_scratch_view_2D(const stk::mesh::FieldBase& field);
 
-  SharedMemView<double***>& get_scratch_view_3D(const stk::mesh::FieldBase& field)
-  {
-    ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 3D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
-    ViewT<SharedMemView<double***>>* vt = static_cast<ViewT<SharedMemView<double***>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
-    return vt->view_;
-  }
+  inline
+  SharedMemView<double***>& get_scratch_view_3D(const stk::mesh::FieldBase& field);
 
-  SharedMemView<double****>& get_scratch_view_4D(const stk::mesh::FieldBase& field)
-  {
-    ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 4D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
-    ViewT<SharedMemView<double****>>* vt = static_cast<ViewT<SharedMemView<double****>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
-    return vt->view_;
-  }
+  inline
+  SharedMemView<double****>& get_scratch_view_4D(const stk::mesh::FieldBase& field);
 
   const stk::mesh::Entity* elemNodes;
   SharedMemView<double**> scs_areav;
@@ -177,213 +71,56 @@ private:
   void create_needed_field_views(const TeamHandleType& team,
                                  const ElemDataRequests& dataNeeded,
                                  const stk::mesh::BulkData& bulkData,
-                                 int nodesPerElem)
-  {
-    const stk::mesh::MetaData& meta = bulkData.mesh_meta_data();
-    unsigned numFields = meta.get_fields().size();
-    // FIXME: Ideally, size based on what was actually added; waht about fast access?
-    fieldViews.resize(numFields, nullptr);
-
-    const FieldSet& neededFields = dataNeeded.get_fields();
-    for(const FieldInfo& fieldInfo : neededFields) {
-      stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
-      ThrowAssertMsg(fieldEntityRank == stk::topology::NODE_RANK || fieldEntityRank == stk::topology::ELEM_RANK, "Currently only node and element fields are supported.");
-      unsigned scalarsDim1 = fieldInfo.scalarsDim1;
-      unsigned scalarsDim2 = fieldInfo.scalarsDim2;
-
-      if (fieldEntityRank==stk::topology::ELEM_RANK) {
-        if (scalarsDim2 == 0) {
-          fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double*>>(get_shmem_view_1D(team, scalarsDim1));
-        }
-        else {
-          fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double**>>(get_shmem_view_2D(team, scalarsDim1, scalarsDim2));
-        }
-      }
-      else if (fieldEntityRank==stk::topology::NODE_RANK) {
-        if (scalarsDim2 == 0) {
-          if (scalarsDim1 == 1) {
-            fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double*>>(get_shmem_view_1D(team, nodesPerElem));
-          }
-          else {
-            fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double**>>(get_shmem_view_2D(team, nodesPerElem, scalarsDim1));
-          }
-        }
-        else {
-            fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double***>>(get_shmem_view_3D(team, nodesPerElem, scalarsDim1, scalarsDim2));
-        }
-      }
-      else {
-        ThrowRequireMsg(false,"Only elem-rank and node-rank fields supported for scratch-views currently.");
-      }
-    }
-  }
+                                 int nodesPerElem);
 
   void create_needed_master_element_views(const TeamHandleType& team,
                                           const ElemDataRequests& dataNeeded,
                                           int nDim, int nodesPerElem,
-                                          int numScsIp, int numScvIp)
-  {
-    const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
-    for(ELEM_DATA_NEEDED data : dataEnums) {
-      switch(data)
-      {
-        case SCS_AREAV:
-           ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
-           scs_areav = get_shmem_view_2D(team, numScsIp, nDim);
-           break;
-
-        case SCS_GRAD_OP:
-           ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
-           dndx = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
-           deriv = get_shmem_view_1D(team, numScsIp*nodesPerElem*nDim);
-           det_j = get_shmem_view_1D(team, numScsIp);
-           break;
-
-        case SCV_VOLUME:
-           ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
-           scv_volume = get_shmem_view_1D(team, numScvIp);
-           break;
-
-        default: break;
-      }
-    }
-  }
+                                          int numScsIp, int numScvIp);
 
   std::vector<ViewHolder*> fieldViews;
 };
 
 inline
-int get_num_bytes_pre_req_data(
-  ElemDataRequests& dataNeededBySuppAlgs,
-  int nDim)
-{
-  // master elements are allowed to be null if they are not required
-  MasterElement *meSCS = dataNeededBySuppAlgs.get_cvfem_surface_me();
-  MasterElement *meSCV = dataNeededBySuppAlgs.get_cvfem_volume_me();
-  
-  const int nodesPerElem = meSCS != nullptr ? meSCS->nodesPerElement_ : 0;
-  const int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
-  const int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
-  int numBytes = 0;
-  
-  const FieldSet& neededFields = dataNeededBySuppAlgs.get_fields();
-  for(const FieldInfo& fieldInfo : neededFields) {
-    stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
-    ThrowAssertMsg(fieldEntityRank == stk::topology::NODE_RANK || fieldEntityRank == stk::topology::ELEM_RANK, "Currently only node and element fields are supported.");
-    unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
-    unsigned entitiesPerElem = fieldEntityRank==stk::topology::ELEM_RANK ? 1 : nodesPerElem;
-    if (fieldInfo.scalarsDim2 > 1) {
-      scalarsPerEntity *= fieldInfo.scalarsDim2;
-    }
-    numBytes += entitiesPerElem*scalarsPerEntity*sizeof(double);
-  }
-  
-  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeededBySuppAlgs.get_data_enums();
-  int dndxLength = 0, derivLength = 0, detJLength = 0;
-  for(ELEM_DATA_NEEDED data : dataEnums) {
-    switch(data)
-      {
-      case SCS_AREAV: numBytes += nDim * numScsIp * sizeof(double);
-        break;
-      case SCS_GRAD_OP:
-        dndxLength = nodesPerElem*numScsIp*nDim;
-        derivLength = nodesPerElem*numScsIp*nDim;
-        detJLength = numScsIp;
-        numBytes += (dndxLength + derivLength + detJLength) * sizeof(double);
-        break;
-      case SCV_VOLUME: numBytes += numScvIp * sizeof(double);
-      default: break;
-      }
-  }
-  
-  return numBytes*2;
+SharedMemView<double*>& ScratchViews::get_scratch_view_1D(const stk::mesh::FieldBase& field)
+{ 
+  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 1D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
+  ViewT<SharedMemView<double*>>* vt = static_cast<ViewT<SharedMemView<double*>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
+  return vt->view_;
 }
 
 inline
-void fill_pre_req_data(
-  ElemDataRequests& dataNeeded,
-  const stk::mesh::BulkData& bulkData,
-  stk::topology topo,
-  stk::mesh::Entity elem,
-  const stk::mesh::FieldBase* coordField,
-  ScratchViews& prereqData)
-{
-  int nodesPerElem = topo.num_nodes();
-
-  // extract master elements
-  MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
-  MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
-
-  const FieldSet& neededFields = dataNeeded.get_fields();
-  for(const FieldInfo& fieldInfo : neededFields) {
-    stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
-    unsigned scalarsDim1 = fieldInfo.scalarsDim1;
-    bool isTensorField = fieldInfo.scalarsDim2 > 1;
-
-    if (fieldEntityRank==stk::topology::ELEM_RANK) {
-      if (isTensorField) {
-        SharedMemView<double**>& shmemView = prereqData.get_scratch_view_2D(*fieldInfo.field);
-        gather_elem_tensor_field(*fieldInfo.field, elem, scalarsDim1, fieldInfo.scalarsDim2, shmemView);
-      }
-      else {
-        SharedMemView<double*>& shmemView = prereqData.get_scratch_view_1D(*fieldInfo.field);
-        unsigned len = shmemView.dimension(0);
-        double* fieldDataPtr = static_cast<double*>(stk::mesh::field_data(*fieldInfo.field, elem));
-        for(unsigned i=0; i<len; ++i) {
-          shmemView(i) = fieldDataPtr[i];
-        }
-      }
-    }
-    else if (fieldEntityRank == stk::topology::NODE_RANK) {
-      if (isTensorField) {
-        SharedMemView<double***>& shmemView3D = prereqData.get_scratch_view_3D(*fieldInfo.field);
-        gather_elem_node_tensor_field(*fieldInfo.field, nodesPerElem, scalarsDim1, fieldInfo.scalarsDim2, bulkData.begin_nodes(elem), shmemView3D);
-      }
-      else {
-        if (scalarsDim1 == 1) {
-          SharedMemView<double*>& shmemView1D = prereqData.get_scratch_view_1D(*fieldInfo.field);
-          gather_elem_node_field(*fieldInfo.field, nodesPerElem, bulkData.begin_nodes(elem), shmemView1D);
-        }
-        else {
-          SharedMemView<double**>& shmemView2D = prereqData.get_scratch_view_2D(*fieldInfo.field);
-          if (scalarsDim1 == 3) {
-            gather_elem_node_field_3D(*fieldInfo.field, nodesPerElem, bulkData.begin_nodes(elem), shmemView2D);
-          }
-          else {
-            gather_elem_node_field(*fieldInfo.field, nodesPerElem, scalarsDim1, bulkData.begin_nodes(elem), shmemView2D);
-          }
-        }
-      }
-    }
-    else {
-      ThrowRequireMsg(false, "Only node and element fields supported currently.");
-    }
-  }
-
-  SharedMemView<double**>& coords = prereqData.get_scratch_view_2D(*coordField);
-  prereqData.elemNodes = bulkData.begin_nodes(elem);
-  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
-  double error = 0;
-  for(ELEM_DATA_NEEDED data : dataEnums) {
-    switch(data)
-    {
-      case SCS_AREAV:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
-         meSCS->determinant(1, &coords(0,0), &prereqData.scs_areav(0,0), &error);
-         break;
-
-      case SCS_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-         meSCS->grad_op(1, &coords(0,0), &prereqData.dndx(0,0,0), &prereqData.deriv(0), &prereqData.det_j(0), &error);
-         break;
-      case SCV_VOLUME:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
-         meSCV->determinant(1, &coords(0,0), &prereqData.scv_volume(0), &error);
-
-      default: break;
-    }
-  }
+SharedMemView<double**>& ScratchViews::get_scratch_view_2D(const stk::mesh::FieldBase& field)
+{ 
+  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 2D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
+  ViewT<SharedMemView<double**>>* vt = static_cast<ViewT<SharedMemView<double**>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
+  return vt->view_;
 }
+
+inline
+SharedMemView<double***>& ScratchViews::get_scratch_view_3D(const stk::mesh::FieldBase& field)
+{ 
+  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 3D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
+  ViewT<SharedMemView<double***>>* vt = static_cast<ViewT<SharedMemView<double***>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
+  return vt->view_;
+}
+
+inline
+SharedMemView<double****>& ScratchViews::get_scratch_view_4D(const stk::mesh::FieldBase& field)
+{
+  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 4D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
+  ViewT<SharedMemView<double****>>* vt = static_cast<ViewT<SharedMemView<double****>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
+  return vt->view_;
+}
+
+int get_num_bytes_pre_req_data( ElemDataRequests& dataNeededBySuppAlgs, int nDim);
+
+void fill_pre_req_data(ElemDataRequests& dataNeeded,
+                       const stk::mesh::BulkData& bulkData,
+                       stk::topology topo,
+                       stk::mesh::Entity elem,
+                       const stk::mesh::FieldBase* coordField,
+                       ScratchViews& prereqData);
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/ElemDataRequests.C
+++ b/src/ElemDataRequests.C
@@ -1,0 +1,71 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include <ElemDataRequests.h>
+
+namespace sierra {
+namespace nalu {
+
+void ElemDataRequests::add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned scalarsPerNode)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+
+  FieldInfo fieldInfo(&field, scalarsPerNode);
+  FieldSet::iterator iter = fields.find(fieldInfo);
+  if (iter == fields.end()) {
+    fields.insert(fieldInfo);
+  }   
+  else {
+    ThrowRequireMsg(iter->scalarsDim1 == scalarsPerNode, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with scalarsPerNode=="<<scalarsPerNode<<", but previously requested with scalarsPerNode=="<<iter->scalarsDim1);
+  }
+}
+
+void ElemDataRequests::add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::NODE_RANK,"ElemDataRequests ERROR, add_gathered_nodal_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==NODE_RANK");
+
+  FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
+  FieldSet::iterator iter = fields.find(fieldInfo);
+  if (iter == fields.end()) {
+    fields.insert(fieldInfo);
+  }
+  else {
+    ThrowRequireMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, gathered-nodal-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
+  }
+}
+
+void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+  FieldInfo fieldInfo(&field, scalarsPerElement);
+  FieldSet::iterator iter = fields.find(fieldInfo);
+  if (iter == fields.end()) {
+    fields.insert(fieldInfo);
+  }
+  else {
+    ThrowRequireMsg(iter->scalarsDim1 == scalarsPerElement, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with scalarsPerElement=="<<scalarsPerElement<<", but previously requested with scalarsPerElement=="<<iter->scalarsDim1);
+  }
+}
+
+void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+  FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
+  FieldSet::iterator iter = fields.find(fieldInfo);
+  if (iter == fields.end()) {
+    fields.insert(fieldInfo);
+  }
+  else {
+    ThrowRequireMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
+  }
+}
+
+}
+}
+

--- a/src/ScalarDiffElemSuppAlg.C
+++ b/src/ScalarDiffElemSuppAlg.C
@@ -65,9 +65,9 @@ ScalarDiffElemSuppAlg<AlgTraits>::ScalarDiffElemSuppAlg(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_);
-  dataPreReqs.add_gathered_nodal_field(*scalarQ);
-  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff);
+  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*scalarQ, 1);
+  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff, 1);
   dataPreReqs.add_master_element_call(SCS_AREAV);
   dataPreReqs.add_master_element_call(SCS_GRAD_OP);
 }

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -1,0 +1,319 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include <ScratchViews.h>
+
+namespace sierra {
+namespace nalu {
+
+inline
+void gather_elem_node_field(const stk::mesh::FieldBase& field,
+                            int numNodes,
+                            const stk::mesh::Entity* elemNodes,
+                            SharedMemView<double*>& shmemView)
+{
+  for(int i=0; i<numNodes; ++i) {
+    shmemView[i] = *static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
+  }
+}
+
+inline
+void gather_elem_node_tensor_field(const stk::mesh::FieldBase& field,
+                            int numNodes,
+                            int tensorDim1,
+                            int tensorDim2,
+                            const stk::mesh::Entity* elemNodes,
+                            SharedMemView<double***>& shmemView)
+{
+  for(int i=0; i<numNodes; ++i) {
+    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
+    unsigned counter = 0;
+    for(int d1=0; d1<tensorDim1; ++d1) { 
+      for(int d2=0; d2<tensorDim2; ++d2) {
+        shmemView(i,d1,d2) = dataPtr[counter++];
+      }
+    }
+  }
+}
+
+inline
+void gather_elem_tensor_field(const stk::mesh::FieldBase& field,
+                              stk::mesh::Entity elem,
+                              int tensorDim1,
+                              int tensorDim2,
+                              SharedMemView<double**>& shmemView)
+{
+  const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elem));
+  unsigned counter = 0;
+  for(int d1=0; d1<tensorDim1; ++d1) { 
+    for(int d2=0; d2<tensorDim2; ++d2) {
+      shmemView(d1,d2) = dataPtr[counter++];
+    }
+  }
+}
+
+inline
+void gather_elem_node_field_3D(const stk::mesh::FieldBase& field,
+                            int numNodes,
+                            const stk::mesh::Entity* elemNodes,
+                            SharedMemView<double**>& shmemView)
+{
+  for(int i=0; i<numNodes; ++i) {
+    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
+    shmemView(i,0) = dataPtr[0];
+    shmemView(i,1) = dataPtr[1];
+    shmemView(i,2) = dataPtr[2];
+  }
+}
+
+inline
+void gather_elem_node_field(const stk::mesh::FieldBase& field,
+                            int numNodes,
+                            int scalarsPerNode,
+                            const stk::mesh::Entity* elemNodes,
+                            SharedMemView<double**>& shmemView)
+{
+  for(int i=0; i<numNodes; ++i) {
+    const double* dataPtr = static_cast<const double*>(stk::mesh::field_data(field, elemNodes[i]));
+    for(int d=0; d<scalarsPerNode; ++d) {
+      shmemView(i,d) = dataPtr[d];
+    }
+  }
+}
+
+ScratchViews::ScratchViews(const TeamHandleType& team,
+             const stk::mesh::BulkData& bulkData,
+             stk::topology topo,
+             ElemDataRequests& dataNeeded)
+: elemNodes(nullptr), scs_areav(), dndx(), deriv(), det_j()
+{
+  /* master elements are allowed to be null if they are not required */
+  MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
+  MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
+
+  int nDim = bulkData.mesh_meta_data().spatial_dimension();
+  int nodesPerElem = topo.num_nodes();
+  int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
+  int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
+
+  create_needed_field_views(team, dataNeeded, bulkData, nodesPerElem);
+
+  create_needed_master_element_views(team, dataNeeded, nDim, nodesPerElem, numScsIp, numScvIp);
+}
+
+void ScratchViews::create_needed_field_views(const TeamHandleType& team,
+                               const ElemDataRequests& dataNeeded,
+                               const stk::mesh::BulkData& bulkData,
+                               int nodesPerElem)
+{
+  const stk::mesh::MetaData& meta = bulkData.mesh_meta_data();
+  unsigned numFields = meta.get_fields().size();
+  fieldViews.resize(numFields, nullptr);
+
+  const FieldSet& neededFields = dataNeeded.get_fields();
+  for(const FieldInfo& fieldInfo : neededFields) {
+    stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
+    ThrowAssertMsg(fieldEntityRank == stk::topology::NODE_RANK || fieldEntityRank == stk::topology::ELEM_RANK, "Currently only node and element fields are supported.");
+    unsigned scalarsDim1 = fieldInfo.scalarsDim1;
+    unsigned scalarsDim2 = fieldInfo.scalarsDim2;
+
+    if (fieldEntityRank==stk::topology::ELEM_RANK) {
+      if (scalarsDim2 == 0) {
+        fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double*>>(get_shmem_view_1D(team, scalarsDim1));
+      }
+      else {
+        fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double**>>(get_shmem_view_2D(team, scalarsDim1, scalarsDim2));
+      }
+    }
+    else if (fieldEntityRank==stk::topology::NODE_RANK) {
+      if (scalarsDim2 == 0) {
+        if (scalarsDim1 == 1) {
+          fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double*>>(get_shmem_view_1D(team, nodesPerElem));
+        }
+        else {
+          fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double**>>(get_shmem_view_2D(team, nodesPerElem, scalarsDim1));
+        }
+      }
+      else {
+          fieldViews[fieldInfo.field->mesh_meta_data_ordinal()] = new ViewT<SharedMemView<double***>>(get_shmem_view_3D(team, nodesPerElem, scalarsDim1, scalarsDim2));
+      }
+    }
+    else {
+      ThrowRequireMsg(false,"Only elem-rank and node-rank fields supported for scratch-views currently.");
+    }
+  }
+}
+
+void ScratchViews::create_needed_master_element_views(const TeamHandleType& team,
+                                        const ElemDataRequests& dataNeeded,
+                                        int nDim, int nodesPerElem,
+                                        int numScsIp, int numScvIp)
+{
+  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
+  for(ELEM_DATA_NEEDED data : dataEnums) {
+    switch(data)
+    {
+      case SCS_AREAV:
+         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
+         scs_areav = get_shmem_view_2D(team, numScsIp, nDim);
+         break;
+
+      case SCS_GRAD_OP:
+         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
+         dndx = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
+         deriv = get_shmem_view_1D(team, numScsIp*nodesPerElem*nDim);
+         det_j = get_shmem_view_1D(team, numScsIp);
+         break;
+
+      case SCV_VOLUME:
+         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
+         scv_volume = get_shmem_view_1D(team, numScvIp);
+         break;
+
+      default: break;
+    }
+  }
+}
+
+int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)
+{
+  /* master elements are allowed to be null if they are not required */
+  MasterElement *meSCS = dataNeededBySuppAlgs.get_cvfem_surface_me();
+  MasterElement *meSCV = dataNeededBySuppAlgs.get_cvfem_volume_me();
+  
+  const int nodesPerElem = meSCS != nullptr ? meSCS->nodesPerElement_ : 0;
+  const int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
+  const int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
+  int numBytes = 0;
+  
+  const FieldSet& neededFields = dataNeededBySuppAlgs.get_fields();
+  for(const FieldInfo& fieldInfo : neededFields) {
+    stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
+    ThrowAssertMsg(fieldEntityRank == stk::topology::NODE_RANK || fieldEntityRank == stk::topology::ELEM_RANK, "Currently only node and element fields are supported.");
+    unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
+    unsigned entitiesPerElem = fieldEntityRank==stk::topology::ELEM_RANK ? 1 : nodesPerElem;
+    if (fieldInfo.scalarsDim2 > 1) {
+      scalarsPerEntity *= fieldInfo.scalarsDim2;
+    }
+    numBytes += entitiesPerElem*scalarsPerEntity*sizeof(double);
+  }
+  
+  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeededBySuppAlgs.get_data_enums();
+  int dndxLength = 0, derivLength = 0, detJLength = 0;
+  for(ELEM_DATA_NEEDED data : dataEnums) {
+    switch(data)
+      {
+      case SCS_AREAV: numBytes += nDim * numScsIp * sizeof(double);
+        break;
+      case SCS_GRAD_OP:
+        dndxLength = nodesPerElem*numScsIp*nDim;
+        derivLength = nodesPerElem*numScsIp*nDim;
+        detJLength = numScsIp;
+        numBytes += (dndxLength + derivLength + detJLength) * sizeof(double);
+        break;
+      case SCV_VOLUME: numBytes += numScvIp * sizeof(double);
+      default: break;
+      }
+  }
+  
+  return numBytes*2;
+}
+
+void fill_pre_req_data(
+  ElemDataRequests& dataNeeded,
+  const stk::mesh::BulkData& bulkData,
+  stk::topology topo,
+  stk::mesh::Entity elem,
+  const stk::mesh::FieldBase* coordField,
+  ScratchViews& prereqData)
+{
+  int nodesPerElem = topo.num_nodes();
+
+  MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
+  MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
+  prereqData.elemNodes = bulkData.begin_nodes(elem);
+
+  const FieldSet& neededFields = dataNeeded.get_fields();
+  for(const FieldInfo& fieldInfo : neededFields) {
+    stk::mesh::EntityRank fieldEntityRank = fieldInfo.field->entity_rank();
+    unsigned scalarsDim1 = fieldInfo.scalarsDim1;
+    bool isTensorField = fieldInfo.scalarsDim2 > 1;
+
+    if (fieldEntityRank==stk::topology::ELEM_RANK) {
+      if (isTensorField) {
+        SharedMemView<double**>& shmemView = prereqData.get_scratch_view_2D(*fieldInfo.field);
+        gather_elem_tensor_field(*fieldInfo.field, elem, scalarsDim1, fieldInfo.scalarsDim2, shmemView);
+      }
+      else {
+        SharedMemView<double*>& shmemView = prereqData.get_scratch_view_1D(*fieldInfo.field);
+        unsigned len = shmemView.dimension(0);
+        double* fieldDataPtr = static_cast<double*>(stk::mesh::field_data(*fieldInfo.field, elem));
+        for(unsigned i=0; i<len; ++i) {
+          shmemView(i) = fieldDataPtr[i];
+        }
+      }
+    }
+    else if (fieldEntityRank == stk::topology::NODE_RANK) {
+      if (isTensorField) {
+        SharedMemView<double***>& shmemView3D = prereqData.get_scratch_view_3D(*fieldInfo.field);
+        gather_elem_node_tensor_field(*fieldInfo.field, nodesPerElem, scalarsDim1, fieldInfo.scalarsDim2, bulkData.begin_nodes(elem), shmemView3D);
+      }
+      else {
+        if (scalarsDim1 == 1) {
+          SharedMemView<double*>& shmemView1D = prereqData.get_scratch_view_1D(*fieldInfo.field);
+          gather_elem_node_field(*fieldInfo.field, nodesPerElem, prereqData.elemNodes, shmemView1D);
+        }
+        else {
+          SharedMemView<double**>& shmemView2D = prereqData.get_scratch_view_2D(*fieldInfo.field);
+          if (scalarsDim1 == 3) {
+            gather_elem_node_field_3D(*fieldInfo.field, nodesPerElem, prereqData.elemNodes, shmemView2D);
+          }
+          else {
+            gather_elem_node_field(*fieldInfo.field, nodesPerElem, scalarsDim1, prereqData.elemNodes, shmemView2D);
+          }
+        }
+      }
+    }
+    else {
+      ThrowRequireMsg(false, "Only node and element fields supported currently.");
+    }
+  } 
+      
+  SharedMemView<double**>* coordsView = nullptr;
+  if (coordField != nullptr) {
+    coordsView = &prereqData.get_scratch_view_2D(*coordField);
+  }
+
+  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
+  double error = 0;
+  for(ELEM_DATA_NEEDED data : dataEnums) {
+    switch(data)
+    {
+      case SCS_AREAV:
+         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+         meSCS->determinant(1, &((*coordsView)(0,0)), &prereqData.scs_areav(0,0), &error);
+         break;
+
+      case SCS_GRAD_OP:
+         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+         meSCS->grad_op(1, &((*coordsView)(0,0)), &prereqData.dndx(0,0,0), &prereqData.deriv(0), &prereqData.det_j(0), &error);
+         break;
+      case SCV_VOLUME:
+         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
+         meSCV->determinant(1, &((*coordsView)(0,0)), &prereqData.scv_volume(0), &error);
+
+      default: break;
+    }
+  }
+}
+
+}
+}
+

--- a/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
@@ -65,7 +65,7 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSu
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_);
+  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME);
 }
 

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -37,7 +37,7 @@ void element_discrete_laplacian_kernel_3d(
     sierra::nalu::SharedMemView<double*>& elemNodePressures = elemData.get_scratch_view_1D(*nodalPressureField);
     sierra::nalu::SharedMemView<double**>& scs_areav = elemData.scs_areav;
     sierra::nalu::SharedMemView<double***>& dndx = elemData.dndx;
-    sierra::nalu::SharedMemView<stk::mesh::Entity*>& elemNodes = elemData.elemNodes;
+    const stk::mesh::Entity* elemNodes = elemData.elemNodes;
 
     for (int ip = 0; ip < numScsIp; ++ip ) {
 
@@ -80,11 +80,10 @@ public:
   {
     //here are the element-data pre-requisites we want computed before
     //our elem_execute method is called.
-    dataNeeded.add(sierra::nalu::NODES);
-    dataNeeded.add(sierra::nalu::SCS_AREAV);
-    dataNeeded.add(sierra::nalu::SCS_GRAD_OP);
-    dataNeeded.add(*coordField);
-    dataNeeded.add(*nodalPressureField);
+    dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV);
+    dataNeeded.add_master_element_call(sierra::nalu::SCS_GRAD_OP);
+    dataNeeded.add_gathered_nodal_field(*coordField, 3);
+    dataNeeded.add_gathered_nodal_field(*nodalPressureField, 1);
 
     // add the master element
     sierra::nalu::MasterElement* meSCS = unit_test_utils::get_surface_master_element(topo);

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -157,7 +157,7 @@ private:
 
 TEST_F(Hex8Mesh, elem_supp_alg_views)
 {
-    fill_mesh_and_initialize_test_fields();
+    fill_mesh_and_initialize_test_fields("generated:20x20x20");
 
     TestElemAlgorithmWithSuppAlgViews testAlgorithm(bulk, partVec, coordField);
 

--- a/unit_tests/UnitTestKokkosUtils.h
+++ b/unit_tests/UnitTestKokkosUtils.h
@@ -7,6 +7,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <KokkosInterface.h>
+#include "UnitTestUtils.h"
 
 template<class OUTER_LOOP_BODY, class INNER_LOOP_BODY>
 void bucket_loop_serial_only(const stk::mesh::BucketVector& buckets, const OUTER_LOOP_BODY& outer_loop_body, const INNER_LOOP_BODY& inner_loop_body)

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -1,0 +1,224 @@
+#include <gtest/gtest.h>
+#include <limits>
+#include <random>
+
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldBLAS.hpp>
+
+#include <stk_util/parallel/Parallel.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <ElemDataRequests.h>
+#include <ScratchViews.h>
+
+#include "UnitTestKokkosUtils.h"
+#include "UnitTestUtils.h"
+
+namespace {
+
+#ifndef KOKKOS_HAVE_CUDA
+
+using sierra::nalu::SharedMemView;
+
+class SuppAlg
+{
+public:
+  virtual ~SuppAlg(){}
+
+  virtual void elem_execute(stk::topology topo,
+                    sierra::nalu::ScratchViews& elemData) = 0;
+};
+
+class TestSuppAlg : public SuppAlg
+{
+public:
+  TestSuppAlg(sierra::nalu::ElemDataRequests& dataNeeded,
+              const ScalarFieldType* ndScalarField,
+              const VectorFieldType* ndVectorField,
+              const TensorFieldType* ndTensorField,
+              const ScalarFieldType* elScalarField,
+              const VectorFieldType* elVectorField,
+              const TensorFieldType* elTensorField)
+   :
+     nodalScalarField(ndScalarField),
+     nodalVectorField(ndVectorField),
+     nodalTensorField(ndTensorField),
+     elemScalarField(elScalarField),
+     elemVectorField(elVectorField),
+     elemTensorField(elTensorField)
+  {
+    //here are the element-data pre-requisites we want computed before
+    //our elem_execute method is called.
+    dataNeeded.add_gathered_nodal_field(*nodalScalarField, 1);
+    dataNeeded.add_gathered_nodal_field(*nodalVectorField, 4);
+    dataNeeded.add_gathered_nodal_field(*nodalTensorField, 3, 3);
+    dataNeeded.add_element_field(*elemScalarField, 1);
+    dataNeeded.add_element_field(*elemVectorField, 8);
+    dataNeeded.add_element_field(*elemTensorField, 2, 2);
+  }
+
+  virtual ~TestSuppAlg() {}
+
+  virtual void elem_execute(stk::topology topo,
+                    sierra::nalu::ScratchViews& elemData)
+  {
+    unsigned nodesPerElem = topo.num_nodes();
+
+    SharedMemView<double*>& nodalScalarView = elemData.get_scratch_view_1D(*nodalScalarField);
+    SharedMemView<double**>& nodalVectorView = elemData.get_scratch_view_2D(*nodalVectorField);
+    SharedMemView<double***>& nodalTensorView = elemData.get_scratch_view_3D(*nodalTensorField);
+
+    SharedMemView<double*>& elemScalarView = elemData.get_scratch_view_1D(*elemScalarField);
+    SharedMemView<double*>& elemVectorView = elemData.get_scratch_view_1D(*elemVectorField);
+    SharedMemView<double**>& elemTensorView = elemData.get_scratch_view_2D(*elemTensorField);
+
+    EXPECT_EQ(nodesPerElem, nodalScalarView.dimension(0));
+    EXPECT_EQ(nodesPerElem, nodalVectorView.dimension(0));
+    EXPECT_EQ(4u,           nodalVectorView.dimension(1));
+    EXPECT_EQ(nodesPerElem, nodalTensorView.dimension(0));
+    EXPECT_EQ(3u,           nodalTensorView.dimension(1));
+    EXPECT_EQ(3u,           nodalTensorView.dimension(2));
+
+    EXPECT_EQ(1u, elemScalarView.dimension(0));
+    EXPECT_EQ(8u, elemVectorView.dimension(0));
+    EXPECT_EQ(2u, elemTensorView.dimension(0));
+    EXPECT_EQ(2u, elemTensorView.dimension(1));
+  }
+
+private:
+  const ScalarFieldType* nodalScalarField;
+  const VectorFieldType* nodalVectorField;
+  const TensorFieldType* nodalTensorField;
+  const ScalarFieldType* elemScalarField;
+  const VectorFieldType* elemVectorField;
+  const TensorFieldType* elemTensorField;
+};
+
+//=========== Test class that mimics an alg with supplemental algs ========
+//
+class TestAlgorithm
+{
+public:
+  TestAlgorithm(stk::mesh::BulkData& bulk, const stk::mesh::PartVector& partVec)
+  : suppAlgs_(), bulkData_(bulk), partVec_(partVec)
+  {}
+
+  void execute()
+  {
+      const stk::mesh::MetaData& meta = bulkData_.mesh_meta_data();
+  
+      const stk::mesh::BucketVector& elemBuckets = bulkData_.get_buckets(stk::topology::ELEM_RANK, meta.locally_owned_part());
+  
+      //In this unit-test we know we're working on a hex8 mesh. In real algorithms,
+      //a topology would be available.
+      dataNeededBySuppAlgs_.add_cvfem_surface_me(unit_test_utils::get_surface_master_element(stk::topology::HEX_8));
+
+      const int bytes_per_team = 0;
+      const int bytes_per_thread = get_num_bytes_pre_req_data(dataNeededBySuppAlgs_, meta.spatial_dimension());
+      auto team_exec = sierra::nalu::get_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);
+      Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
+      {
+          const stk::mesh::Bucket& bkt = *elemBuckets[team.league_rank()];
+          stk::topology topo = bkt.topology();
+
+          sierra::nalu::ScratchViews prereqData(team, bulkData_, topo, dataNeededBySuppAlgs_);
+
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
+          {
+             fill_pre_req_data(dataNeededBySuppAlgs_, bulkData_, topo,
+                               bkt[jj], nullptr, prereqData);
+            
+             for(SuppAlg* alg : suppAlgs_) {
+               alg->elem_execute(topo, prereqData);
+             }
+          });
+      });
+  }
+
+  std::vector<SuppAlg*> suppAlgs_;
+  sierra::nalu::ElemDataRequests dataNeededBySuppAlgs_;
+
+private:
+  stk::mesh::BulkData& bulkData_;
+  const stk::mesh::PartVector& partVec_;
+};
+
+
+TEST_F(Hex8Mesh, supp_alg_data_sharing)
+{
+    ScalarFieldType& nodalScalarField = meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
+    VectorFieldType& nodalVectorField = meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "nodalVectorField");
+    TensorFieldType& nodalTensorField = meta.declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta.declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
+    VectorFieldType& elemVectorField = meta.declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemVectorField");
+    TensorFieldType& elemTensorField = meta.declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+
+    const stk::mesh::Part& wholemesh = meta.universal_part();
+
+    stk::mesh::put_field(nodalScalarField, wholemesh);
+    stk::mesh::put_field(nodalVectorField, wholemesh, 4);
+    stk::mesh::put_field(nodalTensorField, wholemesh, 3, 3);
+
+    stk::mesh::put_field(elemScalarField, wholemesh);
+    stk::mesh::put_field(elemVectorField, wholemesh, 8);
+    stk::mesh::put_field(elemTensorField, wholemesh, 2, 2);
+
+    fill_mesh("generated:10x10x10");
+
+    TestAlgorithm testAlgorithm(bulk, partVec);
+
+    //TestSuppAlg constructor says which data it needs, by inserting
+    //things into the 'dataNeededBySuppAlgs_' container.
+    
+    SuppAlg* suppAlg = new TestSuppAlg(testAlgorithm.dataNeededBySuppAlgs_,
+                                     &nodalScalarField, &nodalVectorField, &nodalTensorField,
+                                     &elemScalarField, &elemVectorField, &elemTensorField);
+
+    testAlgorithm.suppAlgs_.push_back(suppAlg);
+
+    testAlgorithm.execute();
+
+    delete suppAlg;
+}
+
+TEST_F(Hex8Mesh, inconsistent_field_requests)
+{
+    ScalarFieldType& nodalScalarField = meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
+    TensorFieldType& nodalTensorField = meta.declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta.declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
+    TensorFieldType& elemTensorField = meta.declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+
+    const stk::mesh::Part& wholemesh = meta.universal_part();
+
+    stk::mesh::put_field(nodalScalarField, wholemesh);
+    stk::mesh::put_field(nodalTensorField, wholemesh, 3, 3);
+
+    stk::mesh::put_field(elemScalarField, wholemesh);
+    stk::mesh::put_field(elemTensorField, wholemesh, 2, 2);
+
+    fill_mesh("generated:10x10x10");
+
+    sierra::nalu::ElemDataRequests prereqData;
+
+    prereqData.add_gathered_nodal_field(nodalScalarField, 1);
+    EXPECT_THROW(prereqData.add_gathered_nodal_field(nodalScalarField, 2), std::logic_error);
+    prereqData.add_element_field(elemScalarField, 1);
+    EXPECT_THROW(prereqData.add_element_field(elemScalarField, 2), std::logic_error);
+
+    prereqData.add_gathered_nodal_field(nodalTensorField, 3, 3);
+    EXPECT_THROW(prereqData.add_gathered_nodal_field(nodalTensorField, 5, 5), std::logic_error);
+    EXPECT_THROW(prereqData.add_gathered_nodal_field(nodalTensorField, 5), std::logic_error);
+
+    prereqData.add_element_field(elemTensorField, 2, 2);
+    EXPECT_THROW(prereqData.add_element_field(elemTensorField, 5, 5), std::logic_error);
+    EXPECT_THROW(prereqData.add_element_field(elemTensorField, 5), std::logic_error);
+}
+
+//end of stuff that's ifndef'd for KOKKOS_HAVE_CUDA
+#endif
+
+}
+

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -1,3 +1,6 @@
+#ifndef _UnitTestUtils_h_
+#define _UnitTestUtils_h_
+
 #include <string>
 #include <ostream>
 
@@ -13,6 +16,7 @@
 
 typedef stk::mesh::Field<double> ScalarFieldType;
 typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
+typedef stk::mesh::Field<double,stk::mesh::Cartesian,stk::mesh::Cartesian> TensorFieldType;
 
 namespace unit_test_utils {
 
@@ -57,12 +61,12 @@ protected:
 
     ~Hex8Mesh() {}
 
-    void fill_mesh(const std::string& meshSpec = "generated:70x70x70")
+    void fill_mesh(const std::string& meshSpec = "generated:20x20x20")
     { 
       unit_test_utils::fill_hex8_mesh(meshSpec, bulk);
     }
 
-    void fill_mesh_and_initialize_test_fields(const std::string& meshSpec = "generated:70x70x70")
+    void fill_mesh_and_initialize_test_fields(const std::string& meshSpec = "generated:20x20x20")
     {   
         fill_mesh(meshSpec);
 
@@ -89,6 +93,8 @@ protected:
     const VectorFieldType* coordField;
     double exactLaplacian; 
 };
+
+#endif
 
 #endif
 


### PR DESCRIPTION
1. No longer hold 3 arrays of views, each of length num-fields.
   Now just hold 1 array of views. Still of length num-fields for now.

2. Change ElemDataRequests::add_gathered_nodal_field to now take
  'scalarsPerNode' in addition to the field.
   When scalarsPerNode is 1, it will create a 1D scratch-view of length
   nodes-per-element. When scalarsPerNode is greater than 1, it will
   create a 2D scratch-view with dimensions (nodes-per-element , scalarsPerNode).

   This change allows for error-checking to make sure a given gathered
   field is requested with consistent dimensions.

   This change also allows us to avoid internally calling the
   stk::mesh::FieldBase::max_size method.

   The functions for retrieving the scratch views are still named
   get_scratch_view_1D/2D/3D/4D. The names must be different because
   the return-types are different types and you can't overload on
   return-type alone.

3. Don't need to store element-nodes in a view, and pointer is
   sufficient. (May not even need element-nodes on shared-data, but
   we can further evaluate that later.)

4. Remove un-needed 'add' functions on ElemDataRequests. We are
   using the more descriptive 'add_gathered_nodal_field' and
   'add_master_element_call', don't need a generic 'add'.

5. Remove the un-needed 'NODES' enum from ElemDataRequests.

Profiled the hybrid-cylinder case to ensure that performance is still
good. There may be an opportunity to improve the performance of the
gather through templating.