### PR TITLE
Fixed minor typo and changed output precision width.

### DIFF
--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -67,7 +67,7 @@ SurfaceForceAndMomentAlgorithm::SurfaceForceAndMomentAlgorithm(
     dudx_(NULL),
     exposedAreaVec_(NULL),
     assembledArea_(NULL),
-    w_(12)
+    w_(16)
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -96,7 +96,7 @@ SurfaceForceAndMomentAlgorithm::SurfaceForceAndMomentAlgorithm(
     myfile << std::setw(w_) 
            << "Time" << std::setw(w_) 
            << "Fpx"  << std::setw(w_) << "Fpy" << std::setw(w_)  << "Fpz" << std::setw(w_) 
-           << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fxz" << std::setw(w_) 
+           << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fvz" << std::setw(w_) 
            << "Mtx"  << std::setw(w_) << "Mty" << std::setw(w_)  << "Mtz" << std::setw(w_) 
            << "Y+min" << std::setw(w_) << "Y+max"<< std::endl;
   }

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -71,7 +71,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::SurfaceForceAndMomentWallFunctionAlg
     wallNormalDistanceBip_(NULL),
     exposedAreaVec_(NULL),
     assembledArea_(NULL),
-    w_(12)
+    w_(16)
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -105,7 +105,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::SurfaceForceAndMomentWallFunctionAlg
     myfile << std::setw(w_) 
            << "Time" << std::setw(w_) 
            << "Fpx"  << std::setw(w_) << "Fpy" << std::setw(w_)  << "Fpz" << std::setw(w_) 
-           << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fxz" << std::setw(w_) 
+           << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fvz" << std::setw(w_) 
            << "Mtx"  << std::setw(w_) << "Mty" << std::setw(w_)  << "Mtz" << std::setw(w_) 
            << "Y+min" << std::setw(w_) << "Y+max"<< std::endl;
     myfile.close();


### PR DESCRIPTION
`Fxz` should be `Fvz` and the output precision width was causing columns of data to fuse
together, leading to something like the attached screenshot.
![screen shot 2017-03-14 at 12 09 02 pm](https://cloud.githubusercontent.com/assets/15038415/23915544/0ec253ea-08af-11e7-96ed-fd0a92da2eb4.png)

This may have to be changed in other files? Maybe we should consider a "global" value for this? 