### PR TITLE
Print the more informative, default YAML error message for parse errors

### DIFF
--- a/nalu.C
+++ b/nalu.C
@@ -140,17 +140,10 @@ int main( int argc, char ** argv )
   naluEnv.set_log_file_stream(logFileName, pprint);
 
   // proceed with reading input file "document" from YAML
-  YAML::Node doc;
-
-  try {
-    doc = YAML::LoadFile(inputFileName.c_str());
-    if (debug) {
-      if (!naluEnv.parallel_rank())
-        sierra::nalu::NaluParsingHelper::emit(std::cout, doc);
-    }
-  }
-  catch (YAML::ParserException &e) {
-    std::cout << e.what() << std::endl;
+  YAML::Node doc = YAML::LoadFile(inputFileName.c_str());
+  if (debug) {
+    if (!naluEnv.parallel_rank())
+      sierra::nalu::NaluParsingHelper::emit(std::cout, doc);
   }
 
   sierra::nalu::Simulation sim(doc);


### PR DESCRIPTION
The try/catch just causes the program to terminate with a less informative error message than not catching it would.

Case: an extra space added in front of one of the solution options.

Old behavior: 
>
> terminate called after throwing an instance of 'std::runtime_error'  
>  what():  parser error Realms::load
>

New behavior:
>
>terminate called after throwing an instance of 'YAML::ParserException'
>  what():  yaml-cpp: error at line 108, column 10: end of sequence not found
>