### PR TITLE
Improve TpetraLinearSystem initialization and assembly.

### DIFF
--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -9,6 +9,7 @@
 #ifndef LinearSolverTypes_h
 #define LinearSolverTypes_h
 
+#include <KokkosInterface.h>
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
@@ -80,6 +81,8 @@ typedef long   GlobalOrdinal; // MUST be signed
 typedef int    LocalOrdinal;  // MUST be signed
 typedef double Scalar;
 
+typedef Kokkos::DualView<size_t*, DeviceSpace>                             RowLengths;
+typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, DeviceSpace> LocalGraph;
 typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type                Node;
 typedef Teuchos::MpiComm<int>                                              Comm;
 typedef Tpetra::Export< LocalOrdinal, GlobalOrdinal, Node >                Export;


### PR DESCRIPTION
Initialization is improved by computing an array of row-lengths
to give to CrsGraph at construction (instead of the previous hard-
coded '8').

Assembly is improved by calling sumIntoValues on the local kokkos
matrix obtained from the Tpetra::CrsMatrix object via getLocalMatrix().
Previously, we were calling Tpetra::CrsMatrix::sumIntoLocalValues.

Some other optimizations are done, such as reducing the number of calls to
CrsGraph::insertGlobalIndices by trying to process more of the
column-indices for a given row, rather than making separate calls
for each row-column pair.

Overall, these changes appear to speed up the uqSlidingMeshDG test
by ~10%. The cube6M problem running on serrano is sped up by about
an 8-10% improvement in the 'init' timer. The performance of the
Kokkos::CrsMatrix::sumIntoValues method appears to be the same as
that of the Tpetra::CrsMatrix::sumIntoLocalValues method, to within
noise. Some other tests, such as the nightly hoHelium test, appear
to be relatively un-affected by these changes.