### PR TITLE
Fix EQS logic so that nodal time derivative term is not added when CMM is activated

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -147,7 +147,9 @@ public:
   void report_invalid_supp_alg_names();
   void report_built_supp_alg_names();
   bool supp_alg_is_requested(std::string name);
+  bool supp_alg_is_requested(std::vector<std::string>);
 
+  bool nodal_src_is_requested();
 
   EquationSystems &equationSystems_;
   Realm &realm_;

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -472,5 +472,37 @@ EquationSystem::supp_alg_is_requested(std::string suppAlgName)
   return true;
 }
 
+bool
+EquationSystem::supp_alg_is_requested(std::vector<std::string> names)
+{
+  const auto& nameMap = realm_.solutionOptions_->elemSrcTermsMap_;
+  auto it = nameMap.find(eqnTypeName_);
+
+  if (it == nameMap.end()) {
+    return false;
+  }
+
+  const std::vector<std::string>& nameVec = it->second;
+
+  bool found = false;
+  for(auto algName: names) {
+    if (std::find(nameVec.begin(), nameVec.end(), algName) != nameVec.end()) {
+      found = true;
+      break;
+    }
+  }
+  return found;
+}
+
+
+bool
+EquationSystem::nodal_src_is_requested()
+{
+  auto isrc = realm_.solutionOptions_->srcTermsMap_.find(eqnTypeName_);
+
+  return (isrc != realm_.solutionOptions_->srcTermsMap_.end());
+}
+
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1124,13 +1124,12 @@ MomentumEquationSystem::register_interior_algorithm(
     auto& suppAlgVec = solverAlg->supplementalAlg_;
 
     if (solverAlgWasBuilt) {
-      bool hasMass1, hasMass2;
 
-      hasMass1 = build_topo_supp_alg_if_requested<MomentumMassElemSuppAlg>
+      build_topo_supp_alg_if_requested<MomentumMassElemSuppAlg>
         (partTopo, *this, suppAlgVec, "momentum_time_derivative",
          realm_, dataPreReqs, false);
 
-      hasMass2 = build_topo_supp_alg_if_requested<MomentumMassElemSuppAlg>
+      build_topo_supp_alg_if_requested<MomentumMassElemSuppAlg>
         (partTopo, *this, suppAlgVec, "lumped_momentum_time_derivative",
          realm_, dataPreReqs, true);
 


### PR DESCRIPTION
Current code base has a bug where the `useCMM` flag is not set correctly when multiple parts are registered to the interior algorithm. This caused both the element mass SuppAlg as well as the nodal time derivative terms were activated. This pull-request fixes that issue. 

@spdomin: This pull request does not optimize the issue where Nodal Alg Driver is still created when there are zero SuppAlgs requested. That will come in a separate pull request. 

See #84 for discussion. 