### PR TITLE
Promote SuppAlg reporting methods to EquationSystem

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -40,7 +40,8 @@ public:
 
   EquationSystem(
     EquationSystems& eqSystems,
-    const std::string name = "no_name");
+    const std::string name = "no_name",
+    const std::string eqnTypeName = "no_eqn_type_name");
   virtual ~EquationSystem();
 
   void set_nodal_gradient(
@@ -143,9 +144,13 @@ public:
   Simulation *root();
   EquationSystems *parent();
 
+  void report_invalid_supp_alg_names();
+  void report_built_supp_alg_names();
+
   EquationSystems &equationSystems_;
   Realm &realm_;
   std::string name_;
+  const std::string eqnTypeName_;
   int maxIterations_;
   double convergenceTolerance_;
 
@@ -203,7 +208,7 @@ public:
 
   // owner equation system
   /*EquationSystem *ownerEqs_;*/
-  
+
 };
 
 } // namespace nalu

--- a/include/HeatCondEquationSystem.h
+++ b/include/HeatCondEquationSystem.h
@@ -83,9 +83,6 @@ public:
     get_if_present(node, "use_collocation", collocationForViscousTerms_, false);
   }
 
-  void report_invalid_supp_alg_names();
-  void report_built_supp_alg_names();
-
 
   // allow equation system to manage a projected nodal gradient
   const bool managePNG_;
@@ -110,7 +107,6 @@ public:
   bool collocationForViscousTerms_;
   ProjectedNodalGradientEquationSystem *projectedNodalGradEqs_;
 
-  const std::string suppAlgTypeName_;
 };
 
 } // namespace nalu

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -108,7 +108,7 @@ EnthalpyEquationSystem::EnthalpyEquationSystem(
   const double minT,
   const double maxT,
   const bool outputClippingDiag)
-  : EquationSystem(eqSystems, "EnthalpyEQS"),
+  : EquationSystem(eqSystems, "EnthalpyEQS", "enthalpy"),
     minimumT_(minT),
     maximumT_(maxT),
     managePNG_(realm_.get_consistent_mass_matrix_png("enthalpy")),

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -20,6 +20,7 @@
 #include <LinearSystem.h>
 #include <ConstantAuxFunction.h>
 #include <Enums.h>
+#include <SupplementalAlgorithmBuilderLog.h>
 
 // overset
 #include <overset/AssembleOversetSolverConstraintAlgorithm.h>
@@ -36,10 +37,12 @@ namespace nalu{
 
 EquationSystem::EquationSystem(
   EquationSystems& eqSystems,
-  const std::string name) 
+  const std::string name,
+  const std::string eqnTypeName)
   : equationSystems_(eqSystems),
     realm_(eqSystems.realm_),
     name_(name),
+    eqnTypeName_(eqnTypeName),
     maxIterations_(1),
     convergenceTolerance_(1.0),
     solverAlgDriver_(new SolverAlgorithmDriver(realm_)),
@@ -429,5 +432,28 @@ EquationSystem::create_peclet_function(
   return pecletFunction;
 }
 
+//--------------------------------------------------------------------------
+void
+EquationSystem::report_invalid_supp_alg_names()
+{
+  bool noInvalidNamesFound = SuppAlgBuilderLog::self().print_invalid_supp_alg_names(
+    eqnTypeName_, realm_.solutionOptions_->elemSrcTermsMap_
+  );
+
+  if (!noInvalidNamesFound) {
+    SuppAlgBuilderLog::self().print_valid_supp_alg_names(eqnTypeName_);
+
+    std::string msg =
+      "Invalid supplemental algorithms name(s) for " + eqnTypeName_ + ". See log for details.";
+
+    throw std::runtime_error(msg);
+  }
+}
+//--------------------------------------------------------------------------
+void
+EquationSystem::report_built_supp_alg_names()
+{
+  SuppAlgBuilderLog::self().print_built_supp_alg_names(eqnTypeName_);
+}
 } // namespace nalu
 } // namespace Sierra

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -101,7 +101,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 HeatCondEquationSystem::HeatCondEquationSystem(
   EquationSystems& eqSystems)
-  : EquationSystem(eqSystems, "HeatCondEQS"),
+  : EquationSystem(eqSystems, "HeatCondEQS", "temperature"),
     managePNG_(realm_.get_consistent_mass_matrix_png("temperature")),
     temperature_(NULL),
     dtdx_(NULL),
