### PR TITLE
Modify Trilinos configure scripts for Catalyst.

### DIFF
--- a/build/do-configTrilinos_debug
+++ b/build/do-configTrilinos_debug
@@ -77,6 +77,7 @@ cmake \
 -DTrilinos_ENABLE_SEACASExodiff:BOOL=ON \
 -DTrilinos_ENABLE_SEACASNemspread:BOOL=ON \
 -DTrilinos_ENABLE_SEACASNemslice:BOOL=ON \
+-DTrilinos_ENABLE_SEACASIoss:BOOL=ON \
 -DTPL_ENABLE_Netcdf:BOOL=ON \
 -DNetCDF_ROOT:PATH=${netcdf_install_dir} \
 -DHDF5_ROOT:PATH=${hdf_install_dir} \

--- a/build/do-configTrilinos_release
+++ b/build/do-configTrilinos_release
@@ -77,6 +77,7 @@ cmake \
 -DTrilinos_ENABLE_SEACASExodiff:BOOL=ON \
 -DTrilinos_ENABLE_SEACASNemspread:BOOL=ON \
 -DTrilinos_ENABLE_SEACASNemslice:BOOL=ON \
+-DTrilinos_ENABLE_SEACASIoss:BOOL=ON \
 -DTPL_ENABLE_Netcdf:BOOL=ON \
 -DNetCDF_ROOT:PATH=${netcdf_install_dir} \
 -DHDF5_ROOT:PATH=${hdf_install_dir} \


### PR DESCRIPTION
Enable the Seacas IOSS module in Trilinos build to produce
the Iovs library necessary for linking Catalyst.