### PR TITLE
Implementation of the Moeng surface shear stress boundary condition for

### DIFF
--- a/include/AssembleMomentumMoengWallFunctionSolverAlgorithm.h
+++ b/include/AssembleMomentumMoengWallFunctionSolverAlgorithm.h
@@ -1,0 +1,72 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef AssembleMomentumMoengWallFunctionSolverAlgorithm_h
+#define AssembleMomentumMoengWallFunctionSolverAlgorithm_h
+
+#include<SolverAlgorithm.h>
+#include<FieldTypeDef.h>
+#include<ABLProfileFunction.h>
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+}
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class AssembleMomentumMoengWallFunctionSolverAlgorithm : public SolverAlgorithm
+{
+public:
+
+  AssembleMomentumMoengWallFunctionSolverAlgorithm(
+    Realm &realm,
+    stk::mesh::Part *part,
+    EquationSystem *eqSystem,
+    const bool &useShifted,
+    const double &gravity,
+    const double &z0,
+    const double &Tref);
+  virtual ~AssembleMomentumMoengWallFunctionSolverAlgorithm() {}
+  virtual void initialize_connectivity();
+  virtual void execute();
+  void compute_utau(
+    const double &up, const double &zp, 
+    const double &qsurf, const ABLProfileFunction *ABLProfFun, 
+    double &utau );
+
+  const bool useShifted_;
+  const double z0_;
+  const double Tref_;
+  const double gravity_;
+  const double alpha_h_;
+  const double beta_m_;
+  const double beta_h_;
+  const double gamma_m_;
+  const double gamma_h_;
+  const double kappa_;
+
+  VectorFieldType *velocity_;
+  VectorFieldType *bcVelocity_;
+  VectorFieldType *coordinates_;
+  ScalarFieldType *bcHeatFlux_;
+  ScalarFieldType *density_;
+  ScalarFieldType *specificHeat_;
+  GenericFieldType *exposedAreaVec_;
+  GenericFieldType *wallNormalDistanceBip_;
+  GenericFieldType *tauWallBip_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -199,6 +199,7 @@ struct WallUserData : public UserData {
 
   bool wallFunctionApproach_;
   bool ablWallFunctionApproach_;
+  bool ablMoengWallFunctionApproach_;
 
   bool isFsiInterface_;
 
@@ -214,6 +215,7 @@ struct WallUserData : public UserData {
       irradSpec_(false),
       wallFunctionApproach_(false),
       ablWallFunctionApproach_(false),
+      ablMoengWallFunctionApproach_(false),
       isFsiInterface_(false) {}    
 };
 

--- a/include/SurfaceForceAndMomentMoengWallFunctionAlgorithm.h
+++ b/include/SurfaceForceAndMomentMoengWallFunctionAlgorithm.h
@@ -1,0 +1,66 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef SurfaceForceAndMomentMoengWallFunctionAlgorithm_h
+#define SurfaceForceAndMomentMoengWallFunctionAlgorithm_h
+
+#include<Algorithm.h>
+#include<FieldTypeDef.h>
+
+// stk
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class SurfaceForceAndMomentMoengWallFunctionAlgorithm : public Algorithm
+{
+public:
+
+  SurfaceForceAndMomentMoengWallFunctionAlgorithm(
+    Realm &realm,
+    stk::mesh::PartVector &partVec,
+    const std::string &outputFileName,
+    const int &frequency_,
+    const std::vector<double > &parameters,
+    const bool &useShifted);
+  ~SurfaceForceAndMomentMoengWallFunctionAlgorithm();
+
+  void execute();
+
+  void pre_work();
+
+  void cross_product(
+    double *force, double *cross, double *rad);
+
+  const std::string &outputFileName_;
+  const int &frequency_;
+  const std::vector<double > &parameters_;
+  const bool useShifted_;
+
+  VectorFieldType *coordinates_;
+  ScalarFieldType *pressure_;
+  VectorFieldType *pressureForce_;
+  ScalarFieldType *tauWall_;
+  ScalarFieldType *yplus_;
+  ScalarFieldType *density_;
+  ScalarFieldType *viscosity_;
+  GenericFieldType *tauWallBip_;
+  GenericFieldType *wallNormalDistanceBip_;
+  GenericFieldType *exposedAreaVec_;
+  ScalarFieldType *assembledArea_;
+
+  const int w_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/user_functions/BoundaryLayerPerturbationAuxFunction.h
+++ b/include/user_functions/BoundaryLayerPerturbationAuxFunction.h
@@ -42,6 +42,7 @@ private:
   double ky_;
   double thickness_;
   double uInf_;
+  double vInf_;
 
 };
 

--- a/src/AssembleMomentumABLWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumABLWallFunctionSolverAlgorithm.C
@@ -275,7 +275,7 @@ AssembleMomentumABLWallFunctionSolverAlgorithm::execute()
         const double eps_heat_flux = 1.0e-8;
         const double largenum = 1.0e8;
         double Lfac;
-        if (TfluxBip < eps_heat_flux) {
+        if (TfluxBip < -eps_heat_flux) {
           p_ABLProfFun = &StableProfFun;
         }
         else if (TfluxBip > eps_heat_flux) {

--- a/src/AssembleMomentumMoengWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumMoengWallFunctionSolverAlgorithm.C
@@ -1,0 +1,695 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+// nalu
+#include <AssembleMomentumMoengWallFunctionSolverAlgorithm.h>
+#include <SolverAlgorithm.h>
+#include <EquationSystem.h>
+#include <LinearSystem.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+#include <ABLProfileFunction.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// basic c++
+#include <cmath>
+
+// stk_util
+#include <stk_util/parallel/ParallelReduce.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleMomentumMoengWallFunctionSolverAlgorithm - ABL utau at wall bc
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleMomentumMoengWallFunctionSolverAlgorithm::AssembleMomentumMoengWallFunctionSolverAlgorithm(
+  Realm &realm,
+  stk::mesh::Part *part,
+  EquationSystem *eqSystem,
+  const bool &useShifted,
+  const double &gravity,
+  const double &z0,
+  const double &Tref)
+  : SolverAlgorithm(realm, part, eqSystem),
+    useShifted_(useShifted),
+    z0_(z0), 
+    Tref_(Tref), 
+    gravity_(gravity), 
+    alpha_h_(1.0), 
+    beta_m_(16.0), 
+    beta_h_(16.0),
+    gamma_m_(5.0),
+    gamma_h_(5.0),
+    kappa_(realm.get_turb_model_constant(TM_kappa))
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  bcHeatFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc");
+  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
+  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+  tauWallBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "tau_wall_bip");
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize_connectivity -----------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumMoengWallFunctionSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildFaceToNodeGraph(partVec_);
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumMoengWallFunctionSolverAlgorithm::execute()
+{
+
+  ABLProfileFunction *p_ABLProfFun;
+  StableABLProfileFunction StableProfFun(gamma_m_, gamma_h_);
+  UnstableABLProfileFunction UnstableProfFun(beta_m_, beta_h_);
+  NeutralABLProfileFunction NeutralProfFun;
+
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // space for LHS/RHS; nodesPerFace*nDim*nodesPerFace*nDim and nodesPerFace*nDim
+  std::vector<double> lhs;
+  std::vector<double> rhs;
+  std::vector<int> scratchIds;
+  std::vector<double> scratchVals;
+  std::vector<stk::mesh::Entity> connected_nodes;
+
+  // bip values
+  std::vector<double> uBip(nDim);
+  std::vector<double> uBcBip(nDim);
+  std::vector<double> unitNormal(nDim);
+
+  // pointers to fixed values
+  double *p_uBip = &uBip[0];
+  double *p_uBcBip = &uBcBip[0];
+  double *p_unitNormal= &unitNormal[0];
+
+  // nodal fields to gather
+  std::vector<double> ws_velocityNp1;
+  std::vector<double> ws_bcVelocity;
+  std::vector<double> ws_bcHeatFlux;
+  std::vector<double> ws_density;
+  std::vector<double> ws_specificHeat;
+
+
+  // master element
+  std::vector<double> ws_shape_function;
+  std::vector<double> ws_face_shape_function;
+
+  // deal with state
+  VectorFieldType &velocityNp1 = velocity_->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
+
+  // declare and initialize surface-averaged quantities
+  std::vector<double> utan_sa;
+  std::vector<double> tau_sa;
+  utan_sa.resize(nDim);
+  tau_sa.resize(nDim);
+  for (int i=0; i<nDim; ++i) {
+    utan_sa[i] = 0.0;
+    tau_sa[i] = 0.0;
+  }
+  double utau_sa = 0.0;
+  double V_sa = 0.0;
+  double aTot = 0.0;
+  double zp_sa = 0.0;
+  double rho_sa = 0.0;
+  double Cp_sa = 0.0;
+  double heatFlux_sa = 0.0;
+
+  // define vector of parent topos; should always be UNITY in size
+  std::vector<stk::topology> parentTopo;
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // extract connected element topology
+    b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
+    ThrowAssert ( parentTopo.size() == 1 );
+    stk::topology theElemTopo = parentTopo[0];
+
+    // extract master element
+    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+
+    // face master element
+    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    // resize some things; matrix related
+    const int lhsSize = nodesPerFace*nDim*nodesPerFace*nDim;
+    const int rhsSize = nodesPerFace*nDim;
+    lhs.resize(lhsSize);
+    rhs.resize(rhsSize);
+    scratchIds.resize(rhsSize);
+    scratchVals.resize(rhsSize);
+    connected_nodes.resize(nodesPerFace);
+
+    // algorithm related; element
+    ws_velocityNp1.resize(nodesPerFace*nDim);
+    ws_bcVelocity.resize(nodesPerFace*nDim);
+    ws_bcHeatFlux.resize(nodesPerFace);
+    ws_density.resize(nodesPerFace);
+    ws_specificHeat.resize(nodesPerFace);
+
+    ws_face_shape_function.resize(numScsBip*nodesPerFace);
+
+    // pointers
+    double *p_velocityNp1 = &ws_velocityNp1[0];
+    double *p_bcVelocity = &ws_bcVelocity[0];
+    double *p_bcHeatFlux = &ws_bcHeatFlux[0];
+    double *p_density = &ws_density[0];
+    double *p_specificHeat = &ws_specificHeat[0];
+    double *p_face_shape_function = &ws_face_shape_function[0];
+
+    // shape functions
+    if ( useShifted_ )
+      meFC->shifted_shape_fcn(&p_face_shape_function[0]);
+    else
+      meFC->shape_fcn(&p_face_shape_function[0]);
+
+    // Loop to calculate surface-averaged velocities
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      for ( int ni = 0; ni < nodesPerFace; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+        connected_nodes[ni] = node;
+
+        // gather scalars
+        p_bcHeatFlux[ni] = *stk::mesh::field_data(*bcHeatFlux_, node);
+        p_density[ni]    = *stk::mesh::field_data(densityNp1, node);
+        p_specificHeat[ni] = *stk::mesh::field_data(*specificHeat_, node);
+
+        // gather velocity vectors
+        double * uNp1 = stk::mesh::field_data(velocityNp1, node);
+        double * uBc = stk::mesh::field_data(*bcVelocity_, node);
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_velocityNp1[offSet+j] = uNp1[j];
+          p_bcVelocity[offSet+j] = uBc[j];
+        }
+      }
+
+      // extract the connected element to this exposed face; should be single in size!
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
+      ThrowAssert( bulk_data.num_elements(face) == 1 );
+
+      // get element; its face ordinal number
+      stk::mesh::Entity element = face_elem_rels[0];
+      const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
+
+      // pointer to face data
+      const double *areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      double *wallNormalDistanceBip = stk::mesh::field_data(*wallNormalDistanceBip_, face);
+
+      // get the relations off of element
+      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+
+      // loop over face nodes
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        const int offSetAveraVec = ip*nDim;
+        const int offSetSF_face = ip*nodesPerFace;
+
+        const int opposingNode = meSCS->opposingNodes(face_ordinal,ip);
+        const int localFaceNode = faceIpNodeMap[ip];
+
+        // left and right nodes; right is on the face; left is the opposing node
+        stk::mesh::Entity nodeL = elem_node_rels[opposingNode];
+        stk::mesh::Entity nodeR = face_node_rels[localFaceNode];
+
+        // extract nodal fields
+        const double * coordL = stk::mesh::field_data(*coordinates_, nodeL );
+        const double * coordR = stk::mesh::field_data(*coordinates_, nodeR );
+
+        // zero out vector quantities; squeeze in aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          p_uBip[j] = 0.0;
+          p_uBcBip[j] = 0.0;
+          const double axj = areaVec[offSetAveraVec+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // interpolate to bip
+        double heatFluxBip = 0.0;
+        double rhoBip = 0.0;
+        double CpBip = 0.0;
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const double r = p_face_shape_function[offSetSF_face+ic];
+          rhoBip += r*p_density[ic];
+          CpBip += r*p_specificHeat[ic];
+          heatFluxBip += r*p_bcHeatFlux[ic];
+          const int offSetFN = ic*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            p_uBip[j] += r*p_velocityNp1[offSetFN+j];
+            p_uBcBip[j] += r*p_bcVelocity[offSetFN+j];
+          }
+        }
+
+        rho_sa += rhoBip*aMag;
+        heatFlux_sa += heatFlux_sa*aMag;
+        Cp_sa += CpBip*aMag;
+
+        // form unit normal
+        for ( int j = 0; j < nDim; ++j ) {
+          p_unitNormal[j] = areaVec[offSetAveraVec+j]/aMag;
+        }
+
+        // form unit normal and determine yp (approximated by 1/4 distance along edge)
+        double ypBip = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          const double nj = areaVec[offSetAveraVec+j]/aMag;
+          const double ej = 0.25*(coordR[j] - coordL[j]);
+          ypBip += nj*ej*nj*ej;
+          p_unitNormal[j] = nj;
+        }
+        ypBip = std::sqrt(ypBip);
+        wallNormalDistanceBip[ip] = ypBip;
+
+       // determine tangential velocity
+        double uTangential = 0.0;
+        for ( int i = 0; i < nDim; ++i ) {
+          double uiTan = 0.0;
+          double uiBcTan = 0.0;
+          for ( int j = 0; j < nDim; ++j ) {
+            const double ninj = p_unitNormal[i]*p_unitNormal[j];
+            if ( i==j ) {
+              const double om_nini = 1.0 - ninj;
+              uiTan += om_nini*p_uBip[j];
+              uiBcTan += om_nini*p_uBcBip[j];
+            }
+            else {
+              uiTan -= ninj*p_uBip[j];
+              uiBcTan -= ninj*p_uBcBip[j];
+            }
+          }
+          uTangential += (uiTan-uiBcTan)*(uiTan-uiBcTan);
+          utan_sa[i] += uiTan*aMag; // sum into surface-averaged tangential velocity
+        }
+        uTangential = std::sqrt(uTangential);
+        V_sa += uTangential*aMag;
+        aTot += aMag;
+        zp_sa += wallNormalDistanceBip[ip]*aMag;
+
+      } //loop over face integration points
+    } // loop over faces
+  } // loop over buckets 
+
+  // parallel assemble surface-averaged quantities
+  double g_utan_sa[nDim];
+  for ( int i = 0; i < nDim; ++i ) {
+    g_utan_sa[i] = 0.0;
+  }
+  double g_V_sa = 0.0;
+  double g_aTot = 0.0;
+  double g_zp_sa = 0.0;
+  double g_rho_sa = 0.0;
+  double g_heatFlux_sa = 0.0;
+  double g_Cp_sa = 0.0;
+  stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
+  stk::all_reduce_sum(comm, &utan_sa[0], &g_utan_sa[0], nDim);
+  stk::all_reduce_sum(comm, &V_sa, &g_V_sa, 1);
+  stk::all_reduce_sum(comm, &aTot, &g_aTot, 1);
+  stk::all_reduce_sum(comm, &zp_sa, &g_zp_sa, 1);
+  stk::all_reduce_sum(comm, &rho_sa, &g_rho_sa, 1);
+  stk::all_reduce_sum(comm, &heatFlux_sa, &g_heatFlux_sa, 1);
+  stk::all_reduce_sum(comm, &Cp_sa, &g_Cp_sa, 1);
+  for ( int i=0; i < nDim; ++i ) {
+    g_utan_sa[i] /= g_aTot;
+  }
+  g_V_sa /= g_aTot;
+  g_zp_sa /= g_aTot;
+  g_rho_sa /= g_aTot;
+  g_heatFlux_sa /= g_aTot;
+  g_Cp_sa /= g_aTot;
+
+  // determine surface-averaged shear stress from Monin-Obukhov expressions
+  const double Tflux = g_heatFlux_sa / (g_rho_sa * g_Cp_sa);
+
+  const double eps_heat_flux = 1.0e-8;
+  const double largenum = 1.0e8;
+  double Lfac;
+  if (Tflux < -eps_heat_flux) {
+    p_ABLProfFun = &StableProfFun;
+  }
+  else if (Tflux > eps_heat_flux) {
+    p_ABLProfFun = &UnstableProfFun;
+  }
+  else {
+    p_ABLProfFun = &NeutralProfFun;
+  }
+  if (std::abs(Tflux) < eps_heat_flux) {
+    Lfac = largenum;
+  }
+  else {
+    Lfac = -Tref_ / (kappa_ * gravity_ * Tflux);
+  }
+
+  compute_utau(g_V_sa, g_zp_sa, Tflux, p_ABLProfFun, utau_sa);
+  double L = utau_sa*utau_sa*utau_sa * Lfac;
+  double lambda = g_rho_sa*kappa_*utau_sa/(std::log(g_zp_sa/z0_) - p_ABLProfFun->velocity(g_zp_sa/L));
+  for (int i=0; i<nDim; ++i) {
+    tau_sa[i] = lambda*g_utan_sa[i];
+  }
+
+  // Loop to calculate boundary condition terms
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // face master element
+    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    // resize some things; matrix related
+    const int lhsSize = nodesPerFace*nDim*nodesPerFace*nDim;
+    const int rhsSize = nodesPerFace*nDim;
+    lhs.resize(lhsSize);
+    rhs.resize(rhsSize);
+    scratchIds.resize(rhsSize);
+    scratchVals.resize(rhsSize);
+    connected_nodes.resize(nodesPerFace);
+
+    // algorithm related; element
+    ws_velocityNp1.resize(nodesPerFace*nDim);
+
+    ws_face_shape_function.resize(numScsBip*nodesPerFace);
+
+    // pointers
+    double *p_lhs = &lhs[0];
+    double *p_rhs = &rhs[0];
+    double *p_velocityNp1 = &ws_velocityNp1[0];
+    double *p_face_shape_function = &ws_face_shape_function[0];
+
+    // shape functions
+    if ( useShifted_ )
+      meFC->shifted_shape_fcn(&p_face_shape_function[0]);
+    else
+      meFC->shape_fcn(&p_face_shape_function[0]);
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // zero lhs/rhs
+      for ( int p = 0; p < lhsSize; ++p )
+        p_lhs[p] = 0.0;
+      for ( int p = 0; p < rhsSize; ++p )
+        p_rhs[p] = 0.0;
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      for ( int ni = 0; ni < nodesPerFace; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+        connected_nodes[ni] = node;
+
+        // gather vectors
+        double * uNp1 = stk::mesh::field_data(velocityNp1, node);
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_velocityNp1[offSet+j] = uNp1[j];
+        }
+      }
+
+      // pointer to face data
+      const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      double *tauWallBip = stk::mesh::field_data(*tauWallBip_, face);
+
+      // loop over face nodes
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        const int offSetAveraVec = ip*nDim;
+        const int offSetSF_face = ip*nodesPerFace;
+
+        const int localFaceNode = faceIpNodeMap[ip];
+
+        // zero out vector quantities; squeeze in aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          p_uBip[j] = 0.0;
+          const double axj = areaVec[offSetAveraVec+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // interpolate to bip
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const double r = p_face_shape_function[offSetSF_face+ic];
+          const int offSetFN = ic*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            p_uBip[j] += r*p_velocityNp1[offSetFN+j];
+          }
+        }
+
+        // form unit normal
+        for ( int j = 0; j < nDim; ++j ) {
+          p_unitNormal[j] = areaVec[offSetAveraVec+j]/aMag;
+        }
+
+        // start the lhs assembly
+        double lambda_1[nDim];
+        double lambda_2[nDim];
+        double uiTan[nDim];
+        for ( int i = 0; i < nDim; ++i) {
+          double sgnu = (g_utan_sa[i] > 0.0)?1.0:-1.0;
+          lambda_1[i] = tau_sa[i] / std::max(g_V_sa,1.0e-10) * aMag;
+          lambda_2[i] = tau_sa[i] / (sgnu*std::max(std::abs(g_utan_sa[i]),1.0e-10)) * aMag;
+          uiTan[i] = 0.0;
+        }
+        double uTangential = 0.0;
+        for ( int i = 0; i < nDim; ++i ) {
+          for ( int j = 0; j < nDim; ++j ) {
+            const double ninj = p_unitNormal[i]*p_unitNormal[j];
+            if ( i==j ) {
+              const double om_nini = 1.0 - ninj;
+              uiTan[i] += om_nini*p_uBip[j];
+            }
+            else {
+              uiTan[i] -= ninj*p_uBip[j];
+            }
+          }
+          uTangential += uiTan[i]*uiTan[i];
+        }   
+        uTangential = std::sqrt(uTangential);
+
+        for ( int i = 0; i < nDim; ++i ) {
+
+          int indexR = localFaceNode*nDim + i;
+          int rowR = indexR*nodesPerFace*nDim;
+
+          lambda_1[i] /= std::max(1.0e-10,uTangential);
+          for ( int j=0; j < nDim; ++j ) {
+            for ( int k=0; k < nDim; ++k ) {
+              const double njnk = p_unitNormal[j]*p_unitNormal[k];
+              if ( j==k ) {
+                const double om_njnk = 1.0 - njnk;
+                for (int ic = 0; ic < nodesPerFace; ++ic)
+                  p_lhs[rowR+ic*nDim+j] += lambda_1[i]*uiTan[k]*om_njnk*p_face_shape_function[offSetSF_face+ic];
+              }
+              else {
+                for (int ic = 0; ic < nodesPerFace; ++ic)
+                  p_lhs[rowR+ic*nDim+j] -= lambda_1[i]*uiTan[k]*njnk*p_face_shape_function[offSetSF_face+ic];
+              }
+            }
+          }
+
+          for ( int j = 0; j < nDim; ++j ) {
+            const double ninj = p_unitNormal[i]*p_unitNormal[j];
+            if ( i==j ) {
+              const double om_nini = 1.0 - ninj;
+              for (int ic = 0; ic < nodesPerFace; ++ic)
+                p_lhs[rowR+ic*nDim+i] += lambda_2[i]*om_nini*p_face_shape_function[offSetSF_face+ic];
+            }
+            else {
+              for (int ic = 0; ic < nodesPerFace; ++ic)
+                p_lhs[rowR+ic*nDim+j] -= lambda_2[i]*ninj*p_face_shape_function[offSetSF_face+ic];
+            }
+          }
+          double sgnu = (g_utan_sa[i] > 0.0)?1.0:-1.0;
+          double tau_s_i = tau_sa[i] * ( (uTangential*g_utan_sa[i] + g_V_sa*(uiTan[i]-g_utan_sa[i])) / (sgnu*std::max(1.0e-10, std::abs(g_V_sa*g_utan_sa[i]))) );
+          // Store tauWall for forces and moments algorithm to use
+          tauWallBip[ip*nDim+i] = tau_s_i;
+          p_rhs[indexR] -= tau_s_i*aMag;
+        }
+      }
+
+      apply_coeff(connected_nodes, scratchIds, scratchVals, rhs, lhs, __FILE__);
+
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_utau----------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumMoengWallFunctionSolverAlgorithm::compute_utau(
+    const double &up, const double &zp, const double &qsurf, const ABLProfileFunction *ABLProfFun, double &utau )
+{
+  bool converged = false;
+  const int maxIteration = 40;
+  const double tolerance = 1.0e-7;
+
+  double Lfac;
+  if (qsurf == 0.0) {
+    Lfac = 0.0;
+  }
+  else {
+    Lfac = -Tref_ / (kappa_ * gravity_ * qsurf);
+  }
+  const double log_z_over_z0 = std::log(zp / z0_);
+
+  // initial guesses for utau
+  const double eps_u = 1.0e-8;
+  const double perturb = 1.0e-3;
+ 
+  double utau0;
+  if (std::abs(up) < eps_u) {
+    utau0 = eps_u;
+    utau = eps_u;
+    return;
+  }
+  else {
+    utau0 = kappa_ * up / log_z_over_z0;
+  }
+  if (qsurf > 0.0) { // if unstable ABL
+    utau0 = 3*utau0; // push initial guess above the singularity in the function to be zero'd
+  }
+  double utau1 = (1.0+perturb) * utau0;
+
+  for ( int k = 0; k < maxIteration; ++k) {
+
+    // calculate Monin-Obukhov length
+    double L0 = utau0*utau0*utau0 * Lfac;
+    double L1 = utau1*utau1*utau1 * Lfac;
+
+    // limit the values of L...
+    //   to be negative and finite for qsurf>0 (unstable)
+    //   to be positive and finite for qsurf<0 (stable)
+    double sgnq = (qsurf > 0.0)?1.0:-1.0;
+    L0 = - sgnq * std::max(1.0e-10,std::abs(L0));
+    L1 = - sgnq * std::max(1.0e-10,std::abs(L1));
+
+    // calculate normalized coordinate
+    const double znorm0 = zp / L0;
+    const double znorm1 = zp / L1;
+
+    const double denom0 = log_z_over_z0 - ABLProfFun->velocity(znorm0);
+    const double denom1 = log_z_over_z0 - ABLProfFun->velocity(znorm1);
+
+    // form function to be zeroed
+    const double f0 = utau0 - up * kappa_ / denom0;
+    const double f1 = utau1 - up * kappa_ / denom1;
+
+    // estimate slope, d f/d utau
+    double dutau = utau1 - utau0;
+    if (dutau > 0.0) {
+      dutau  = std::max(1.0e-15, dutau);
+    }
+    else  {
+      dutau = std::min(-1.0e-15, dutau);
+    }
+    double fPrime = (f1 - f0) / dutau;
+    if (fPrime > 0.0) {
+      fPrime  = std::max(1.0e-15, fPrime);
+    }
+    else  {
+      fPrime = std::min(-1.0e-15, fPrime);
+    }
+
+    // update utau
+    const double utau_tmp = utau1;
+    utau1 = utau0 - f0 / fPrime;
+    //enforce non-negativity of utau
+    //utau1 = std::max(0.0, utau1);
+    utau0 = utau_tmp;
+
+    // check for convergence
+    if ( (std::abs(f1) < tolerance) ) {
+      converged = true;
+      //enforce non-negativity of utau
+      utau = std::max(0.0, utau1);
+      break;
+    }
+  }
+
+  // report trouble
+  if ( !converged ) {
+    NaluEnv::self().naluOutputP0() << "Issue with ABL utau: not converged " << std::endl;
+    NaluEnv::self().naluOutputP0() << up << " " << zp << " " << utau0 << " " << utau1 << std::endl;
+  }
+
+
+  // NOTE: SOWFA implementation contains another block to check if utau
+  // converged to a small value.  In this case, a different zero to
+  // the function is sought using a different algorithm.
+}
+
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -24,6 +24,7 @@
 #include <AssembleMomentumElemSymmetrySolverAlgorithm.h>
 #include <AssembleMomentumWallFunctionSolverAlgorithm.h>
 #include <AssembleMomentumABLWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumMoengWallFunctionSolverAlgorithm.h>
 #include <AssembleMomentumNonConformalSolverAlgorithm.h>
 #include <AssembleNodalGradAlgorithmDriver.h>
 #include <AssembleNodalGradEdgeAlgorithm.h>
