### PR TITLE
Possibility of suppressing deprecated declaration warnings until a new Yaml-cpp release exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,14 @@ ENDIF(Trilinos_BUILD_SHARED_LIBS)
 
 PROJECT(Nalu)
 
+# Suppress deprecated declarations until next Yaml-cpp
+# release uses unique_ptr instead of the deprecated auto_ptr
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  SET(EXTRA_FLAGS "")
+  SET(EXTRA_FLAGS "-Wno-deprecated-declarations")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  SET(EXTRA_FLAGS "")
+  SET(EXTRA_FLAGS "-Wno-deprecated-declarations")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-  SET(EXTRA_FLAGS "-restrict")
+  SET(EXTRA_FLAGS "-Wno-deprecated -restrict")
 endif()
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Trilinos_CXX_COMPILER_FLAGS} ${EXTRA_FLAGS}")


### PR DESCRIPTION
This is a purely cosmetic pull request I'm opening for consideration. Nalu has warnings due to Yaml-cpp 0.5.3 using `auto_ptr` which is considered deprecated. Looking at the current Yaml github, they have moved onto using `unique_ptr` which should resolve these warnings in a future Yaml-cpp release. In the meantime, we can have the luxury of ignoring these deprecated declaration warnings, unless I'm missing a good reason not to.