### PR TITLE
Convert SupplementalAlgorithm::element_execute to take SharedMemViews.

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -44,13 +44,8 @@ public:
   MasterElement *meSCS_;
   MasterElement *meSCV_;
 
-  std::vector<double> lhs_;
-  std::vector<double> rhs_;
-  std::vector<int> scratchIds_;
-  std::vector<double> scratchVals_;
-  std::vector<stk::mesh::Entity> connectedNodes_;
-
   ElemDataRequests dataNeededBySuppAlgs_;
+  int rhsSize_;
 };
 
 } // namespace nalu

--- a/include/ContinuityAdvElemSuppAlg.h
+++ b/include/ContinuityAdvElemSuppAlg.h
@@ -40,8 +40,8 @@ public:
   virtual void setup();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews
   );

--- a/include/ContinuityMassElemSuppAlg.h
+++ b/include/ContinuityMassElemSuppAlg.h
@@ -42,8 +42,8 @@ public:
   virtual void setup();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>&lhs,
+    SharedMemView<double *>&rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews
   );

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -8,6 +8,7 @@
 #ifndef INCLUDE_KOKKOSINTERFACE_H_
 #define INCLUDE_KOKKOSINTERFACE_H_
 
+#include <stk_mesh/base/Entity.hpp>
 #include <Kokkos_Core.hpp>
 
 namespace sierra {
@@ -30,6 +31,12 @@ inline DeviceTeamPolicy get_team_policy(const size_t sz, const size_t bytes_per_
 {
   DeviceTeamPolicy policy(sz, Kokkos::AUTO);
   return policy.set_scratch_size(0, Kokkos::PerTeam(bytes_per_team), Kokkos::PerThread(bytes_per_thread));
+}
+
+inline
+SharedMemView<int*> get_int_shmem_view_1D(const TeamHandleType& team, size_t len)
+{
+  return Kokkos::subview(SharedMemView<int**>(team.team_shmem(), team.team_size(), len), team.team_rank(), Kokkos::ALL());
 }
 
 inline

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -10,6 +10,7 @@
 #define LinearSystem_h
 
 #include <LinearSolverTypes.h>
+#include <KokkosInterface.h>
 
 #include <Teuchos_RCP.hpp>
 #include <Tpetra_DefaultPlatform.hpp>
@@ -62,6 +63,15 @@ public:
 
   // Matrix Assembly
   virtual void zeroSystem()=0;
+
+  virtual void sumInto(
+      unsigned numEntities,
+      const stk::mesh::Entity* entities,
+      const SharedMemView<const double*> & rhs,
+      const SharedMemView<const double**> & lhs,
+      const SharedMemView<int*> & localIds,
+      const char * trace_tag
+      )=0;
 
   virtual void sumInto(
     const std::vector<stk::mesh::Entity> & sym_meshobj,

--- a/include/MomentumAdvDiffElemSuppAlg.h
+++ b/include/MomentumAdvDiffElemSuppAlg.h
@@ -40,8 +40,8 @@ public:
   virtual ~MomentumAdvDiffElemSuppAlg() {}
 
   void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
 

--- a/include/MomentumBuoyancySrcElemSuppAlg.h
+++ b/include/MomentumBuoyancySrcElemSuppAlg.h
@@ -38,8 +38,8 @@ public:
   virtual ~MomentumBuoyancySrcElemSuppAlg() {}
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double*>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/include/MomentumMassElemSuppAlg.h
+++ b/include/MomentumMassElemSuppAlg.h
@@ -41,8 +41,8 @@ public:
   virtual void setup();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/include/ScalarAdvDiffElemSuppAlg.h
+++ b/include/ScalarAdvDiffElemSuppAlg.h
@@ -39,8 +39,8 @@ public:
   virtual ~ScalarAdvDiffElemSuppAlg() {}
 
   void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/include/ScalarDiffElemSuppAlg.h
+++ b/include/ScalarDiffElemSuppAlg.h
@@ -39,8 +39,8 @@ public:
   virtual ~ScalarDiffElemSuppAlg() {}
 
   void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double**>& lhs,
+    SharedMemView<double*>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/include/ScalarDiffFemSuppAlg.h
+++ b/include/ScalarDiffFemSuppAlg.h
@@ -36,8 +36,8 @@ public:
   virtual ~ScalarDiffFemSuppAlg();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews &scratchViews);
   

--- a/include/ScalarMassElemSuppAlg.h
+++ b/include/ScalarMassElemSuppAlg.h
@@ -43,8 +43,8 @@ public:
   virtual void setup();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews
   );

--- a/include/ScalarUpwAdvDiffElemSuppAlg.h
+++ b/include/ScalarUpwAdvDiffElemSuppAlg.h
@@ -43,8 +43,8 @@ public:
   virtual ~ScalarUpwAdvDiffElemSuppAlg();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
 

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -10,6 +10,7 @@
 #define SolverAlgorithm_h
 
 #include <Algorithm.h>
+#include <KokkosInterface.h>
 
 #include <stk_mesh/base/Entity.hpp>
 #include <vector>
@@ -44,6 +45,14 @@ protected:
     const std::vector<double> &lhs,
     const char *trace_tag=0);
   
