### PR TITLE
Refactor MasterElement and SupplementalAlgorithm logic to improve modularity

### DIFF
--- a/docs/source/theory/codeAbstractions.rst
+++ b/docs/source/theory/codeAbstractions.rst
@@ -196,7 +196,7 @@ entities that are provided to the developer.
       const stk::mesh::Bucket::size_type length   = b.size();
 
       // extract master element (homogeneous over buckets)
-      MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+      MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
       
       for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
         

--- a/include/Algorithm.h
+++ b/include/Algorithm.h
@@ -22,6 +22,7 @@ namespace nalu{
 
 class Realm;
 class MasterElement;
+class SupplementalAlgorithm;
 
 class Algorithm
 {
@@ -45,6 +46,7 @@ public:
 
   Realm &realm_;
   stk::mesh::PartVector partVec_;
+  std::vector<SupplementalAlgorithm *> supplementalAlg_;
 };
 
 } // namespace nalu

--- a/include/Algorithm.h
+++ b/include/Algorithm.h
@@ -22,7 +22,6 @@ namespace nalu{
 
 class Realm;
 class MasterElement;
-class SupplementalAlgorithm;
 
 class Algorithm
 {
@@ -46,7 +45,6 @@ public:
 
   Realm &realm_;
   stk::mesh::PartVector partVec_;
-  std::vector<SupplementalAlgorithm *> supplementalAlg_;
 };
 
 } // namespace nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -269,11 +269,6 @@ class Realm {
   void dump_simulation_time();
   double provide_mean_norm();
 
