### PR TITLE
modify getDofStatus to work with both noncormal and periodic.

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -79,9 +79,6 @@ class LagrangeBasis;
 class PromotedElementIO;
 struct ElementDescription;
 
-struct PeriodicPartAttribute {};
-struct NonConformalPartAttribute {};
-
 class Realm {
  public:
 
@@ -571,8 +568,10 @@ class Realm {
 
   double timerPromoteMesh_; // timer
 
-  static PeriodicPartAttribute periodic_part_attribute_;
-  static NonConformalPartAttribute nonconformal_part_attribute_;
+  stk::mesh::PartVector allPeriodicInteractingParts_;
+  stk::mesh::PartVector allNonConformalInteractingParts_;
+  stk::mesh::Selector *allPeriodicInteractingSelector_;
+  stk::mesh::Selector *allNonConformalInteractingSelector_;
 };
 
 } // namespace nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -79,6 +79,9 @@ class LagrangeBasis;
 class PromotedElementIO;
 struct ElementDescription;
 
+struct PeriodicPartAttribute {};
+struct NonConformalPartAttribute {};
+
 class Realm {
  public:
 
@@ -546,7 +549,6 @@ class Realm {
     const TurbulenceModelConstant turbModelEnum);
   bool process_adaptivity();
 
-
   // element promotion
 
   // options
@@ -569,6 +571,8 @@ class Realm {
 
   double timerPromoteMesh_; // timer
 
+  static PeriodicPartAttribute periodic_part_attribute_;
+  static NonConformalPartAttribute nonconformal_part_attribute_;
 };
 
 } // namespace nalu

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -136,6 +136,9 @@
 namespace sierra{
 namespace nalu{
 
+  PeriodicPartAttribute   Realm::periodic_part_attribute_;
+  NonConformalPartAttribute Realm::nonconformal_part_attribute_;
+
 //==========================================================================
 // Class Definition
 //==========================================================================
@@ -3018,6 +3021,11 @@ Realm::register_periodic_bc(
   const double &searchTolerance,
   const std::string &searchMethodName)
 {
+  metaData_->declare_attribute_no_delete(*masterMeshPart, &periodic_part_attribute_);
+  metaData_->declare_attribute_no_delete(*slaveMeshPart, &periodic_part_attribute_);
+
+  // std::cerr << "declare_attribute_no_delete: masterMeshPart= " << masterMeshPart->name() << std::endl;
+  // std::cerr << "declare_attribute_no_delete: slaveMeshPart= " << slaveMeshPart->name() << std::endl;
 
   // push back the part for book keeping and, later, skin mesh
   bcPartVec_.push_back(masterMeshPart);
@@ -3073,6 +3081,8 @@ Realm::register_non_conformal_bc(
   stk::mesh::Part *part,
   const stk::topology &theTopo)
 {
+  metaData_->declare_attribute_no_delete(*part, &nonconformal_part_attribute_);
+  //std::cerr << "declare_attribute_no_delete: nonconformal_part_attribute_= " << part->name() << std::endl;
 
   // push back the part for book keeping and, later, skin mesh
   bcPartVec_.push_back(part);

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -152,11 +152,49 @@ int TpetraLinearSystem::getDofStatus(stk::mesh::Entity node)
   const bool entityIsShared = b.shared();
   const bool entityIsGhosted = !entityIsOwned && !entityIsShared;
 
-  if (realm_.hasPeriodic_ && realm_.has_non_matching_boundary_face_alg())
-    throw std::logic_error("not ready for primetime to compbine periodic and non-matching algorithm suite");
+  bool has_non_matching_boundary_face_alg = false;
+  bool hasPeriodic = false;
+
+  bool debug = false;
+
+  stk::mesh::Part *periodicPart = 0, *nonConformalPart = 0;
+  for (auto part : b.supersets())
+    {
+      const PeriodicPartAttribute *isPeriodic = part->attribute<PeriodicPartAttribute>();
+      const NonConformalPartAttribute *isNonConformal = part->attribute<NonConformalPartAttribute>();
+
+      if (isPeriodic) {
+        periodicPart = part;
+        hasPeriodic = true;
+      }
+      if (isNonConformal) {
+        nonConformalPart = part;
+        has_non_matching_boundary_face_alg = true;
+      }
+
+      if (debug) std::cerr << "part= " << part->name() << " A= " << (periodicPart ? periodicPart->name() : "") << " " << (nonConformalPart ? nonConformalPart->name() : "")
+              << " node= " << realm_.bulkData_->identifier(node)
+              << " has_non_matching_boundary_face_alg= " << has_non_matching_boundary_face_alg
+              << " hasPeriodic= " << hasPeriodic << std::endl;
+
+    }
+
+  if (has_non_matching_boundary_face_alg && hasPeriodic)
+    {
+      std::ostringstream ostr;
+      ostr << "node id= " << realm_.bulkData_->identifier(node);
+      throw std::logic_error("not ready for primetime to combine periodic and non-matching algorithm on same node: "+ostr.str());
+    }
+
+  if (debug && (hasPeriodic || has_non_matching_boundary_face_alg)) {
+    std::cerr << "part= " << (periodicPart ? periodicPart->name() : "") << " " << (nonConformalPart ? nonConformalPart->name() : "")
+              << " node= " << realm_.bulkData_->identifier(node)
+              << " has_non_matching_boundary_face_alg= " << has_non_matching_boundary_face_alg
+              << " hasPeriodic= " << hasPeriodic << std::endl;
+  }
 
   // simple case
-  if (!realm_.hasPeriodic_ && !realm_.has_non_matching_boundary_face_alg()) {
+  if (!hasPeriodic && !has_non_matching_boundary_face_alg) {
     if (entityIsGhosted)
       return DS_GhostedDOF;
     if (entityIsOwned)
@@ -165,15 +203,19 @@ int TpetraLinearSystem::getDofStatus(stk::mesh::Entity node)
       return DS_GloballyOwnedDOF;
   }
 
-  if (realm_.has_non_matching_boundary_face_alg()) {
+  if (has_non_matching_boundary_face_alg) {
+    if (entityIsGhosted)
+      return DS_GhostedDOF;
     if (entityIsOwned)
       return DS_OwnedDOF;
-    if (!entityIsOwned && (entityIsGhosted || entityIsShared)){
+    if (entityIsShared && !entityIsOwned) {
+      //if (!entityIsOwned && (entityIsGhosted || entityIsShared)){
       return DS_GloballyOwnedDOF;
     }
+    // maybe return DS_GhostedDOF if entityIsGhosted
   }
 
-  if (realm_.hasPeriodic_) {
+  if (hasPeriodic) {
     const stk::mesh::EntityId stkId = bulkData.identifier(node);
     const stk::mesh::EntityId naluId = *stk::mesh::field_data(*realm_.naluGlobalId_, node);
 


### PR DESCRIPTION
   * add part attributes to identify non-conformal and periodic boundaries

   * modify getDofStatus to use part attributes instead of global Realm flags

   * note: small tests with periodic and MueLu only work if MueLu parameter

     <Parameter        name="coarse: max size"                 type="int"      value="100"/>

     is set small enough to force a coarse solve (thanks Stefan for this suggestion)"