### PR TITLE
Enable paraview catalyst

### DIFF
--- a/include/OutputInfo.h
+++ b/include/OutputInfo.h
@@ -37,6 +37,9 @@ public:
   int get_restart_compression();
   bool get_restart_shuffle();
   
+  std::string catalystFileName_;
+  std::string paraviewScriptName_;
+  std::string catalystParseJson_;
   std::string outputDBName_;
   int outputFreq_;
   int outputStart_;

--- a/src/OutputInfo.C
+++ b/src/OutputInfo.C
@@ -30,6 +30,9 @@ namespace nalu{
 //--------------------------------------------------------------------------
 OutputInfo::OutputInfo() 
   : outputDBName_("output.e"),
+    catalystFileName_(""),
+    catalystParseJson_(""),
+    paraviewScriptName_(""),
     outputFreq_(1),
     outputStart_(0),
     outputNodeSet_(false),
@@ -81,6 +84,12 @@ OutputInfo::load(
 
     // output data base name
     get_if_present(y_output, "output_data_base_name", outputDBName_, outputDBName_);
+
+    // catalyst file name
+    get_if_present(y_output, "catalyst_file_name", catalystFileName_, catalystFileName_);
+
+    // paraview script name
+    get_if_present(y_output, "paraview_script_name", paraviewScriptName_, paraviewScriptName_);
     
     // output frequency
     get_if_present(y_output, "output_frequency", outputFreq_, outputFreq_);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1951,26 +1951,6 @@ Realm::create_output_mesh()
       stk::util::filename_substitution(input_deck_name);
       outputInfo_->outputPropertyManager_->add(Ioss::Property("CATALYST_BLOCK_PARSE_INPUT_DECK_NAME", input_deck_name));
 
-      /*std::string cod = catalyst_output_directory;
-      boost::filesystem::path full_path(cod);
-      full_path = boost::filesystem::system_complete(full_path);
-
-      try {
-        boost::filesystem::create_directory(full_path);
-      }
-      catch(boost::filesystem::filesystem_error& e) {
-        std::cerr << e.what() << std::endl;
-        throw std::runtime_error("Directory: " + full_path.string() + "\nCould not be created \n");
-      }
-      outputInfo_->outputPropertyManager_->add(Ioss::Property("CATALYST_OUTPUT_DIRECTORY", full_path.c_str()));
-
-      std::ostringstream s;
-      s << input_deck_name << "." << number_of_catalyst_blocks << catalyst_file_suffix;
-      full_path = full_path / s.str();
-      std::string fn(full_path.string());
-      number_of_catalyst_blocks++;
-*/
-
       if(!outputInfo_->paraviewScriptName_.empty())
         outputInfo_->outputPropertyManager_->add(Ioss::Property("CATALYST_SCRIPT", outputInfo_->paraviewScriptName_.c_str()));
 


### PR DESCRIPTION

The changes are in Realm.C and OutputInfo.C, and OutputInfo.h. The build will succeed as long as you are building against the Trilinos master branch and you set the following flag in your Trilinos build:

-DTrilinos_ENABLE_SEACASIoss:BOOL=ON

ParaView Catalyst will only be active when an "output" block in a Nalu input deck contains a "catalyst_file_name" command. It is also necessary to build the ParaView Catalyst adapter against an install of ParaView and set an environment variable to point to the install location. We will need to update the Nalu build instructions to show these details. 

The environment variable is called CATALYST_ADAPTER_INSTALL_DIR. It should be set to the root of the install directory for the Catalyst adapter.