### PR TITLE
Add input checking to turbulence model specification

### DIFF
--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -452,6 +452,9 @@ void operator >> (const YAML::Node& node, std::map<std::string,std::string>& map
 void operator >> (const YAML::Node& node, std::map<std::string,std::vector<std::string> >& mapName);
 void operator >> (const YAML::Node& node, std::map<std::string,std::vector<double> >& mapName);
 
+bool case_insensitive_compare(std::string s1, std::string s2);
+
+
 } // namespace nalu
 } // namespace Sierra
 

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -17,6 +17,8 @@
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
 #include <string>
+#include <cctype>
+#include <algorithm>
 
 namespace sierra{
   namespace nalu{
@@ -384,6 +386,13 @@ namespace sierra{
       }
   }
     
+
+
+  bool case_insensitive_compare(std::string s1, std::string s2){
+    std::transform(s1.begin(), s1.end(), s1.begin(), ::tolower);
+    std::transform(s2.begin(), s2.end(), s2.begin(), ::tolower);
+    return (s1 == s2);
+  }
     
   } // namespace nalu
 } // namespace Sierra
@@ -953,6 +962,8 @@ namespace YAML {
       
       return true;
     }
+
+
   
 }
   

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -160,11 +160,25 @@ SolutionOptions::load(const YAML::Node & y_node)
     std::string defaultTurbModel = "laminar";
     get_if_present(y_solution_options,
         "turbulence_model", specifiedTurbModel, defaultTurbModel);
+
+    bool matchedTurbulenceModel = false;
     for ( int k=0; k < TurbulenceModel_END; ++k ) {
-      if ( specifiedTurbModel == TurbulenceModelNames[k] ) {
+      if (case_insensitive_compare(specifiedTurbModel, TurbulenceModelNames[k])) {
         turbulenceModel_ = TurbulenceModel(k);
+        matchedTurbulenceModel = true;
         break;
       }
+    }
+
+    if (!matchedTurbulenceModel) {
+      std::string msg = "Turbulence model `" + specifiedTurbModel +
+          "' not implemented.\n  Available turbulence models are ";
+
+     for ( int k=0; k < TurbulenceModel_END; ++k ) {
+       msg += "`" + TurbulenceModelNames[k] + "'";
+       if ( k != TurbulenceModel_END-1) { msg += ", "; }
+     }
+      throw std::runtime_error(msg);
     }
     if ( turbulenceModel_ != LAMINAR ) {
       isTurbulent_ = true;


### PR DESCRIPTION
Case: a user says
`turbulence_model: smag`

Old behavior: code would run with a laminar model. (Incorrect name).

New behavior: throws
`` 
  what():  Turbulence model `smag' not implemented.
  Available turbulence models are `laminar', `ksgs', `smagorinsky', `wale', `sst', `sst_des'
``