-  MasterElement* get_surface_master_element(
-    const stk::topology & theTopo);
-  MasterElement* get_volume_master_element(
-    const stk::topology & theTopo);
-
   double get_hybrid_factor(
     const std::string dofname);
   double get_alpha_factor(
@@ -419,9 +414,6 @@ class Realm {
   std::vector<Algorithm *> propertyAlg_;
   std::map<PropertyIdentifier, ScalarFieldType *> propertyMap_;
   std::vector<Algorithm *> initCondAlg_;
-
-  std::map<stk::topology, MasterElement *> surfaceMeMap_;
-  std::map<stk::topology, MasterElement *> volumeMeMap_;
 
   SizeType nodeCount_;
   bool estimateMemoryOnly_;

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -20,6 +20,7 @@ namespace nalu{
 
 class EquationSystem;
 class Realm;
+class SupplementalAlgorithm;
 
 class SolverAlgorithm : public Algorithm
 {
@@ -29,11 +30,12 @@ public:
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem);
-  virtual ~SolverAlgorithm() {}
+  virtual ~SolverAlgorithm();
 
   virtual void execute() = 0;
   virtual void initialize_connectivity() = 0;
 
+  std::vector<SupplementalAlgorithm *> supplementalAlg_;
 protected:
 
   // Need to find out whether this ever gets called inside a modification cycle.

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -20,7 +20,6 @@ namespace nalu{
 
 class EquationSystem;
 class Realm;
-class SupplementalAlgorithm;
 
 class SolverAlgorithm : public Algorithm
 {
@@ -30,12 +29,11 @@ public:
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem);
-  virtual ~SolverAlgorithm();
+  virtual ~SolverAlgorithm() {}
 
   virtual void execute() = 0;
   virtual void initialize_connectivity() = 0;
 
-  std::vector<SupplementalAlgorithm *> supplementalAlg_;
 protected:
 
   // Need to find out whether this ever gets called inside a modification cycle.

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <cstdlib>
 #include <stdexcept>
+#include <string>
 
 namespace stk {
 struct topology;
@@ -30,15 +31,23 @@ enum Direction
 }
 
 struct ElementDescription;
+class MasterElement;
+
+MasterElement*
+get_surface_master_element(
+  const stk::topology& theTopo,
+  ElementDescription* desc = nullptr,
+  std::string quadType = "GaussLegendre");
+
+MasterElement*
+get_volume_master_element(
+  const stk::topology& theTopo,
+  ElementDescription* desc = nullptr,
+  std::string quadType = "GaussLegendre");
 
 class MasterElement
 {
 public:
-  static MasterElement* create_surface_master_element(stk::topology topo);
-  static MasterElement* create_volume_master_element(stk::topology topo);
-  static MasterElement* create_surface_master_element(stk::topology topo, const ElementDescription& desc, std::string quadType);
-  static MasterElement* create_volume_master_element(stk::topology topo, const ElementDescription& desc, std::string quadType);
-
   MasterElement();
   virtual ~MasterElement();
 

--- a/include/xfer/LinInterp.h
+++ b/include/xfer/LinInterp.h
@@ -93,7 +93,7 @@ template <class FROM, class TO>  void LinInterp<FROM,TO>::filter_to_nearest (
       // extract master element from the bucket in which the element resides
       const stk::mesh::Bucket &theBucket = fromBulkData.bucket(theElem);
       const stk::topology &theElemTopo = theBucket.topology();
-      MasterElement *meSCS = fromRealm.get_surface_master_element(theElemTopo);
+      MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
       // load nodal coordinates from element
       stk::mesh::Entity const* elem_node_rels = fromBulkData.begin_nodes(theElem);
@@ -171,7 +171,7 @@ template <class FROM, class TO>  void LinInterp<FROM,TO>::apply
 
     const stk::mesh::Bucket &theBucket = fromBulkData.bucket(theElem);
     const stk::topology &theElemTopo = theBucket.topology();
-    MasterElement *meSCS = fromRealm.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     stk::mesh::Entity const* elem_node_rels = fromBulkData.begin_nodes(theElem);
     const int num_nodes = fromBulkData.num_nodes(theElem);

--- a/src/ActuatorLine.C
+++ b/src/ActuatorLine.C
@@ -855,7 +855,7 @@ ActuatorLine::complete_search()
       // extract topo and master element for this topo
       const stk::mesh::Bucket &theBucket = bulkData.bucket(elem);
       const stk::topology &elemTopo = theBucket.topology();
-      MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+      MasterElement *meSCS = sierra::nalu::get_surface_master_element(elemTopo);
       const int nodesPerElement = meSCS->nodesPerElement_;
 
       // gather elemental coords
@@ -905,7 +905,7 @@ ActuatorLine::resize_std_vector(
   const stk::mesh::BulkData & bulkData)
 {
   const stk::topology &elemTopo = bulkData.bucket(elem).topology();
-  MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(elemTopo);
   const int nodesPerElement = meSCS->nodesPerElement_;
   theVector.resize(nodesPerElement*sizeOfField);
 }
@@ -963,7 +963,7 @@ ActuatorLine::compute_volume(
 {
   // extract master element from the bucket in which the element resides
   const stk::topology &elemTopo = bulkData.bucket(elem).topology();
-  MasterElement *meSCV = realm_.get_volume_master_element(elemTopo);
+  MasterElement *meSCV = sierra::nalu::get_volume_master_element(elemTopo);
   const int numScvIp = meSCV->numIntPoints_;
 
   // compute scv for this element
@@ -992,7 +992,7 @@ ActuatorLine::interpolate_field(
 {
   // extract master element from the bucket in which the element resides
   const stk::topology &elemTopo = bulkData.bucket(elem).topology();
-  MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(elemTopo);
   
   // interpolate velocity to this best point
   meSCS->interpolatePoint(
@@ -1056,7 +1056,7 @@ ActuatorLine::assemble_source_to_nodes(
 {
   // extract master element from the bucket in which the element resides
   const stk::topology &elemTopo = bulkData.bucket(elem).topology();
-  MasterElement *meSCV = realm_.get_volume_master_element(elemTopo);
+  MasterElement *meSCV = sierra::nalu::get_volume_master_element(elemTopo);
   const int numScvIp = meSCV->numIntPoints_;
 
   // extract elem_node_relations

--- a/src/Algorithm.C
+++ b/src/Algorithm.C
@@ -7,6 +7,7 @@
 
 
 #include <Algorithm.h>
+#include <SupplementalAlgorithm.h>
 
 namespace sierra{
 namespace nalu{
@@ -42,7 +43,11 @@ Algorithm::Algorithm(
 //-------- destructor ------------------------------------------------------
 //--------------------------------------------------------------------------
 Algorithm::~Algorithm()
-{}
+{
+  std::vector<SupplementalAlgorithm *>::iterator ii;
+  for( ii=supplementalAlg_.begin(); ii!=supplementalAlg_.end(); ++ii )
+    delete *ii;
+}
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/Algorithm.C
+++ b/src/Algorithm.C
@@ -7,7 +7,6 @@
 
 
 #include <Algorithm.h>
-#include <SupplementalAlgorithm.h>
 
 namespace sierra{
 namespace nalu{
@@ -43,11 +42,7 @@ Algorithm::Algorithm(
 //-------- destructor ------------------------------------------------------
 //--------------------------------------------------------------------------
 Algorithm::~Algorithm()
-{
-  std::vector<SupplementalAlgorithm *>::iterator ii;
-  for( ii=supplementalAlg_.begin(); ii!=supplementalAlg_.end(); ++ii )
-    delete *ii;
-}
+{}
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
@@ -121,7 +121,7 @@ AssembleContinuityEdgeOpenSolverAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // resize some things; matrix related

--- a/src/AssembleContinuityElemOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityElemOpenSolverAlgorithm.C
@@ -158,12 +158,12 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
     const int numScsIp = meSCS->numIntPoints_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleContinuityElemSolverAlgorithm.C
+++ b/src/AssembleContinuityElemSolverAlgorithm.C
@@ -150,8 +150,8 @@ AssembleContinuityElemSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleContinuityInflowSolverAlgorithm.C
+++ b/src/AssembleContinuityInflowSolverAlgorithm.C
@@ -114,7 +114,7 @@ AssembleContinuityInflowSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element specifics
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
     const int *ipNodeMap = meFC->ipNodeMap();

--- a/src/AssembleCourantReynoldsElemAlgorithm.C
+++ b/src/AssembleCourantReynoldsElemAlgorithm.C
@@ -107,7 +107,7 @@ AssembleCourantReynoldsElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleElemSolverAlgorithmDep.C
+++ b/src/AssembleElemSolverAlgorithmDep.C
@@ -88,8 +88,8 @@ AssembleElemSolverAlgorithmDep::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleHeatCondIrradWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondIrradWallSolverAlgorithm.C
@@ -102,7 +102,7 @@ AssembleHeatCondIrradWallSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element specifics
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsIp = meFC->numIntPoints_;
 

--- a/src/AssembleHeatCondWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondWallSolverAlgorithm.C
@@ -101,7 +101,7 @@ AssembleHeatCondWallSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element specifics
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsIp = meFC->numIntPoints_;
 

--- a/src/AssembleMomentumABLWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumABLWallFunctionSolverAlgorithm.C
@@ -141,7 +141,7 @@ AssembleMomentumABLWallFunctionSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
@@ -126,7 +126,7 @@ AssembleMomentumEdgeOpenSolverAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // resize some things; matrix related

--- a/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
@@ -113,7 +113,7 @@ AssembleMomentumEdgeSymmetrySolverAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // resize some things; matrix related

--- a/src/AssembleMomentumElemOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumElemOpenSolverAlgorithm.C
@@ -175,12 +175,12 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
     const int numScsIp = meSCS->numIntPoints_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleMomentumElemSolverAlgorithm.C
+++ b/src/AssembleMomentumElemSolverAlgorithm.C
@@ -199,8 +199,8 @@ AssembleMomentumElemSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
@@ -117,11 +117,11 @@ AssembleMomentumElemSymmetrySolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
@@ -123,7 +123,7 @@ AssembleMomentumWallFunctionSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleNodalGradBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradBoundaryAlgorithm.C
@@ -81,7 +81,7 @@ AssembleNodalGradBoundaryAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerFace = meFC->nodesPerElement_;

--- a/src/AssembleNodalGradElemAlgorithm.C
+++ b/src/AssembleNodalGradElemAlgorithm.C
@@ -187,7 +187,7 @@ AssembleNodalGradElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerElement = meSCS->nodesPerElement_;
     const int numScsIp = meSCS->numIntPoints_;
     ws_shape_function.resize(numScsIp*nodesPerElement);

--- a/src/AssembleNodalGradUBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradUBoundaryAlgorithm.C
@@ -84,7 +84,7 @@ AssembleNodalGradUBoundaryAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerFace = meFC->nodesPerElement_;

--- a/src/AssembleNodalGradUElemAlgorithm.C
+++ b/src/AssembleNodalGradUElemAlgorithm.C
@@ -87,7 +87,7 @@ AssembleNodalGradUElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssemblePNGBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGBoundarySolverAlgorithm.C
@@ -93,7 +93,7 @@ AssemblePNGBoundarySolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
     const int *faceIpNodeMap = meFC->ipNodeMap();

--- a/src/AssemblePNGElemSolverAlgorithm.C
+++ b/src/AssemblePNGElemSolverAlgorithm.C
@@ -106,8 +106,8 @@ AssemblePNGElemSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleScalarEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeOpenSolverAlgorithm.C
@@ -104,7 +104,7 @@ AssembleScalarEdgeOpenSolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
 

--- a/src/AssembleScalarElemDiffSolverAlgorithm.C
+++ b/src/AssembleScalarElemDiffSolverAlgorithm.C
@@ -115,8 +115,8 @@ AssembleScalarElemDiffSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleScalarElemOpenSolverAlgorithm.C
+++ b/src/AssembleScalarElemOpenSolverAlgorithm.C
@@ -152,11 +152,11 @@ AssembleScalarElemOpenSolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/AssembleScalarElemSolverAlgorithm.C
+++ b/src/AssembleScalarElemSolverAlgorithm.C
@@ -172,8 +172,8 @@ AssembleScalarElemSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/AssembleScalarFluxBCSolverAlgorithm.C
+++ b/src/AssembleScalarFluxBCSolverAlgorithm.C
@@ -97,7 +97,7 @@ AssembleScalarFluxBCSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeABLWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeABLWallFrictionVelocityAlgorithm.C
@@ -150,10 +150,10 @@ ComputeABLWallFrictionVelocityAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeGeometryBoundaryAlgorithm.C
+++ b/src/ComputeGeometryBoundaryAlgorithm.C
@@ -66,7 +66,7 @@ ComputeGeometryBoundaryAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meFC->nodesPerElement_;

--- a/src/ComputeGeometryInteriorAlgorithm.C
+++ b/src/ComputeGeometryInteriorAlgorithm.C
@@ -80,7 +80,7 @@ ComputeGeometryInteriorAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCV->nodesPerElement_;
@@ -140,7 +140,7 @@ ComputeGeometryInteriorAlgorithm::execute()
       stk::mesh::Bucket & b = **ib ;
 
       // extract master element
-      MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+      MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
       // extract master element specifics
       const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/ComputeHeatTransferEdgeWallAlgorithm.C
+++ b/src/ComputeHeatTransferEdgeWallAlgorithm.C
@@ -100,7 +100,7 @@ ComputeHeatTransferEdgeWallAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();

--- a/src/ComputeHeatTransferElemWallAlgorithm.C
+++ b/src/ComputeHeatTransferElemWallAlgorithm.C
@@ -113,11 +113,11 @@ ComputeHeatTransferElemWallAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeLowReynoldsSDRWallAlgorithm.C
+++ b/src/ComputeLowReynoldsSDRWallAlgorithm.C
@@ -107,10 +107,10 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeMdotEdgeOpenAlgorithm.C
+++ b/src/ComputeMdotEdgeOpenAlgorithm.C
@@ -105,7 +105,7 @@ ComputeMdotEdgeOpenAlgorithm::execute()
     b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
     ThrowAssert ( parentTopo.size() == 1 );
     stk::topology theElemTopo = parentTopo[0];
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();

--- a/src/ComputeMdotElemAlgorithm.C
+++ b/src/ComputeMdotElemAlgorithm.C
@@ -141,7 +141,7 @@ ComputeMdotElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;
@@ -304,7 +304,7 @@ ComputeMdotElemAlgorithm::assemble_edge_mdot()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int *lrscv = meSCS->adjacentNodes();

--- a/src/ComputeMdotElemOpenAlgorithm.C
+++ b/src/ComputeMdotElemOpenAlgorithm.C
@@ -137,12 +137,12 @@ ComputeMdotElemOpenAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
     const int numScsIp = meSCS->numIntPoints_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -94,7 +94,7 @@ ComputeSSTMaxLengthScaleElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int numScsIp = meSCS->numIntPoints_;

--- a/src/ComputeWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityAlgorithm.C
@@ -130,10 +130,10 @@ ComputeWallFrictionVelocityAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 

--- a/src/ComputeWallModelSDRWallAlgorithm.C
+++ b/src/ComputeWallModelSDRWallAlgorithm.C
@@ -96,7 +96,7 @@ ComputeWallModelSDRWallAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // face master element
     const int nodesPerFace = b.topology().num_nodes();

--- a/src/ContinuityAdvElemSuppAlg.C
+++ b/src/ContinuityAdvElemSuppAlg.C
@@ -51,7 +51,7 @@ ContinuityAdvElemSuppAlg<AlgTraits>::ContinuityAdvElemSuppAlg(
     reducedSensitivities_(realm_.get_cvfem_reduced_sens_poisson()),
     interpTogether_(realm_.get_mdot_interp()),
     om_interpTogether_(1.0-interpTogether_),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -65,7 +65,7 @@ ContinuityAdvElemSuppAlg<AlgTraits>::ContinuityAdvElemSuppAlg(
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   if ( shiftMdot_ )
     meSCS->shifted_shape_fcn(&v_shape_function_(0,0));
   else

--- a/src/ContinuityMassElemSuppAlg.C
+++ b/src/ContinuityMassElemSuppAlg.C
@@ -47,7 +47,7 @@ ContinuityMassElemSuppAlg<AlgTraits>::ContinuityMassElemSuppAlg(
     gamma2_(0.0),
     gamma3_(0.0),
     lumpedMass_(lumpedMass),
-    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   // save off fields; shove state N into Nm1 if this is BE
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -57,7 +57,7 @@ ContinuityMassElemSuppAlg<AlgTraits>::ContinuityMassElemSuppAlg(
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
-  MasterElement *meSCV = realm.get_volume_master_element(AlgTraits::topo_);
+  MasterElement *meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
 
   // compute shape function
   if ( lumpedMass_ )

--- a/src/LimiterErrorIndicatorElemAlgorithm.C
+++ b/src/LimiterErrorIndicatorElemAlgorithm.C
@@ -78,7 +78,7 @@ LimiterErrorIndicatorElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -284,7 +284,7 @@ LowMachEquationSystem::register_element_fields(
   // register mdot for element-based scheme...
   if ( elementContinuityEqs_ ) {
     // extract master element and get scs points
-    MasterElement *meSCS = realm_.get_surface_master_element(theTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theTopo);
     const int numScsIp = meSCS->numIntPoints_;
     GenericFieldType *massFlowRate = &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs"));
     stk::mesh::put_field(*massFlowRate, *part, numScsIp );
@@ -424,7 +424,7 @@ LowMachEquationSystem::register_open_bc(
   bcDataAlg_.push_back(auxAlgPbc);
 
   // mdot at open bc; register field
-  MasterElement *meFC = realm_.get_surface_master_element(theTopo);
+  MasterElement *meFC = sierra::nalu::get_surface_master_element(theTopo);
   const int numScsBip = meFC->numIntPoints_;
   GenericFieldType *mdotBip 
     = &(metaData.declare_field<GenericFieldType>(static_cast<stk::topology::rank_t>(metaData.side_rank()), 
@@ -1643,7 +1643,7 @@ MomentumEquationSystem::register_wall_bc(
     stk::mesh::put_field(*assembledWallNormalDistance, *part);
 
     // integration point; size it based on number of boundary integration points
-    MasterElement *meFC = realm_.get_surface_master_element(theTopo);
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(theTopo);
     const int numScsBip = meFC->numIntPoints_;
 
     stk::topology::rank_t sideRank = static_cast<stk::topology::rank_t>(meta_data.side_rank());
@@ -1830,7 +1830,7 @@ MomentumEquationSystem::register_non_conformal_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // mdot at nc bc; register field; require topo and num ips
-  MasterElement *meFC = realm_.get_surface_master_element(theTopo);
+  MasterElement *meFC = sierra::nalu::get_surface_master_element(theTopo);
   const int numScsBip = meFC->numIntPoints_;
 
   stk::topology::rank_t sideRank = static_cast<stk::topology::rank_t>(meta_data.side_rank());
@@ -2654,7 +2654,7 @@ ContinuityEquationSystem::register_non_conformal_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // mdot at nc bc; register field; require topo and num ips
-  MasterElement *meFC = realm_.get_surface_master_element(theTopo);
+  MasterElement *meFC = sierra::nalu::get_surface_master_element(theTopo);
   const int numScsBip = meFC->numIntPoints_;
   
   stk::topology::rank_t sideRank = static_cast<stk::topology::rank_t>(meta_data.side_rank());

--- a/src/MomentumAdvDiffElemSuppAlg.C
+++ b/src/MomentumAdvDiffElemSuppAlg.C
@@ -49,7 +49,7 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::MomentumAdvDiffElemSuppAlg(
     coordinates_(NULL),
     viscosity_(viscosity),
     massFlowRate_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     includeDivU_(realm_.get_divU())
 {
   // save off fields; for non-BDF2 gather in state N for Nm1 (gamma3_ will be zero)
@@ -59,7 +59,7 @@ MomentumAdvDiffElemSuppAlg<AlgTraits>::MomentumAdvDiffElemSuppAlg(
   massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/src/MomentumBuoyancySrcElemSuppAlg.C
+++ b/src/MomentumBuoyancySrcElemSuppAlg.C
@@ -45,7 +45,7 @@ MomentumBuoyancySrcElemSuppAlg<AlgTraits>::MomentumBuoyancySrcElemSuppAlg(
     coordinates_(NULL),
     rhoRef_(0.0),
     useShifted_(false),
-    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -57,7 +57,7 @@ MomentumBuoyancySrcElemSuppAlg<AlgTraits>::MomentumBuoyancySrcElemSuppAlg(
     gravity_(j) = realm_.solutionOptions_->gravity_[j];
   rhoRef_ = realm_.solutionOptions_->referenceDensity_;
 
-  MasterElement* meSCV = realm.get_volume_master_element(AlgTraits::topo_);
+  MasterElement* meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
 
   meSCV->shape_fcn(&v_shape_function_(0,0));
 

--- a/src/MomentumMassElemSuppAlg.C
+++ b/src/MomentumMassElemSuppAlg.C
@@ -52,7 +52,7 @@ MomentumMassElemSuppAlg<AlgTraits>::MomentumMassElemSuppAlg(
     gamma2_(0.0),
     gamma3_(0.0),
     lumpedMass_(lumpedMass),
-    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   // save off fields; shove state N into Nm1 if this is BE
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -67,7 +67,7 @@ MomentumMassElemSuppAlg<AlgTraits>::MomentumMassElemSuppAlg(
   Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
-  MasterElement* meSCV = realm.get_volume_master_element(AlgTraits::topo_);
+  MasterElement* meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
 
   // compute shape function
   if ( lumpedMass_ )

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -196,8 +196,8 @@ NonConformalInfo::construct_dgInfo_state()
     stk::topology currentElemTopo = parentTopo[0];
 
     // volume and surface master element
-    MasterElement *meSCS = realm_.get_surface_master_element(currentElemTopo);
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(currentElemTopo);
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
 
     // master element-specific values
     const int numScsBip = meFC->numIntPoints_;
@@ -412,7 +412,7 @@ NonConformalInfo::complete_search()
             
             // extract the topo from this face element...
             const stk::topology theFaceTopo = bulk_data.bucket(opposingFace).topology();
-            MasterElement *meFC = realm_.get_surface_master_element(theFaceTopo);
+            MasterElement *meFC = sierra::nalu::get_surface_master_element(theFaceTopo);
             
             // find distance between true current gauss point coords (the point) and the candidate bounding box
             const double nearestDistance = meFC->isInElement(&theElementCoords[0],
@@ -435,7 +435,7 @@ NonConformalInfo::complete_search()
               
               // extract the opposing element topo and associated master element
               const stk::topology theOpposingElementTopo = bulk_data.bucket(opposingElement).topology();
-              MasterElement *meSCS = realm_.get_surface_master_element(theOpposingElementTopo);
+              MasterElement *meSCS = sierra::nalu::get_surface_master_element(theOpposingElementTopo);
               dgInfo->meSCSOpposing_ = meSCS;
               dgInfo->opposingElementTopo_ = theOpposingElementTopo;
               dgInfo->opposingIsoParCoords_ = opposingIsoParCoords;

--- a/src/PstabErrorIndicatorElemAlgorithm.C
+++ b/src/PstabErrorIndicatorElemAlgorithm.C
@@ -99,7 +99,7 @@ PstabErrorIndicatorElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/ScalarAdvDiffElemSuppAlg.C
+++ b/src/ScalarAdvDiffElemSuppAlg.C
@@ -49,7 +49,7 @@ ScalarAdvDiffElemSuppAlg<AlgTraits>::ScalarAdvDiffElemSuppAlg(
     diffFluxCoeff_(diffFluxCoeff),
     coordinates_(NULL),
     massFlowRate_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -57,7 +57,7 @@ ScalarAdvDiffElemSuppAlg<AlgTraits>::ScalarAdvDiffElemSuppAlg(
   massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
   
   // add master elements

--- a/src/ScalarDiffElemSuppAlg.C
+++ b/src/ScalarDiffElemSuppAlg.C
@@ -48,14 +48,14 @@ ScalarDiffElemSuppAlg<AlgTraits>::ScalarDiffElemSuppAlg(
     scalarQ_(scalarQ),
     diffFluxCoeff_(diffFluxCoeff),
     coordinates_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
   
   // add master elements

--- a/src/ScalarMassElemSuppAlg.C
+++ b/src/ScalarMassElemSuppAlg.C
@@ -51,7 +51,7 @@ ScalarMassElemSuppAlg<AlgTraits>::ScalarMassElemSuppAlg(
     gamma2_(0.0),
     gamma3_(0.0),
     lumpedMass_(lumpedMass),
-    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   // save off fields; shove state N into Nm1 if this is BE
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -64,7 +64,7 @@ ScalarMassElemSuppAlg<AlgTraits>::ScalarMassElemSuppAlg(
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
-  MasterElement *meSCV = realm.get_volume_master_element(AlgTraits::topo_);
+  MasterElement *meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
 
   // compute shape function
   if ( lumpedMass_ )

--- a/src/ScalarUpwAdvDiffElemSuppAlg.C
+++ b/src/ScalarUpwAdvDiffElemSuppAlg.C
@@ -57,7 +57,7 @@ ScalarUpwAdvDiffElemSuppAlg<AlgTraits>::ScalarUpwAdvDiffElemSuppAlg(
     coordinates_(NULL),
     density_(NULL),
     massFlowRate_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     dofName_(scalarQ_->name()),
     alpha_(realm.get_alpha_factor(dofName_)),
     alphaUpw_(realm.get_alpha_upw_factor(dofName_)),
@@ -82,7 +82,7 @@ ScalarUpwAdvDiffElemSuppAlg<AlgTraits>::ScalarUpwAdvDiffElemSuppAlg(
   pecletFunction_ = eqSystem->create_peclet_function(scalarQ_->name());
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
   
   // add master elements

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -414,7 +414,7 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
      stk::topology theElemTopo = parentTopo[0];
 
      // extract master element
-     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+     MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
      const stk::mesh::Bucket::size_type length   = b.size();
 

--- a/src/SimpleErrorIndicatorElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorElemAlgorithm.C
@@ -85,7 +85,7 @@ SimpleErrorIndicatorElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/SimpleErrorIndicatorScalarElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorScalarElemAlgorithm.C
@@ -91,7 +91,7 @@ SimpleErrorIndicatorScalarElemAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -10,6 +10,7 @@
 #include <Algorithm.h>
 #include <EquationSystem.h>
 #include <LinearSystem.h>
+#include <SupplementalAlgorithm.h>
 
 #include <stk_mesh/base/Entity.hpp>
 
@@ -38,6 +39,13 @@ SolverAlgorithm::SolverAlgorithm(
     eqSystem_(eqSystem)
 {
   // does nothing
+}
+
+SolverAlgorithm::~SolverAlgorithm()
+{
+  std::vector<SupplementalAlgorithm *>::iterator ii;
+  for( ii=supplementalAlg_.begin(); ii!=supplementalAlg_.end(); ++ii )
+    delete *ii;
 }
 
 //--------------------------------------------------------------------------

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -10,7 +10,6 @@
 #include <Algorithm.h>
 #include <EquationSystem.h>
 #include <LinearSystem.h>
-#include <SupplementalAlgorithm.h>
 
 #include <stk_mesh/base/Entity.hpp>
 
@@ -39,13 +38,6 @@ SolverAlgorithm::SolverAlgorithm(
     eqSystem_(eqSystem)
 {
   // does nothing
-}
-
-SolverAlgorithm::~SolverAlgorithm()
-{
-  std::vector<SupplementalAlgorithm *>::iterator ii;
-  for( ii=supplementalAlg_.begin(); ii!=supplementalAlg_.end(); ++ii )
-    delete *ii;
 }
 
 //--------------------------------------------------------------------------

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -180,7 +180,7 @@ SurfaceForceAndMomentAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 
@@ -193,7 +193,7 @@ SurfaceForceAndMomentAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // extract master element for this element topo
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
 
     // algorithm related; element
     ws_pressure.resize(nodesPerFace);
@@ -430,7 +430,7 @@ SurfaceForceAndMomentAlgorithm::pre_work()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int numScsBip = meFC->numIntPoints_;
 
     // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -201,7 +201,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
 
@@ -440,7 +440,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::pre_work()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int numScsBip = meFC->numIntPoints_;
 
     // mapping from ip to nodes for this ordinal

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -580,7 +580,7 @@ TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & pa
     const stk::mesh::Bucket & b = *buckets[ib];
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
     // extract master element specifics
     const int numScsIp = meSCS->numIntPoints_;
     const int *lrscv = meSCS->adjacentNodes();

--- a/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
+++ b/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
@@ -113,7 +113,7 @@ AssembleMeshDisplacementElemSolverAlgorithm::execute()
     const stk::mesh::Bucket::size_type length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
+++ b/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
@@ -104,11 +104,11 @@ AssemblePressureForceBCSolverAlgorithm::execute()
     stk::topology theElemTopo = parentTopo[0];
 
     // volume master element
-    MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(theElemTopo);
     const int nodesPerElement = meSCS->nodesPerElement_;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
 
 

--- a/src/nso/MomentumNSOElemSuppAlg.C
+++ b/src/nso/MomentumNSOElemSuppAlg.C
@@ -59,7 +59,7 @@ MomentumNSOElemSuppAlg<AlgTraits>::MomentumNSOElemSuppAlg(
     coordinates_(NULL),
     viscosity_(viscosity),
     Gju_(Gju),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     dt_(0.0),
     gamma1_(0.0),
     gamma2_(0.0),
@@ -92,7 +92,7 @@ MomentumNSOElemSuppAlg<AlgTraits>::MomentumNSOElemSuppAlg(
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/src/nso/MomentumNSOKeElemSuppAlg.C
+++ b/src/nso/MomentumNSOKeElemSuppAlg.C
@@ -53,7 +53,7 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::MomentumNSOKeElemSuppAlg(
     coordinates_(NULL),
     Gju_(Gju),
     Gjp_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     Cupw_(0.1),
     small_(1.0e-16),
     fourthFac_(fourthFac)
@@ -75,7 +75,7 @@ MomentumNSOKeElemSuppAlg<AlgTraits>::MomentumNSOKeElemSuppAlg(
   Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
 
   // compute shape function
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/src/nso/MomentumNSOSijElemSuppAlg.C
+++ b/src/nso/MomentumNSOSijElemSuppAlg.C
@@ -50,7 +50,7 @@ MomentumNSOSijElemSuppAlg<AlgTraits>::MomentumNSOSijElemSuppAlg(
     velocityRTM_(NULL),
     coordinates_(NULL),
     Gjp_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     Cupw_(0.1),
     small_(1.0e-16),
     includeDivU_(realm_.get_divU())
@@ -72,7 +72,7 @@ MomentumNSOSijElemSuppAlg<AlgTraits>::MomentumNSOSijElemSuppAlg(
   Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
 
   // compute shape function
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/src/nso/ScalarNSOElemSuppAlg.C
+++ b/src/nso/ScalarNSOElemSuppAlg.C
@@ -58,7 +58,7 @@ ScalarNSOElemSuppAlg<AlgTraits>::ScalarNSOElemSuppAlg(
     velocityRTM_(NULL),
     Gjq_(Gjq),
     coordinates_(NULL),
-    lrscv_(realm.get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
+    lrscv_(sierra::nalu::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     dt_(0.0),
     gamma1_(0.0),
     gamma2_(0.0),
@@ -89,7 +89,7 @@ ScalarNSOElemSuppAlg<AlgTraits>::ScalarNSOElemSuppAlg(
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // compute shape function; do we want to push this to dataPreReqs?
-  MasterElement *meSCS = realm.get_surface_master_element(AlgTraits::topo_);
+  MasterElement *meSCS = sierra::nalu::get_surface_master_element(AlgTraits::topo_);
   meSCS->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -995,7 +995,7 @@ OversetManager::complete_search(
       }
       
       // extract master element
-      MasterElement *meSCS = realm_.get_surface_master_element(elementTopo);
+      MasterElement *meSCS = sierra::nalu::get_surface_master_element(elementTopo);
       const double nearestDistance = meSCS->isInElement(&elementCoords[0],
         &(orphanCoords[0]),
         &(isoParCoords[0]));

--- a/src/pmr/AssembleRadTransElemSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransElemSolverAlgorithm.C
@@ -134,8 +134,8 @@ AssembleRadTransElemSolverAlgorithm::execute()
     const size_t length   = b.size();
 
     // extract master element
-    MasterElement *meSCS = realm_.get_surface_master_element(b.topology());
-    MasterElement *meSCV = realm_.get_volume_master_element(b.topology());
+    MasterElement *meSCS = sierra::nalu::get_surface_master_element(b.topology());
+    MasterElement *meSCV = sierra::nalu::get_volume_master_element(b.topology());
 
     // extract master element specifics
     const int nodesPerElement = meSCS->nodesPerElement_;

--- a/src/pmr/AssembleRadTransWallSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransWallSolverAlgorithm.C
@@ -105,7 +105,7 @@ AssembleRadTransWallSolverAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
 
     // resize some things; matrix related

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -1275,7 +1275,7 @@ RadiativeTransportEquationSystem::assemble_irradiation()
     stk::mesh::Bucket & b = **ib ;
 
     // extract master element specifics
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsIp = meFC->numIntPoints_;
 

--- a/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemSuppAlg.C
@@ -44,7 +44,7 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSu
   ElemDataRequests& dataPreReqs)
   : SupplementalAlgorithm(realm),
     coordinates_(NULL),
-    ipNodeMap_(realm.get_volume_master_element(AlgTraits::topo_)->ipNodeMap()),
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap()),
     a_(1.0),
     k_(1.0),
     pi_(std::acos(-1.0))
@@ -54,7 +54,7 @@ SteadyThermal3dContactSrcElemSuppAlg<AlgTraits>::SteadyThermal3dContactSrcElemSu
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // compute shape function; possibly push this to dataPreReqs?
-  MasterElement *meSCV = realm.get_volume_master_element(AlgTraits::topo_);
+  MasterElement *meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
   meSCV->shape_fcn(&v_shape_function_(0,0));
 
   // add master elements

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -86,7 +86,7 @@ public:
     dataNeeded.add_gathered_nodal_field(*nodalPressureField, 1);
 
     // add the master element
-    sierra::nalu::MasterElement* meSCS = unit_test_utils::get_surface_master_element(topo);
+    sierra::nalu::MasterElement* meSCS = sierra::nalu::get_surface_master_element(topo);
     dataNeeded.add_cvfem_surface_me(meSCS);
   }
 

--- a/unit_tests/UnitTestKokkosUtils.h
+++ b/unit_tests/UnitTestKokkosUtils.h
@@ -16,7 +16,7 @@ void bucket_loop_serial_only(const stk::mesh::BucketVector& buckets, const OUTER
     {   
         const stk::mesh::Bucket& bkt = *bptr;
         stk::topology topo = bkt.topology();
-        sierra::nalu::MasterElement* meSCS = unit_test_utils::get_surface_master_element(topo);
+        sierra::nalu::MasterElement* meSCS = sierra::nalu::get_surface_master_element(topo);
 
         outer_loop_body(topo,*meSCS);
 
@@ -61,7 +61,7 @@ void kokkos_thread_team_bucket_loop_with_topo(const stk::mesh::BucketVector& buc
     {
         const stk::mesh::Bucket& bkt = *buckets[team.league_rank()];
         stk::topology topo = bkt.topology();
-        sierra::nalu::MasterElement* meSCS = unit_test_utils::get_surface_master_element(topo);
+        sierra::nalu::MasterElement* meSCS = sierra::nalu::get_surface_master_element(topo);
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& j)
         {
             inner_loop_body(bkt[j], topo, *meSCS);

--- a/unit_tests/UnitTestKokkosViews.C
+++ b/unit_tests/UnitTestKokkosViews.C
@@ -30,7 +30,7 @@ void find_max_nodes_and_ips(const stk::mesh::BucketVector& buckets,
   for(const stk::mesh::Bucket* bptr : buckets) {
     stk::topology topo = bptr->topology();
     maxNodesPerElement = std::max(maxNodesPerElement, (int)topo.num_nodes());
-    sierra::nalu::MasterElement *meSCS = unit_test_utils::get_surface_master_element(topo);
+    sierra::nalu::MasterElement *meSCS = sierra::nalu::get_surface_master_element(topo);
     maxScsIp = std::max(maxScsIp, meSCS->numIntPoints_);
     numEntities += bptr->size();
   }
@@ -307,7 +307,7 @@ public:
     {
         const stk::mesh::Bucket& bkt = *elemBuckets[team.league_rank()];
         stk::topology topo = bkt.topology();
-        sierra::nalu::MasterElement& meSCS = *unit_test_utils::get_surface_master_element(topo);
+        sierra::nalu::MasterElement& meSCS = *sierra::nalu::get_surface_master_element(topo);
 
         const int nodesPerElem = topo.num_nodes();
         const int numScsIp = meSCS.numIntPoints_;

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -304,8 +304,8 @@ protected:
       meta = std::unique_ptr<stk::mesh::MetaData>(new stk::mesh::MetaData(topo.dimension()));
       bulk = std::unique_ptr<stk::mesh::BulkData>(new stk::mesh::BulkData(*meta, comm));
       elem = unit_test_utils::create_one_reference_element(*bulk, topo);
-      meSS = unit_test_utils::get_surface_master_element(topo);
-      meSV = unit_test_utils::get_volume_master_element(topo);
+      meSS = sierra::nalu::get_surface_master_element(topo);
+      meSV = sierra::nalu::get_volume_master_element(topo);
     }
 
     void scs_interpolation(stk::topology topo) {

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -109,7 +109,7 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, topo);
 
-  auto* mescs = unit_test_utils::get_surface_master_element(topo);
+  auto* mescs = sierra::nalu::get_surface_master_element(topo);
 
   // apply some arbitrary linear map the reference element
   std::mt19937 rng;
@@ -155,7 +155,7 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, topo);
 
-  auto* mescs = unit_test_utils::get_surface_master_element(topo);
+  auto* mescs = sierra::nalu::get_surface_master_element(topo);
 
   // apply some arbitrary linear map the reference element
   std::mt19937 rng;

--- a/unit_tests/UnitTestSideNodeOrdinals.C
+++ b/unit_tests/UnitTestSideNodeOrdinals.C
@@ -6,7 +6,7 @@ namespace {
 
   void side_node_ordinals_are_same_as_stk(stk::topology topo)
   {
-    auto* me = unit_test_utils::get_surface_master_element(topo);
+    auto* me = sierra::nalu::get_surface_master_element(topo);
 
     for (unsigned side_ordinal = 0; side_ordinal < topo.num_sides(); ++side_ordinal) {
       int numSideNodes = topo.side_topology(side_ordinal).num_nodes();

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -114,7 +114,7 @@ public:
   
       //In this unit-test we know we're working on a hex8 mesh. In real algorithms,
       //a topology would be available.
-      dataNeededBySuppAlgs_.add_cvfem_surface_me(unit_test_utils::get_surface_master_element(stk::topology::HEX_8));
+      dataNeededBySuppAlgs_.add_cvfem_surface_me(sierra::nalu::get_surface_master_element(stk::topology::HEX_8));
 
       const int bytes_per_team = 0;
       const int bytes_per_thread = get_num_bytes_pre_req_data(dataNeededBySuppAlgs_, meta.spatial_dimension());

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -282,50 +282,6 @@ double quadratic(double a, const double* b, const double* H, const double* x)
   return (linear(a,b,x) + 0.5*quad);
 }
 
-sierra::nalu::MasterElement *
-get_surface_master_element(const stk::topology & theTopo)
-{
-  sierra::nalu::MasterElement *theElem = NULL;
-
-  static std::map<stk::topology, sierra::nalu::MasterElement*> s_topo_masterelem_map;
-
-  std::map<stk::topology, sierra::nalu::MasterElement *>::iterator it =
-    s_topo_masterelem_map.find(theTopo);
-  if ( it == s_topo_masterelem_map.end() ) {
-    theElem = sierra::nalu::MasterElement::create_surface_master_element(theTopo);
-    ThrowRequire(theElem != nullptr);
-
-    s_topo_masterelem_map[theTopo] = theElem;
-  }
-  else {
-    theElem = it->second;
-  }
-
-  return theElem;
-}
-
-sierra::nalu::MasterElement *
-get_volume_master_element(const stk::topology & theTopo)
-{
-  sierra::nalu::MasterElement *theElem = NULL;
-
-  static std::map<stk::topology, sierra::nalu::MasterElement*> s_topov_masterelem_map;
-
-  std::map<stk::topology, sierra::nalu::MasterElement *>::iterator it =
-    s_topov_masterelem_map.find(theTopo);
-  if ( it == s_topov_masterelem_map.end() ) {
-    theElem = sierra::nalu::MasterElement::create_volume_master_element(theTopo);
-    ThrowRequire(theElem != nullptr);
-
-    s_topov_masterelem_map[theTopo] = theElem;
-  }
-  else {
-    theElem = it->second;
-  }
-
-  return theElem;
-}
-
 #ifndef KOKKOS_HAVE_CUDA
 
 double initialize_linear_scalar_field(

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -35,13 +35,6 @@ double initialize_quadratic_scalar_field(const stk::mesh::BulkData& bulk,
                                       const VectorFieldType& coordField,
                                       const ScalarFieldType& qField);
 
-sierra::nalu::MasterElement *
-get_surface_master_element(const stk::topology & theTopo);
-
-sierra::nalu::MasterElement *
-get_volume_master_element(const stk::topology & theTopo);
-
-
 }
 
 const double tol = 1.e-10;


### PR DESCRIPTION
- Extract surface and volume `MasterElement` creation logic from `Realm` into free functions. 
- Move `supplementalAlg_` vector from `Algorithm` to `SolverAlgorithm` in preparation for future deprecation with `ComputationalKernel` redesign. 