### PR TITLE
Fix error message in CMake file for regression tests.

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -5,13 +5,13 @@
 if(NOT ${NALURTEST_DIR} STREQUAL "")
   message("NaluRtest directory is ${NALURTEST_DIR}")
 else(NOT ${NALURTEST_DIR} STREQUAL "")
-  message( FATAL_ERROR "You need to set the ${NALURTEST_DIR} variable. CMake will exit." )
+  message( FATAL_ERROR "You need to set the 'NALURTEST_DIR' variable. CMake will exit." )
 endif()
 
 if(NOT ${RUNNALURTEST_DIR} STREQUAL "")
   message("runNaluRtest directory is ${RUNNALURTEST_DIR}")
 else(NOT ${RUNNALURTEST_DIR} STREQUAL "")
-  message( FATAL_ERROR "You need to set the ${RUNNALURTEST_DIR} variable. CMake will exit." )
+  message( FATAL_ERROR "You need to set the 'RUNNALURTEST_DIR' variable. CMake will exit." )
 endif()
 
 ## -- Set TOLERANCE for testing


### PR DESCRIPTION
The previous implementation printed an empty string instead of the
variable that was not set when generating the fatal error message. The
modifications print out the actual variable name that the user must set
for CTests to work.