### PR TITLE
Adding SDRWallFactor as a parameter so BC can be matched to NASA.

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -171,7 +171,8 @@ enum TurbulenceModelConstant {
   TM_cmuCs = 17,
   TM_Cw = 18,
   TM_CbTwo = 19,
-  TM_END = 20
+  TM_SDRWallFactor = 20,
+  TM_END = 21
 };
 
 static const std::string TurbulenceModelConstantNames[] = {
@@ -195,6 +196,7 @@ static const std::string TurbulenceModelConstantNames[] = {
   "cmuCs",
   "Cw",
   "Cb2",
+  "SDRWallFactor",
   "END"};
 
 } // namespace nalu

--- a/src/ComputeLowReynoldsSDRWallAlgorithm.C
+++ b/src/ComputeLowReynoldsSDRWallAlgorithm.C
@@ -46,7 +46,7 @@ ComputeLowReynoldsSDRWallAlgorithm::ComputeLowReynoldsSDRWallAlgorithm(
   : Algorithm(realm, part),
     useShifted_(useShifted),
     betaOne_(realm.get_turb_model_constant(TM_betaOne)),
-    wallFactor_(1.0)
+    wallFactor_(realm.get_turb_model_constant(TM_SDRWallFactor))
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -553,6 +553,7 @@ SolutionOptions::initialize_turbulence_constants()
   turbModelConstantMap_[TM_cmuCs] = 0.17;
   turbModelConstantMap_[TM_Cw] = 0.325;
   turbModelConstantMap_[TM_CbTwo] = 0.35;
+  turbModelConstantMap_[TM_SDRWallFactor] = 1.0;
 }
  
 } // namespace nalu

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -99,6 +99,7 @@ SurfaceForceAndMomentAlgorithm::SurfaceForceAndMomentAlgorithm(
            << "Fvx"  << std::setw(w_) << "Fvy" << std::setw(w_)  << "Fvz" << std::setw(w_) 
            << "Mtx"  << std::setw(w_) << "Mty" << std::setw(w_)  << "Mtz" << std::setw(w_) 
            << "Y+min" << std::setw(w_) << "Y+max"<< std::endl;
+    myfile.close();
   }
  }
 


### PR DESCRIPTION
NASA's description of the BC for the Menter SST model includes a wall
factor of 10. The wall factor is now exposed to the user as a
parameter.