@@ -83,6 +84,7 @@
 #include <SurfaceForceAndMomentAlgorithmDriver.h>
 #include <SurfaceForceAndMomentAlgorithm.h>
 #include <SurfaceForceAndMomentWallFunctionAlgorithm.h>
+#include <SurfaceForceAndMomentMoengWallFunctionAlgorithm.h>
 #include <Simulation.h>
 #include <SolutionOptions.h>
 #include <SolverAlgorithmDriver.h>
@@ -471,6 +473,17 @@ LowMachEquationSystem::register_surface_pp_algorithm(
       surfaceForceAndMomentAlgDriver_ = new SurfaceForceAndMomentAlgorithmDriver(realm_);
     SurfaceForceAndMomentWallFunctionAlgorithm *ppAlg
       = new SurfaceForceAndMomentWallFunctionAlgorithm(
+          realm_, partVector, theData.outputFileName_, theData.frequency_,
+          theData.parameters_, realm_.realmUsesEdges_);
+    surfaceForceAndMomentAlgDriver_->algVec_.push_back(ppAlg);
+  }
+  else if ( thePhysics == "surface_force_and_moment_moeng" ) {
+    ScalarFieldType *assembledArea =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf"));
+    stk::mesh::put_field(*assembledArea, stk::mesh::selectUnion(partVector));
+    if ( NULL == surfaceForceAndMomentAlgDriver_ )
+      surfaceForceAndMomentAlgDriver_ = new SurfaceForceAndMomentAlgorithmDriver(realm_);
+    SurfaceForceAndMomentMoengWallFunctionAlgorithm *ppAlg
+      = new SurfaceForceAndMomentMoengWallFunctionAlgorithm(
           realm_, partVector, theData.outputFileName_, theData.frequency_,
           theData.parameters_, realm_.realmUsesEdges_);
     surfaceForceAndMomentAlgDriver_->algVec_.push_back(ppAlg);
@@ -1538,6 +1551,7 @@ MomentumEquationSystem::register_wall_bc(
   WallUserData userData = wallBCData.userData_;
   const bool wallFunctionApproach = userData.wallFunctionApproach_;
   const bool ablWallFunctionApproach = userData.ablWallFunctionApproach_;
+  const bool ablMoengWallFunctionApproach = userData.ablMoengWallFunctionApproach_;
 
   const std::string bcFieldName = wallFunctionApproach ? "wall_velocity_bc" : "velocity_bc";
 
@@ -1647,7 +1661,7 @@ MomentumEquationSystem::register_wall_bc(
 
     if (ablWallFunctionApproach) {
 
-      // register boundary data: heat_flux_bc
+     // register boundary data: heat_flux_bc
       ScalarFieldType *theHeatFluxBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc"));
       stk::mesh::put_field(*theHeatFluxBcField, *part);
 
@@ -1678,31 +1692,51 @@ MomentumEquationSystem::register_wall_bc(
       const double z0 = rough.z0_;
       ReferenceTemperature Tref = userData.referenceTemperature_;
       const double referenceTemperature = Tref.referenceTemperature_;
-      std::map<AlgorithmType, Algorithm *>::iterator it_utau =
-        wallFunctionParamsAlgDriver_->algMap_.find(wfAlgType);
-      if ( it_utau == wallFunctionParamsAlgDriver_->algMap_.end() ) {
-        ComputeABLWallFrictionVelocityAlgorithm *theUtauAlg =
-          new ComputeABLWallFrictionVelocityAlgorithm(realm_, part, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
-        wallFunctionParamsAlgDriver_->algMap_[wfAlgType] = theUtauAlg;
-      }
-      else {
-        it_utau->second->partVec_.push_back(part);
-      }
 
-      // create lhs/rhs algorithm; generalized for edge (nearest node usage) and element
-      std::map<AlgorithmType, SolverAlgorithm *>::iterator it_wf =
-        solverAlgDriver_->solverAlgMap_.find(wfAlgType);
-      if ( it_wf == solverAlgDriver_->solverAlgMap_.end() ) {
-        AssembleMomentumABLWallFunctionSolverAlgorithm *theAlg
-          = new AssembleMomentumABLWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
-        solverAlgDriver_->solverAlgMap_[wfAlgType] = theAlg;
+      if (ablMoengWallFunctionApproach) {
+        // Create a field that stores wall shear stress at the boundary face ips
+        GenericFieldType *tauWallBip 
+           =  &(meta_data.declare_field<GenericFieldType>(sideRank, "tau_wall_bip"));
+        stk::mesh::put_field(*tauWallBip, *part, nDim*numScsBip);
+	// create lhs/rhs algorithm; generalized for edge (nearest node usage) and element
+	std::map<AlgorithmType, SolverAlgorithm *>::iterator it_wf =
+	  solverAlgDriver_->solverAlgMap_.find(wfAlgType);
+	if ( it_wf == solverAlgDriver_->solverAlgMap_.end() ) {
+	  AssembleMomentumMoengWallFunctionSolverAlgorithm *theAlg
+	    = new AssembleMomentumMoengWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
+	  solverAlgDriver_->solverAlgMap_[wfAlgType] = theAlg;
+	}
+	else {
+	  it_wf->second->partVec_.push_back(part);
+	}
       }
-      else {
-        it_wf->second->partVec_.push_back(part);
+      else { 
+	std::map<AlgorithmType, Algorithm *>::iterator it_utau =
+	  wallFunctionParamsAlgDriver_->algMap_.find(wfAlgType);
+	if ( it_utau == wallFunctionParamsAlgDriver_->algMap_.end() ) {
+	  ComputeABLWallFrictionVelocityAlgorithm *theUtauAlg =
+	    new ComputeABLWallFrictionVelocityAlgorithm(realm_, part, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
+	  wallFunctionParamsAlgDriver_->algMap_[wfAlgType] = theUtauAlg;
+	}
+	else {
+	  it_utau->second->partVec_.push_back(part);
+	}
+
+	// create lhs/rhs algorithm; generalized for edge (nearest node usage) and element
+	std::map<AlgorithmType, SolverAlgorithm *>::iterator it_wf =
+	  solverAlgDriver_->solverAlgMap_.find(wfAlgType);
+	if ( it_wf == solverAlgDriver_->solverAlgMap_.end() ) {
+	  AssembleMomentumABLWallFunctionSolverAlgorithm *theAlg
+	    = new AssembleMomentumABLWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
+	  solverAlgDriver_->solverAlgMap_[wfAlgType] = theAlg;
+	}
+	else {
+	  it_wf->second->partVec_.push_back(part);
+	}
       }
     }
-
-    else {
+      
+    else { // smooth aerodynamic wall - wall function approach
 
       const AlgorithmType wfAlgType = WALL;
 

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -654,6 +654,11 @@ namespace YAML {
 	wallData.wallFunctionApproach_ = node["use_abl_wall_function"].as<bool>() ;
 	wallData.ablWallFunctionApproach_ = node["use_abl_wall_function"].as<bool>() ;
       }
+      if ( node["use_moeng_wall_function"] ) {
+	wallData.wallFunctionApproach_ = node["use_moeng_wall_function"].as<bool>() ;
+	wallData.ablWallFunctionApproach_ = node["use_moeng_wall_function"].as<bool>() ;
+        wallData.ablMoengWallFunctionApproach_ = node["use_moeng_wall_function"].as<bool>() ;
+      }
       if ( node["pressure"] ) {
 	wallData.pressure_ = node["pressure"].as<sierra::nalu::Pressure>() ;
 	wallData.bcDataSpecifiedMap_["pressure"] = true;

--- a/src/SurfaceForceAndMomentMoengWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentMoengWallFunctionAlgorithm.C
@@ -1,0 +1,424 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+// nalu
+#include <SurfaceForceAndMomentMoengWallFunctionAlgorithm.h>
+#include <Algorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+#include <NaluEnv.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// stk_util
+#include <stk_util/parallel/ParallelReduce.hpp>
+
+// basic c++
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// SurfaceForceAndMomentMoengWallFunctionAlgorithm - post process sigma_ijnjdS and 
+//                                  tau_wall via lumped nodal projection (area 
+//                                  weighed) Driven by SurfaceForceAndMomentAlgDriver
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+SurfaceForceAndMomentMoengWallFunctionAlgorithm::SurfaceForceAndMomentMoengWallFunctionAlgorithm(
+  Realm &realm,
+  stk::mesh::PartVector &partVec,
+  const std::string &outputFileName,
+  const int &frequency,
+  const std::vector<double > &parameters,
+  const bool &useShifted)
+  : Algorithm(realm, partVec),
+    outputFileName_(outputFileName),
+    frequency_(frequency),
+    parameters_(parameters),
+    useShifted_(useShifted),
+    coordinates_(NULL),
+    pressure_(NULL),
+    pressureForce_(NULL),
+    tauWall_(NULL),
+    yplus_(NULL),
+    density_(NULL),
+    viscosity_(NULL),
+    tauWallBip_(NULL),
+    wallNormalDistanceBip_(NULL),
+    exposedAreaVec_(NULL),
+    assembledArea_(NULL),
+    w_(12)
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  pressureForce_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
+  tauWall_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
+  yplus_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
+  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  assembledArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf");
+  tauWallBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "tau_wall_bip");
+
+  // error check on params
+  const size_t nDim = meta_data.spatial_dimension();
+  if ( parameters_.size() > nDim )
+    throw std::runtime_error("SurfaceForce: parameter length wrong; expect nDim");
+
+  // make sure that the wall function params are registered
+  if ( NULL == tauWallBip_ )
+    throw std::runtime_error("SurfaceForce: tau_wall on the surface is not registered; wall bcs and post processing must be consistent");
+
+  // deal with file name and banner
+  if ( NaluEnv::self().parallel_rank() == 0 ) {
+    std::ofstream myfile;
+    myfile.open(outputFileName_.c_str());
+    myfile << std::setw(w_) 
+           << "Time" << std::setw(w_) 
+           << "Fpx"  << std::setw(w_) << "Fpy" << std::setw(w_)  << "Fpz" << std::setw(w_) 
+           << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fxz" << std::setw(w_) 
+           << "Mtx"  << std::setw(w_) << "Mty" << std::setw(w_)  << "Mtz" << std::setw(w_) 
+           << "Y+min" << std::setw(w_) << "Y+max"<< std::endl;
+    myfile.close();
+  }
+ }
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+SurfaceForceAndMomentMoengWallFunctionAlgorithm::~SurfaceForceAndMomentMoengWallFunctionAlgorithm()
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SurfaceForceAndMomentMoengWallFunctionAlgorithm::execute()
+{
+
+  // check to see if this is a valid step to process output file
+  const int timeStepCount = realm_.get_time_step_count();
+  const bool processMe = (timeStepCount % frequency_) == 0 ? true : false;
+
+  // do not waste time here
+  if ( !processMe )
+    return;
+
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // set min and max values
+  double yplusMin = 1.0e8;
+  double yplusMax = -1.0e8;
+
+  // bip values
+  std::vector<double> unitNormal(nDim);
+
+  // nodal fields to gather
+  std::vector<double> ws_pressure;
+  std::vector<double> ws_density;
+  std::vector<double> ws_viscosity;
+
+  // master element
+  std::vector<double> ws_face_shape_function;
+
+  // deal with state
+  ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
+  const double currentTime = realm_.get_current_time();
+
+  // local force and MomentWallFunction; i.e., to be assembled
+  double l_force_moment[9] = {};
+
+  // work force, MomentWallFunction and radius; i.e., to be pused to cross_product()
+  double ws_p_force[3] = {};
+  double ws_v_force[3] = {};
+  double ws_t_force[3] = {};
+  double ws_moment[3] = {};
+  double ws_radius[3] = {};
+
+  // centroid
+  double centroid[3] = {};
+  for ( size_t k = 0; k < parameters_.size(); ++k)
+    centroid[k] = parameters_[k];
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // face master element
+    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    // algorithm related; element
+    ws_pressure.resize(nodesPerFace);
+    ws_density.resize(nodesPerFace);
+    ws_viscosity.resize(nodesPerFace);
+    ws_face_shape_function.resize(numScsBip*nodesPerFace);
+
+    // pointers
+    double *p_pressure = &ws_pressure[0];
+    double *p_density = &ws_density[0];
+    double *p_viscosity = &ws_viscosity[0];
+    double *p_face_shape_function = &ws_face_shape_function[0];
+
+    // shape functions
+    if ( useShifted_ )
+      meFC->shifted_shape_fcn(&p_face_shape_function[0]);
+    else
+      meFC->shape_fcn(&p_face_shape_function[0]);
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      // face node relations
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      for ( int ni = 0; ni < nodesPerFace; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+
+        // gather scalars
+        p_pressure[ni]    = *stk::mesh::field_data(*pressure_, node);
+        p_density[ni]    = *stk::mesh::field_data(densityNp1, node);
+        p_viscosity[ni] = *stk::mesh::field_data(*viscosity_, node);
+
+      }
+
+      // pointer to face data
+      const double *areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      const double *wallNormalDistanceBip = stk::mesh::field_data(*wallNormalDistanceBip_, face);
+      const double *tauWallBip = stk::mesh::field_data(*tauWallBip_, face);
+
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        // offsets
+        const int offSetAveraVec = ip*nDim;
+        const int offSetSF_face = ip*nodesPerFace;
+        const int localFaceNode = faceIpNodeMap[ip];
+        
+        // aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          const double axj = areaVec[offSetAveraVec+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // interpolate to bip
+        double pBip = 0.0;
+        double rhoBip = 0.0;
+        double muBip = 0.0;
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const double r = p_face_shape_function[offSetSF_face+ic];
+          pBip += r*p_pressure[ic];
+          rhoBip += r*p_density[ic];
+          muBip += r*p_viscosity[ic];
+        }
+
+        // extract bip data
+        const double yp = wallNormalDistanceBip[ip];
+        const double utau= std::sqrt(tauWallBip[ip]/rhoBip);
+
+        // determine yplus
+        const double yplusBip = rhoBip*yp*utau/muBip;
+
+        // min and max
+        yplusMin = std::min(yplusMin, yplusBip);
+        yplusMax = std::max(yplusMax, yplusBip);
+
+        // extract nodal fields
+        stk::mesh::Entity node = face_node_rels[localFaceNode];
+        const double * coord = stk::mesh::field_data(*coordinates_, node );
+        double *pressureForce = stk::mesh::field_data(*pressureForce_, node );
+        double *tauWall = stk::mesh::field_data(*tauWall_, node );
+        double *yplus = stk::mesh::field_data(*yplus_, node );
+        const double assembledArea = *stk::mesh::field_data(*assembledArea_, node );
+
+        // load radius; assemble force -sigma_ij*njdS
+        double tauWallMag = 0.0;
+        for ( int i = 0; i < nDim; ++i ) {
+          const double ai = areaVec[offSetAveraVec+i];
+          ws_radius[i] = coord[i] - centroid[i];
+          ws_p_force[i] = pBip*ai;
+          ws_v_force[i] = tauWallBip[ip*nDim+i]*aMag;
+          ws_t_force[i] = ws_p_force[i] + ws_v_force[i];
+          pressureForce[i] += ws_p_force[i];
+          tauWallMag += tauWallBip[ip*nDim+i]*tauWallBip[ip*nDim+i];
+        }
+
+        cross_product(&ws_t_force[0], &ws_moment[0], &ws_radius[0]);
+
+        // assemble force and moment
+        for ( int j = 0; j < 3; ++j ) {
+          l_force_moment[j] += ws_p_force[j];
+          l_force_moment[j+3] += ws_v_force[j];
+          l_force_moment[j+6] += ws_moment[j];
+        }
+
+        // assemble tauWall; area weighting is hiding in lambda/assembledArea
+        *tauWall += std::sqrt(tauWallMag)*aMag/assembledArea;
+
+        // deal with yplus
+        *yplus += yplusBip*aMag/assembledArea;
+
+      }
+    }
+  }
+
+  if ( processMe ) {
+    // parallel assemble and output
+    double g_force_moment[9] = {};
+    stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
+
+    // Parallel assembly of L2
+    stk::all_reduce_sum(comm, &l_force_moment[0], &g_force_moment[0], 9);
+
+    // min/max
+    double g_yplusMin = 0.0, g_yplusMax = 0.0;
+    stk::all_reduce_min(comm, &yplusMin, &g_yplusMin, 1);
+    stk::all_reduce_max(comm, &yplusMax, &g_yplusMax, 1);
+
+    // deal with file name and banner
+    if ( NaluEnv::self().parallel_rank() == 0 ) {
+      std::ofstream myfile;
+      myfile.open(outputFileName_.c_str(), std::ios_base::app);
+      myfile << std::setprecision(6) 
+             << std::setw(w_) 
+             << currentTime << std::setw(w_) 
+             << g_force_moment[0] << std::setw(w_) << g_force_moment[1] << std::setw(w_) << g_force_moment[2] << std::setw(w_)
+             << g_force_moment[3] << std::setw(w_) << g_force_moment[4] << std::setw(w_) << g_force_moment[5] <<  std::setw(w_)
+             << g_force_moment[6] << std::setw(w_) << g_force_moment[7] << std::setw(w_) << g_force_moment[8] <<  std::setw(w_)
+             << g_yplusMin << std::setw(w_) << g_yplusMax << std::endl;
+      myfile.close();
+    }
+  }
+
+}
+
+//--------------------------------------------------------------------------
+//-------- pre_work --------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SurfaceForceAndMomentMoengWallFunctionAlgorithm::pre_work()
+{
+
+  // common
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  const int nDim = meta_data.spatial_dimension();
+
+  //======================
+  // assemble area
+  //======================
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+      &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets
+    = realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+           ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // face master element
+    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      // face node relations
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+
+      // pointer to face data
+      const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+        // offsets
+        const int offSetAveraVec = ip*nDim;
+
+        // nearest node mapping to this ip
+        const int localFaceNode = faceIpNodeMap[ip];
+
+        // extract nodal fields
+        stk::mesh::Entity node = face_node_rels[localFaceNode];
+        double *assembledArea = stk::mesh::field_data(*assembledArea_, node );
+
+        // aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j)
+          aMag += areaVec[offSetAveraVec+j]*areaVec[offSetAveraVec+j];
+         aMag = std::sqrt(aMag);
+
+         // assemble nodal quantities
+         *assembledArea += aMag;
+       }
+     }
+   }
+}
+
+//--------------------------------------------------------------------------
+//-------- cross_product ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SurfaceForceAndMomentMoengWallFunctionAlgorithm::cross_product(
+  double *force, double *cross, double *rad)
+{
+  cross[0] =   rad[1]*force[2] - rad[2]*force[1];
+  cross[1] = -(rad[0]*force[2] - rad[2]*force[0]);
+  cross[2] =   rad[0]*force[1] - rad[1]*force[0];
+}
+
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/BoundaryLayerPerturbationAuxFunction.C
+++ b/src/user_functions/BoundaryLayerPerturbationAuxFunction.C
@@ -26,16 +26,18 @@ BoundaryLayerPerturbationAuxFunction::BoundaryLayerPerturbationAuxFunction(
   kx_(0.1),
   ky_(0.1),
   thickness_(0.05),
-  uInf_(10.0)
+  uInf_(10.0),
+  vInf_(0.0)
 {
   // check size and populate
-  if ( params.size() != 5 )
-    throw std::runtime_error("Realm::setup_initial_conditions: boundary_layer_perturbation requires 5 params: ");
+  if ( params.size() != 6 )
+    throw std::runtime_error("Realm::setup_initial_conditions: boundary_layer_perturbation requires 6 params: ");
   amplitude_ = params[0];
   kx_        = params[1];
   ky_        = params[2];
   thickness_ = params[3];
   uInf_      = params[4];
+  vInf_      = params[5];
 }
 
 
@@ -58,10 +60,13 @@ BoundaryLayerPerturbationAuxFunction::do_evaluate(
 
     const double dampfun = std::exp(-cZ/thickness_)*cZ/thickness_/std::exp(-1.0);
     const double Upower = std::pow((cZ/(5.0*thickness_)),1.0/7.0);
-    const double Umean = std::min(Upower, 1.0)*uInf_;
+    const double UmeanMag = std::min(Upower, 1.0)*std::sqrt(uInf_*uInf_+vInf_*vInf_);
 
-    const double velX = Umean + amplitude_*std::cos(kx_*cX)*std::cos(ky_*cY)*dampfun;
-    const double velY = amplitude_*kx_/ky_*std::sin(kx_*cX)*std::sin(ky_*cY)*dampfun;
+    const double eX = std::cos(std::atan2(vInf_,uInf_));
+    const double eY = std::sin(std::atan2(vInf_,uInf_));
+
+    const double velX = UmeanMag*eX + amplitude_*std::cos(kx_*cX)*std::cos(ky_*cY)*dampfun;
+    const double velY = UmeanMag*eY + amplitude_*kx_/ky_*std::sin(kx_*cX)*std::sin(ky_*cY)*dampfun;
     const double velZ = 0.0;
 
     fieldPtr[0] = velX;


### PR DESCRIPTION
simulation of atmospheric flows.  This boundary condition is activated by
specifying 'use_moeng_wall_function' in the wall_user_data section of the
input file.  This commit contains only the shear stress boundary term
for the momentum system.  For non-isothermal runs an enthalpy boundary
flux is required as well.

Fixed bug with assigning proper ABL velocity profile function when surface temperature flux was zero.  Affects both ABL wall function and Moeng wall function.

Added algorithm for computing forces and moments for the Moeng ABL wall function.
Since the Moeng condition does not utilize a local friction velocity, a surface field
was created to store the local surface shear stress at the face integration points.  The
surface force and moment algorithm assembles these to the nodal tau_wall field.

Modified the BoundaryLayerPeturbationAuxFunction class to accept a U and V
velocity input to allow for boundary layer initialization for arbitrary flow
direction in the x-y plane.