+  void apply_coeff(
+    unsigned numMeshobjs,
+    const stk::mesh::Entity* symMeshobjs,
+    const SharedMemView<int*> & scratchIds,
+    const SharedMemView<const double*> & rhs,
+    const SharedMemView<const double**> & lhs,
+    const char *trace_tag);
+
   EquationSystem *eqSystem_;
 };
 

--- a/include/SupplementalAlgorithm.h
+++ b/include/SupplementalAlgorithm.h
@@ -10,6 +10,7 @@
 #define SupplementalAlgorithm_h
 
 #include <master_element/MasterElement.h>
+#include <KokkosInterface.h>
 #include <vector>
 
 #include <stk_mesh/base/Types.hpp>
@@ -33,8 +34,8 @@ public:
   virtual void setup() {}
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double**>& lhs,
+    SharedMemView<double*>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews) {}
 

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -64,6 +64,14 @@ public:
   // Matrix Assembly
   void zeroSystem();
 
+void sumInto(
+      unsigned numEntities,
+      const stk::mesh::Entity* entities,
+      const SharedMemView<const double*> & rhs,
+      const SharedMemView<const double**> & lhs,
+      const SharedMemView<int*> & localIds,
+      const char * trace_tag);
+
   void sumInto(
     const std::vector<stk::mesh::Entity> & entities,
     std::vector<int> &scratchIds,

--- a/include/nso/MomentumNSOElemSuppAlg.h
+++ b/include/nso/MomentumNSOElemSuppAlg.h
@@ -45,8 +45,8 @@ public:
   void setup();
 
   void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
 

--- a/include/nso/MomentumNSOKeElemSuppAlg.h
+++ b/include/nso/MomentumNSOKeElemSuppAlg.h
@@ -41,8 +41,8 @@ public:
   virtual ~MomentumNSOKeElemSuppAlg() {}
 
   void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
 

--- a/include/nso/ScalarNSOElemSuppAlg.h
+++ b/include/nso/ScalarNSOElemSuppAlg.h
@@ -45,8 +45,8 @@ public:
   virtual void setup();
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/include/user_functions/SteadyThermal3dContactSrcElemSuppAlg.h
+++ b/include/user_functions/SteadyThermal3dContactSrcElemSuppAlg.h
@@ -37,8 +37,8 @@ public:
   virtual ~SteadyThermal3dContactSrcElemSuppAlg() {}
 
   virtual void element_execute(
-    double *lhs,
-    double *rhs,
+    SharedMemView<double **>& lhs,
+    SharedMemView<double *>& rhs,
     stk::mesh::Entity element,
     ScratchViews& scratchViews);
   

--- a/src/ContinuityAdvElemSuppAlg.C
+++ b/src/ContinuityAdvElemSuppAlg.C
@@ -107,8 +107,8 @@ ContinuityAdvElemSuppAlg<AlgTraits>::setup()
 template<typename AlgTraits>
 void
 ContinuityAdvElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity /*element*/,
   ScratchViews& scratchViews)
 {
@@ -128,9 +128,6 @@ ContinuityAdvElemSuppAlg<AlgTraits>::element_execute(
   for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
     const int il = lrscv_[2*ip];
     const int ir = lrscv_[2*ip+1];
-
-    const int rowL = il * AlgTraits::nodesPerElement_;
-    const int rowR = ir * AlgTraits::nodesPerElement_;
 
     double rhoIp = 0.0;
     for (int j = 0; j < AlgTraits::nDim_; ++j) {
@@ -156,8 +153,8 @@ ContinuityAdvElemSuppAlg<AlgTraits>::element_execute(
         lhsfac += -v_dndx_lhs(ip, ic, j) * v_scs_areav(ip, j);
       }
 
-      lhs[rowL+ic] += lhsfac;
-      lhs[rowR+ic] -= lhsfac;
+      lhs(il,ic) += lhsfac;
+      lhs(ir,ic) -= lhsfac;
     }
 
     // assemble mdot
@@ -168,8 +165,8 @@ ContinuityAdvElemSuppAlg<AlgTraits>::element_execute(
     }
 
     // residuals
-    rhs[il] -= mdot / projTimeScale_;
-    rhs[ir] += mdot / projTimeScale_;
+    rhs(il) -= mdot / projTimeScale_;
+    rhs(ir) += mdot / projTimeScale_;
   }
 }
 