@@ -118,8 +118,7 @@ HeatCondEquationSystem::HeatCondEquationSystem(
     assembleNodalGradAlgDriver_(new AssembleNodalGradAlgorithmDriver(realm_, "temperature", "dtdx")),
     isInit_(true),
     collocationForViscousTerms_(false),
-    projectedNodalGradEqs_(NULL),
-    suppAlgTypeName_("temperature")
+    projectedNodalGradEqs_(NULL)
 {
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("temperature");
@@ -268,29 +267,6 @@ HeatCondEquationSystem::register_element_fields(
   }
 }
 //--------------------------------------------------------------------------
-void
-HeatCondEquationSystem::report_invalid_supp_alg_names()
-{
-  bool noInvalidNamesFound = SuppAlgBuilderLog::self().print_invalid_supp_alg_names(
-    suppAlgTypeName_, realm_.solutionOptions_->elemSrcTermsMap_
-  );
-
-  if (!noInvalidNamesFound) {
-    SuppAlgBuilderLog::self().print_valid_supp_alg_names(suppAlgTypeName_);
-
-    std::string msg =
-        "Invalid supplemental algorithms name(s) for " + suppAlgTypeName_ + ". See log for details.";
-
-    throw std::runtime_error(msg);
-  }
-}
-//--------------------------------------------------------------------------
-void
-HeatCondEquationSystem::report_built_supp_alg_names()
-{
-  SuppAlgBuilderLog::self().print_built_supp_alg_names(suppAlgTypeName_);
-}
-//--------------------------------------------------------------------------
 //-------- register_interior_algorithm -------------------------------------
 //--------------------------------------------------------------------------
 void
@@ -397,17 +373,17 @@ HeatCondEquationSystem::register_interior_algorithm(
 
     if (solverAlgWasBuilt) {
       build_topo_supp_alg_if_requested<SteadyThermal3dContactSrcElemSuppAlg>(
-        partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+        partTopo, reqSuppAlgNameMap, suppAlgVec, eqnTypeName_,
         realm_, dataPreReqs
       );
 
       build_topo_supp_alg_if_requested<ScalarDiffElemSuppAlg>(
-        partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+        partTopo, reqSuppAlgNameMap, suppAlgVec, eqnTypeName_,
         realm_, temperature_, thermalCond_, dataPreReqs
       );
 
       build_topo_supp_alg_if_requested<ScalarDiffFemSuppAlg>(
-        partTopo, reqSuppAlgNameMap, suppAlgVec, suppAlgTypeName_,
+        partTopo, reqSuppAlgNameMap, suppAlgVec, eqnTypeName_,
         realm_, temperature_, thermalCond_
       );
 

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -169,7 +169,7 @@ namespace nalu{
 LowMachEquationSystem::LowMachEquationSystem(
   EquationSystems& eqSystems,
   const bool elementContinuityEqs)
-  : EquationSystem(eqSystems, "LowMachEOSWrap"),
+  : EquationSystem(eqSystems, "LowMachEOSWrap","low_mach_type"),
     elementContinuityEqs_(elementContinuityEqs),
     density_(NULL),
     viscosity_(NULL),
@@ -805,7 +805,7 @@ LowMachEquationSystem::post_converged_work()
 //--------------------------------------------------------------------------
 MomentumEquationSystem::MomentumEquationSystem(
   EquationSystems& eqSystems)
-  : EquationSystem(eqSystems, "MomentumEQS"),
+  : EquationSystem(eqSystems, "MomentumEQS","momentum"),
     managePNG_(realm_.get_consistent_mass_matrix_png("velocity")),
     velocity_(NULL),
     dudx_(NULL),
@@ -1962,7 +1962,7 @@ MomentumEquationSystem::compute_projected_nodal_gradient()
 ContinuityEquationSystem::ContinuityEquationSystem(
   EquationSystems& eqSystems,
   const bool elementContinuityEqs)
-  : EquationSystem(eqSystems, "ContinuityEQS"),
+  : EquationSystem(eqSystems, "ContinuityEQS","continuity"),
     elementContinuityEqs_(elementContinuityEqs),
     managePNG_(realm_.get_consistent_mass_matrix_png("pressure")),
     pressure_(NULL),

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -83,7 +83,7 @@ namespace nalu{
 MassFractionEquationSystem::MassFractionEquationSystem(
   EquationSystems& eqSystems,
   const int numMassFraction)
-  : EquationSystem(eqSystems, "MassFractionEQS"),
+  : EquationSystem(eqSystems, "MassFractionEQS","mass_fraction"),
     managePNG_(realm_.get_consistent_mass_matrix_png("note_follow_momentum_approach")),
     numMassFraction_(numMassFraction),
     massFraction_(NULL),

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -91,7 +91,7 @@ MixtureFractionEquationSystem::MixtureFractionEquationSystem(
   EquationSystems& eqSystems,
   const bool outputClippingDiag,
   const double deltaZClip)
-  : EquationSystem(eqSystems, "MixtureFractionEQS"),
+  : EquationSystem(eqSystems, "MixtureFractionEQS","mixture_fraction"),
     managePNG_(realm_.get_consistent_mass_matrix_png("mixture_fraction")),
     outputClippingDiag_(outputClippingDiag),
     deltaZClip_(deltaZClip),

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -85,7 +85,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 SpecificDissipationRateEquationSystem::SpecificDissipationRateEquationSystem(
   EquationSystems& eqSystems)
-  : EquationSystem(eqSystems, "SpecDissRateEQS"),
+  : EquationSystem(eqSystems, "SpecDissRateEQS","specific_dissipation_rate"),
     managePNG_(realm_.get_consistent_mass_matrix_png("specific_dissipation_rate")),
     sdr_(NULL),
     dwdx_(NULL),

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -89,7 +89,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 TurbKineticEnergyEquationSystem::TurbKineticEnergyEquationSystem(
   EquationSystems& eqSystems)
-  : EquationSystem(eqSystems, "TurbKineticEnergyEQS"),
+  : EquationSystem(eqSystems, "TurbKineticEnergyEQS","turbulent_ke"),
     managePNG_(realm_.get_consistent_mass_matrix_png("turbulent_ke")),
     tke_(NULL),
     dkdx_(NULL),


### PR DESCRIPTION
Move methods from HeatCondEquationSystem so that other EQS can use it.

In preparation for moving Continuity and Momentum SupplementalAlgorithms to the new kokkos-based `AssembleElemSolverAlgorithm`

@rcknaus: Stefan said he wanted you to look at this. 