--- a/src/ContinuityMassElemSuppAlg.C
+++ b/src/ContinuityMassElemSuppAlg.C
@@ -95,8 +95,8 @@ ContinuityMassElemSuppAlg<AlgTraits>::setup()
 template<typename AlgTraits>
 void
 ContinuityMassElemSuppAlg<AlgTraits>::element_execute(
-  double */*lhs*/,
-  double *rhs,
+  SharedMemView<double **>&/*lhs*/,
+  SharedMemView<double *>&rhs,
   stk::mesh::Entity /* element */,
   ScratchViews& scratchViews)
 {
@@ -126,7 +126,7 @@ ContinuityMassElemSuppAlg<AlgTraits>::element_execute(
     }
 
     const double scV = v_scv_volume(ip);
-    rhs[nearestNode] += - ( gamma1_ * rhoNp1 + gamma2_ * rhoN +
+    rhs(nearestNode) += - ( gamma1_ * rhoNp1 + gamma2_ * rhoN +
                             gamma3_ * rhoNm1 ) * scV / dt_ / projTimeScale;
 
     // manage LHS : N/A

--- a/src/MomentumAdvDiffElemSuppAlg.C
+++ b/src/MomentumAdvDiffElemSuppAlg.C
@@ -79,8 +79,8 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::MomentumAdvDiffElemSuppAlg(
 template<class AlgTraits>
 void
 MomentumAdvDiffElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -138,8 +138,8 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::element_execute(
       const int indexR = irNdim + i;
 
       // right hand side; L and R
-      rhs[indexL] -= aflux + divUstress;
-      rhs[indexR] += aflux + divUstress;
+      rhs(indexL) -= aflux + divUstress;
+      rhs(indexR) += aflux + divUstress;
     }
 
     for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
@@ -157,16 +157,10 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::element_execute(
         const int indexL = ilNdim + i;
         const int indexR = irNdim + i;
 
-        const int rowL = indexL*AlgTraits::nodesPerElement_*AlgTraits::nDim_;
-        const int rowR = indexR*AlgTraits::nodesPerElement_*AlgTraits::nDim_;
-
-        const int rLiC_i = rowL+icNdim+i;
-        const int rRiC_i = rowR+icNdim+i;
-
         // advection operator lhs; rhs handled above
         // lhs; il then ir
-        lhs[rLiC_i] += lhsfacAdv;
-        lhs[rRiC_i] -= lhsfacAdv;
+        lhs(indexL,icNdim+i) += lhsfacAdv;
+        lhs(indexR,icNdim+i) -= lhsfacAdv;
 
         // viscous stress
         double lhs_riC_i = 0.0;
@@ -183,19 +177,19 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::element_execute(
           // -mu*duj/dxi*A_j
           const double lhsfacDiff_j = -muIp*v_dndx(ip,ic,i)*axj;
           // lhs; il then ir
-          lhs[rowL+icNdim+j] += lhsfacDiff_j;
-          lhs[rowR+icNdim+j] -= lhsfacDiff_j;
+          lhs(indexL,icNdim+j) += lhsfacDiff_j;
+          lhs(indexR,icNdim+j) -= lhsfacDiff_j;
           // rhs; il then ir
-          rhs[indexL] -= lhsfacDiff_j*uj;
-          rhs[indexR] += lhsfacDiff_j*uj;
+          rhs(indexL) -= lhsfacDiff_j*uj;
+          rhs(indexR) += lhsfacDiff_j*uj;
         }
 
         // deal with accumulated lhs and flux for -mu*dui/dxj*Aj
-        lhs[rLiC_i] += lhs_riC_i;
-        lhs[rRiC_i] -= lhs_riC_i;
+        lhs(indexL,icNdim+i) += lhs_riC_i;
+        lhs(indexR,icNdim+i) -= lhs_riC_i;
         const double ui = v_uNp1(ic,i);
-        rhs[indexL] -= lhs_riC_i*ui;
-        rhs[indexR] += lhs_riC_i*ui;
+        rhs(indexL) -= lhs_riC_i*ui;
+        rhs(indexR) += lhs_riC_i*ui;
       }
     }
   }

--- a/src/MomentumBuoyancySrcElemSuppAlg.C
+++ b/src/MomentumBuoyancySrcElemSuppAlg.C
@@ -76,8 +76,8 @@ MomentumBuoyancySrcElemSuppAlg<AlgTraits>::MomentumBuoyancySrcElemSuppAlg(
 template<typename AlgTraits>
 void
 MomentumBuoyancySrcElemSuppAlg<AlgTraits>::element_execute(
-  double* /* lhs */,
-  double* rhs,
+  SharedMemView<double **>& /* lhs */,
+  SharedMemView<double*>& rhs,
   stk::mesh::Entity /*element*/,
   ScratchViews& scratchViews)
 {
@@ -98,7 +98,7 @@ MomentumBuoyancySrcElemSuppAlg<AlgTraits>::element_execute(
     const int nnNdim = nearestNode * AlgTraits::nDim_;
     const double fac = (rhoNp1 - rhoRef_) * scV;
     for (int j=0; j < AlgTraits::nDim_; j++) {
-      rhs[nnNdim + j] += fac * gravity_(j);
+      rhs(nnNdim + j) += fac * gravity_(j);
     }
 
     // No LHS contributions

--- a/src/MomentumMassElemSuppAlg.C
+++ b/src/MomentumMassElemSuppAlg.C
@@ -109,8 +109,8 @@ MomentumMassElemSuppAlg<AlgTraits>::setup()
 template<typename AlgTraits>
 void
 MomentumMassElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity /* element */,
   ScratchViews& scratchViews
 )
@@ -156,7 +156,7 @@ MomentumMassElemSuppAlg<AlgTraits>::element_execute(
     const int nnNdim = nearestNode * AlgTraits::nDim_;
     // Compute RHS
     for (int j=0; j < AlgTraits::nDim_; ++j) {
-      rhs[nnNdim + j] +=
+      rhs(nnNdim + j) +=
         - ( gamma1_ * rhoNp1 * v_uNp1_(j) +
             gamma2_ * rhoN   * v_uN_(j) +
             gamma3_ * rhoNm1 * v_uNm1_(j)) * scV / dt_
@@ -164,7 +164,6 @@ MomentumMassElemSuppAlg<AlgTraits>::element_execute(
     }
 
     // Compute LHS
-    const int npeNdim = AlgTraits::nodesPerElement_ * AlgTraits::nDim_;
     for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
       const int icNdim = ic * AlgTraits::nDim_;
       const double r = v_shape_function_(ip, ic);
@@ -172,9 +171,7 @@ MomentumMassElemSuppAlg<AlgTraits>::element_execute(
 
       for (int j=0; j<AlgTraits::nDim_; ++j) {
         const int indexNN = nnNdim + j;
-        const int rowNN = indexNN * npeNdim;
-        const int rNNiC_j = rowNN + icNdim + j;
-        lhs[rNNiC_j] += lhsfac;
+        lhs(indexNN,icNdim+j) += lhsfac;
       }
     }
   }

--- a/src/ScalarAdvDiffElemSuppAlg.C
+++ b/src/ScalarAdvDiffElemSuppAlg.C
@@ -77,8 +77,8 @@ ScalarAdvDiffElemSuppAlg<AlgTraits>::ScalarAdvDiffElemSuppAlg(
 template<class AlgTraits>
 void
 ScalarAdvDiffElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -98,10 +98,6 @@ ScalarAdvDiffElemSuppAlg<AlgTraits>::element_execute(
     const int il = lrscv_[2*ip];
     const int ir = lrscv_[2*ip+1];
     
-    // corresponding matrix rows
-    const int rowL = il*AlgTraits::nodesPerElement_;
-    const int rowR = ir*AlgTraits::nodesPerElement_;
-
     // save off mdot
     const double tmdot = mdot[ip];
 
@@ -130,13 +126,13 @@ ScalarAdvDiffElemSuppAlg<AlgTraits>::element_execute(
       qDiff += lhsfacDiff*v_scalarQ(ic);
       
       // lhs; il then ir
-      lhs[rowL+ic] += lhsfacAdv + lhsfacDiff;
-      lhs[rowR+ic] -= lhsfacAdv + lhsfacDiff;
+      lhs(il,ic) += lhsfacAdv + lhsfacDiff;
+      lhs(ir,ic) -= lhsfacAdv + lhsfacDiff;
     }
     
     // rhs; il then ir
-    rhs[il] -= qAdv + qDiff;
-    rhs[ir] += qAdv + qDiff;
+    rhs(il) -= qAdv + qDiff;
+    rhs(ir) += qAdv + qDiff;
   }
 }
 

--- a/src/ScalarDiffElemSuppAlg.C
+++ b/src/ScalarDiffElemSuppAlg.C
@@ -75,8 +75,8 @@ ScalarDiffElemSuppAlg<AlgTraits>::ScalarDiffElemSuppAlg(
 template<class AlgTraits>
 void
 ScalarDiffElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double*>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -93,10 +93,6 @@ ScalarDiffElemSuppAlg<AlgTraits>::element_execute(
     const int il = lrscv_[2*ip];
     const int ir = lrscv_[2*ip+1];
     
-    // corresponding matrix rows
-    const int rowL = il*AlgTraits::nodesPerElement_;
-    const int rowR = ir*AlgTraits::nodesPerElement_;
-
     // compute ip property
     double diffFluxCoeffIp = 0.0;
     for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
@@ -114,8 +110,8 @@ ScalarDiffElemSuppAlg<AlgTraits>::element_execute(
       qDiff += lhsfacDiff*v_scalarQ(ic);
       
       // lhs; il then ir
-      lhs[rowL+ic] += lhsfacDiff;
-      lhs[rowR+ic] -= lhsfacDiff;
+      lhs(il,ic) += lhsfacDiff;
+      lhs(ir,ic) -= lhsfacDiff;
     }
     
     // rhs; il then ir

--- a/src/ScalarDiffFemSuppAlg.C
+++ b/src/ScalarDiffFemSuppAlg.C
@@ -81,8 +81,8 @@ ScalarDiffFemSuppAlg<AlgTraits>::~ScalarDiffFemSuppAlg()
 template<class AlgTraits>
 void
 ScalarDiffFemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews &/*scratchViews*/)
 {  
@@ -145,9 +145,9 @@ ScalarDiffFemSuppAlg<AlgTraits>::element_execute(
           lhsSum += fac;
           rhsSum += fac*T;
         }
-        lhs[ir*AlgTraits::nodesPerElement_+ic] += lhsSum*ipFactor;
+        lhs(ir,ic) += lhsSum*ipFactor;
       }
-      rhs[ir] -= rhsSum*ipFactor;
+      rhs(ir) -= rhsSum*ipFactor;
     }
   }
 }

--- a/src/ScalarMassElemSuppAlg.C
+++ b/src/ScalarMassElemSuppAlg.C
@@ -105,8 +105,8 @@ ScalarMassElemSuppAlg<AlgTraits>::setup()
 template<typename AlgTraits>
 void
 ScalarMassElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity /* element */,
   ScratchViews& scratchViews)
 {
@@ -155,7 +155,7 @@ ScalarMassElemSuppAlg<AlgTraits>::element_execute(
 
     // assemble rhs
     const double scV = v_scv_volume(ip);
-    rhs[nearestNode] += 
+    rhs(nearestNode) += 
       -(gamma1_*rhoNp1Scv*qNp1Scv + gamma2_*rhoNScv*qNScv + gamma3_*rhoNm1Scv*qNm1Scv)*scV/dt_;
     
     // manage LHS
@@ -163,8 +163,7 @@ ScalarMassElemSuppAlg<AlgTraits>::element_execute(
       // save off shape function
       const double r = v_shape_function_(ip,ic);
       const double lhsfac = r*gamma1_*rhoNp1Scv*scV/dt_;
-      const int rNNiC = nearestNode*AlgTraits::nodesPerElement_+ic;
-      lhs[rNNiC] += lhsfac;
+      lhs(nearestNode,ic) += lhsfac;
     }   
   }
 }

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -54,5 +54,17 @@ SolverAlgorithm::apply_coeff(
   eqSystem_->linsys_->sumInto(sym_meshobj, scratchIds, scratchVals, rhs, lhs, trace_tag);
 }
 
+void
+SolverAlgorithm::apply_coeff(
+  unsigned numMeshobjs,
+  const stk::mesh::Entity* symMeshobjs,
+  const SharedMemView<int*> & scratchIds,
+  const SharedMemView<const double*> & rhs,
+  const SharedMemView<const double**> & lhs,
+  const char *trace_tag)
+{
+  eqSystem_->linsys_->sumInto(numMeshobjs, symMeshobjs, rhs, lhs, scratchIds, trace_tag);
+}
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/nso/MomentumNSOKeElemSuppAlg.C
+++ b/src/nso/MomentumNSOKeElemSuppAlg.C
@@ -102,8 +102,8 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::MomentumNSOKeElemSuppAlg(
 template<class AlgTraits>
 void
 MomentumNSOKeElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -206,9 +206,6 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::element_execute(
       const int indexL = ilNdim + k;
       const int indexR = irNdim + k;
       
-      const int rowL = indexL*AlgTraits::nodesPerElement_*AlgTraits::nDim_;
-      const int rowR = indexR*AlgTraits::nodesPerElement_*AlgTraits::nDim_;
-      
       double gijFac = 0.0;
       for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
 
@@ -217,8 +214,6 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::element_execute(
 
         // find the row
         const int icNdim = ic*AlgTraits::nDim_;
-        const int rLkC_k = rowL+icNdim+k;
-        const int rRkC_k = rowR+icNdim+k;
 
         // save of some variables
         const double ukNp1 = v_uNp1(ic,k);
@@ -237,8 +232,8 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::element_execute(
         }
         
         // no coupling between components
-        lhs[rLkC_k] += nu*lhsfac;
-        lhs[rRkC_k] -= nu*lhsfac;
+        lhs(indexL,icNdim+k) += nu*lhsfac;
+        lhs(indexR,icNdim+k) -= nu*lhsfac;
       }
       
       // residual; left and right

--- a/src/nso/ScalarNSOElemSuppAlg.C
+++ b/src/nso/ScalarNSOElemSuppAlg.C
@@ -133,8 +133,8 @@ ScalarNSOElemSuppAlg<AlgTraits>::setup()
 template<class AlgTraits>
 void
 ScalarNSOElemSuppAlg<AlgTraits>::element_execute(
-  double *lhs,
-  double *rhs,
+  SharedMemView<double **>& lhs,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -159,10 +159,6 @@ ScalarNSOElemSuppAlg<AlgTraits>::element_execute(
     const int il = lrscv_[2*ip];
     const int ir = lrscv_[2*ip+1];
 
-    // corresponding matrix rows
-    const int rowL = il*AlgTraits::nodesPerElement_;
-    const int rowR = ir*AlgTraits::nodesPerElement_;
-   
     // zero out; scalar
     double qNm1Scs = 0.0;
     double qNScs = 0.0;
@@ -269,14 +265,14 @@ ScalarNSOElemSuppAlg<AlgTraits>::element_execute(
         }
       }
       
-      lhs[rowL+ic] += nu*lhsfac;
-      lhs[rowR+ic] -= nu*lhsfac;
+      lhs(il,ic) += nu*lhsfac;
+      lhs(ir,ic) -= nu*lhsfac;
     }
     
     // residual; left and right
     const double residualNSO = -nu*gijFac;
-    rhs[il] -= residualNSO;
-    rhs[ir] += residualNSO;
+    rhs(il) -= residualNSO;
+    rhs(ir) += residualNSO;
   }      
 }
 

--- a/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
@@ -71,8 +71,8 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSu
 template<class AlgTraits>
 void
 SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::element_execute(
-  double */*lhs*/,
-  double *rhs,
+  SharedMemView<double **>& /*lhs*/,
+  SharedMemView<double *>& rhs,
   stk::mesh::Entity element,
   ScratchViews& scratchViews)
 {
@@ -97,7 +97,7 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::element_execute(
     const double x = v_scvCoords_(0);
     const double y = v_scvCoords_(1);
     const double z = v_scvCoords_(2);
-    rhs[nearestNode] += k_/4.0*(2.0*a_*pi_)*(2.0*a_*pi_)*(cos(2.0*a_*pi_*x) 
+    rhs(nearestNode) += k_/4.0*(2.0*a_*pi_)*(2.0*a_*pi_)*(cos(2.0*a_*pi_*x) 
                                                           + cos(2.0*a_*pi_*y) 
                                                           + cos(2.0*a_*pi_*z))*v_scv_volume(ip);
   }


### PR DESCRIPTION
lhs is a 2D view and rhs is a 1D view.

Converted all supplemental-algs that use ScratchViews.

Required adding an overload of sumInto in TpetraLinearSystem.