### PR TITLE
Kokkos ScratchViews interface update

### DIFF
--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -94,9 +94,9 @@ public:
   void add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
 
   void add_coordinates_field(
-    const stk::mesh::FieldBase&,
+    const stk::mesh::FieldBase& field,
     unsigned scalarsPerNode,
-    COORDS_TYPES cType = CURRENT_COORDINATES);
+    COORDS_TYPES cType);
 
   void add_cvfem_volume_me(MasterElement *meSCV)
   {
@@ -108,11 +108,11 @@ public:
   }
 
   const std::set<ELEM_DATA_NEEDED>& get_data_enums(
-    const COORDS_TYPES cType = CURRENT_COORDINATES) const
+    const COORDS_TYPES cType) const
   { return dataEnums[cType]; }
 
   const stk::mesh::FieldBase* get_coordinates_field(
-    const COORDS_TYPES cType = CURRENT_COORDINATES) const
+    const COORDS_TYPES cType) const
   {
     auto it = coordsFields_.find(cType);
     ThrowRequireMsg(

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -89,7 +89,7 @@ public:
   SharedMemView<double****>& get_scratch_view_4D(const stk::mesh::FieldBase& field);
 
   inline
-  MasterElementViews& get_me_views(const COORDS_TYPES cType = CURRENT_COORDINATES)
+  MasterElementViews& get_me_views(const COORDS_TYPES cType)
   {
     ThrowRequire(hasCoordField[cType] == true);
     return meViews[cType];
@@ -111,9 +111,8 @@ private:
                                           int numScsIp, int numScvIp);
 
   std::vector<ViewHolder*> fieldViews;
-
-  std::vector<MasterElementViews> meViews;
-  std::vector<bool> hasCoordField;
+  MasterElementViews meViews[MAX_COORDS_TYPES];
+  bool hasCoordField[MAX_COORDS_TYPES] = {false, false};
   int num_bytes_required{0};
 };
 

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -72,8 +72,6 @@ AssembleElemSolverAlgorithm::execute()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
-  stk::mesh::FieldBase* coordField = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-
   // set any data
   const size_t activeKernelsSize = activeKernels_.size();
   for ( size_t i = 0; i < activeKernelsSize; ++i )
@@ -117,7 +115,7 @@ AssembleElemSolverAlgorithm::execute()
       // get element
       stk::mesh::Entity element = b[k];
       fill_pre_req_data(dataNeededBySuppAlgs_, bulk_data, topo_, element,
-                        coordField, prereqData);
+                        prereqData);
 
       // extract node relations and provide connected nodes
       stk::mesh::Entity const * node_rels = b.begin_nodes(k);

--- a/src/ContinuityAdvElemKernel.C
+++ b/src/ContinuityAdvElemKernel.C
@@ -61,18 +61,18 @@ ContinuityAdvElemKernel<AlgTraits>::ContinuityAdvElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(*pressure_, 1);
   dataPreReqs.add_gathered_nodal_field(*Gpdx_, AlgTraits::nDim_);
-  dataPreReqs.add_master_element_call(SCS_AREAV);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
 
   // manage dndx
   if ( !shiftPoisson_ || !reducedSensitivities_ )
-    dataPreReqs.add_master_element_call(SCS_GRAD_OP);
+    dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
   if ( shiftPoisson_ || reducedSensitivities_ )
-    dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP);
+    dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -102,12 +102,12 @@ ContinuityAdvElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_velocity = scratchViews.get_scratch_view_2D(*velocityRTM_);
   SharedMemView<double**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gpdx_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
 
   SharedMemView<double***>& v_dndx = shiftPoisson_ ?
-    scratchViews.get_me_views().dndx_shifted : scratchViews.get_me_views().dndx;
+    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted : scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
   SharedMemView<double***>& v_dndx_lhs = (!shiftPoisson_ && reducedSensitivities_)?
-    scratchViews.get_me_views().dndx_shifted : scratchViews.get_me_views().dndx;
+    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted : scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
     const int il = lrscv_[2*ip];

--- a/src/ContinuityAdvElemKernel.C
+++ b/src/ContinuityAdvElemKernel.C
@@ -61,7 +61,7 @@ ContinuityAdvElemKernel<AlgTraits>::ContinuityAdvElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(*pressure_, 1);
@@ -102,12 +102,12 @@ ContinuityAdvElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_velocity = scratchViews.get_scratch_view_2D(*velocityRTM_);
   SharedMemView<double**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gpdx_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
 
   SharedMemView<double***>& v_dndx = shiftPoisson_ ?
-    scratchViews.dndx_shifted : scratchViews.dndx;
+    scratchViews.get_me_views().dndx_shifted : scratchViews.get_me_views().dndx;
   SharedMemView<double***>& v_dndx_lhs = (!shiftPoisson_ && reducedSensitivities_)?
-    scratchViews.dndx_shifted : scratchViews.dndx;
+    scratchViews.get_me_views().dndx_shifted : scratchViews.get_me_views().dndx;
 
   for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
     const int il = lrscv_[2*ip];

--- a/src/ContinuityMassElemKernel.C
+++ b/src/ContinuityMassElemKernel.C
@@ -61,7 +61,7 @@ ContinuityMassElemKernel<AlgTraits>::ContinuityMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
@@ -99,7 +99,7 @@ ContinuityMassElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
     *densityNp1_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/ContinuityMassElemKernel.C
+++ b/src/ContinuityMassElemKernel.C
@@ -61,11 +61,11 @@ ContinuityMassElemKernel<AlgTraits>::ContinuityMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_master_element_call(SCV_VOLUME);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -99,7 +99,7 @@ ContinuityMassElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
     *densityNp1_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/ElemDataRequests.C
+++ b/src/ElemDataRequests.C
@@ -66,6 +66,15 @@ void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsi
   }
 }
 
+void ElemDataRequests::add_coordinates_field(
+  const stk::mesh::FieldBase& field,
+  unsigned scalarsPerNode,
+  COORDS_TYPES cType)
+{
+  coordsFields_[cType] = &field;
+  add_gathered_nodal_field(field, scalarsPerNode);
+}
+
 }
 }
 

--- a/src/MomentumAdvDiffElemKernel.C
+++ b/src/MomentumAdvDiffElemKernel.C
@@ -49,7 +49,7 @@ MomentumAdvDiffElemKernel<AlgTraits>::MomentumAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data; mdot not gathered as element data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocity, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
   dataPreReqs.add_master_element_call(SCS_AREAV);
@@ -71,8 +71,8 @@ MomentumAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<double*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/MomentumAdvDiffElemKernel.C
+++ b/src/MomentumAdvDiffElemKernel.C
@@ -49,11 +49,11 @@ MomentumAdvDiffElemKernel<AlgTraits>::MomentumAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data; mdot not gathered as element data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocity, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template<class AlgTraits>
@@ -71,8 +71,8 @@ MomentumAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<double*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/MomentumBuoyancySrcElemKernel.C
+++ b/src/MomentumBuoyancySrcElemKernel.C
@@ -51,7 +51,7 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::MomentumBuoyancySrcElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME);
 }
@@ -69,7 +69,7 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::execute(
   ScratchViews& scratchViews)
 {
   SharedMemView<double*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
-  SharedMemView<double*>& v_scv_volume = scratchViews.scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/MomentumBuoyancySrcElemKernel.C
+++ b/src/MomentumBuoyancySrcElemKernel.C
@@ -51,9 +51,9 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::MomentumBuoyancySrcElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_master_element_call(SCV_VOLUME);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
 template<class AlgTraits>
@@ -69,7 +69,7 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::execute(
   ScratchViews& scratchViews)
 {
   SharedMemView<double*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
-  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/MomentumMassElemKernel.C
+++ b/src/MomentumMassElemKernel.C
@@ -71,7 +71,7 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
@@ -79,7 +79,7 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   dataPreReqs.add_gathered_nodal_field(*velocityN_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
-  dataPreReqs.add_master_element_call(SCV_VOLUME);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -112,7 +112,7 @@ MomentumMassElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<double**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gjp_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/MomentumMassElemKernel.C
+++ b/src/MomentumMassElemKernel.C
@@ -71,7 +71,7 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
@@ -112,7 +112,7 @@ MomentumMassElemKernel<AlgTraits>::execute(
   SharedMemView<double**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<double**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gjp_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nearestNode = ipNodeMap_[ip];

--- a/src/ScalarAdvDiffElemKernel.C
+++ b/src/ScalarAdvDiffElemKernel.C
@@ -48,11 +48,11 @@ ScalarAdvDiffElemKernel<AlgTraits>::ScalarAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -70,8 +70,8 @@ ScalarAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/ScalarAdvDiffElemKernel.C
+++ b/src/ScalarAdvDiffElemKernel.C
@@ -48,7 +48,7 @@ ScalarAdvDiffElemKernel<AlgTraits>::ScalarAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
   dataPreReqs.add_master_element_call(SCS_AREAV);
@@ -70,8 +70,8 @@ ScalarAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/ScalarDiffElemKernel.C
+++ b/src/ScalarDiffElemKernel.C
@@ -47,7 +47,7 @@ ScalarDiffElemKernel<AlgTraits>::ScalarDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
   dataPreReqs.add_master_element_call(SCS_AREAV);
@@ -69,8 +69,8 @@ ScalarDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
 
   // start the assembly
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {

--- a/src/ScalarDiffElemKernel.C
+++ b/src/ScalarDiffElemKernel.C
@@ -47,11 +47,11 @@ ScalarDiffElemKernel<AlgTraits>::ScalarDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -69,8 +69,8 @@ ScalarDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   // start the assembly
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {

--- a/src/ScalarMassElemKernel.C
+++ b/src/ScalarMassElemKernel.C
@@ -69,14 +69,14 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*scalarQNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*scalarQN_, 1);
   dataPreReqs.add_gathered_nodal_field(*scalarQNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_master_element_call(SCV_VOLUME);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -114,7 +114,7 @@ ScalarMassElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(
     *densityNp1_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for ( int ip = 0; ip < AlgTraits::numScvIp_; ++ip ) {
 

--- a/src/ScalarMassElemKernel.C
+++ b/src/ScalarMassElemKernel.C
@@ -69,7 +69,7 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQNm1_, 1);
   dataPreReqs.add_gathered_nodal_field(*scalarQN_, 1);
   dataPreReqs.add_gathered_nodal_field(*scalarQNp1_, 1);
@@ -114,7 +114,7 @@ ScalarMassElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(
     *densityNp1_);
 
-  SharedMemView<double*>& v_scv_volume = scratchViews.scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
 
   for ( int ip = 0; ip < AlgTraits::numScvIp_; ++ip ) {
 

--- a/src/ScalarUpwAdvDiffElemKernel.C
+++ b/src/ScalarUpwAdvDiffElemKernel.C
@@ -73,13 +73,13 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
 
   // fields and data; mdot not gathered
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*Gjq, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQ, 1);
   dataPreReqs.add_gathered_nodal_field(*density_, 1);
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff, 1);
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -117,8 +117,8 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_density = scratchViews.get_scratch_view_1D(*density_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/ScalarUpwAdvDiffElemKernel.C
+++ b/src/ScalarUpwAdvDiffElemKernel.C
@@ -73,7 +73,7 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
 
   // fields and data; mdot not gathered
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjq, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQ, 1);
   dataPreReqs.add_gathered_nodal_field(*density_, 1);
@@ -117,8 +117,8 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_density = scratchViews.get_scratch_view_1D(*density_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
 
   // ip data for this element
   const double *mdot = stk::mesh::field_data(*massFlowRate_, element);

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -195,9 +195,6 @@ ScratchViews::ScratchViews(const TeamHandleType& team,
              const stk::mesh::BulkData& bulkData,
              stk::topology topo,
              ElemDataRequests& dataNeeded)
-  :
-    meViews(MAX_COORDS_TYPES),
-    hasCoordField(MAX_COORDS_TYPES,false)
 {
   /* master elements are allowed to be null if they are not required */
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -85,11 +85,119 @@ void gather_elem_node_field(const stk::mesh::FieldBase& field,
   }
 }
 
+int
+MasterElementViews::create_master_element_views(
+  const TeamHandleType& team,
+  const std::set<ELEM_DATA_NEEDED>& dataEnums,
+  int nDim, int nodesPerElem,
+  int numScsIp, int numScvIp)
+{
+  int numScalars = 0;
+  bool needDeriv = false;
+  bool needDetj = false;
+  for(ELEM_DATA_NEEDED data : dataEnums) {
+    switch(data)
+    {
+      case SCS_AREAV:
+         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
+         scs_areav = get_shmem_view_2D(team, numScsIp, nDim);
+         numScalars += numScsIp * nDim;
+         break;
+
+      case SCS_GRAD_OP:
+         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
+         dndx = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
+         numScalars += nodesPerElem * numScsIp * nDim;
+         needDeriv = true;
+         needDetj = true;
+         break;
+
+      case SCS_SHIFTED_GRAD_OP:
+        ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_GRAD_OP is requested.");
+        dndx_shifted = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
+        numScalars += nodesPerElem * numScsIp * nDim;
+        needDeriv = true;
+        needDetj = true;
+        break;
+
+      case SCS_GIJ:
+         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GIJ is requested.");
+         gijUpper = get_shmem_view_3D(team, numScsIp, nDim, nDim);
+         gijLower = get_shmem_view_3D(team, numScsIp, nDim, nDim);
+         numScalars += 2 * numScsIp * nDim * nDim;
+         needDeriv = true;
+         break;
+
+      case SCV_VOLUME:
+         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
+         scv_volume = get_shmem_view_1D(team, numScvIp);
+         numScalars += numScvIp;
+         break;
+
+      default: break;
+    }
+  }
+  if (needDeriv) {
+    deriv = get_shmem_view_1D(team, numScsIp*nodesPerElem*nDim);
+    numScalars += numScsIp * nodesPerElem * nDim;
+  }
+
+  if (needDetj) {
+    det_j = get_shmem_view_1D(team, numScsIp);
+    numScalars += numScsIp;
+  }
+
+  return numScalars;
+}
+
+void
+MasterElementViews::fill_master_element_views(
+  const std::set<ELEM_DATA_NEEDED>& dataEnums,
+  SharedMemView<double**>* coordsView,
+  MasterElement* meSCS,
+  MasterElement* meSCV)
+{
+  double error = 0.0;
+  for(ELEM_DATA_NEEDED data : dataEnums) {
+    switch(data)
+    {
+      case SCS_AREAV:
+         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+         meSCS->determinant(1, &((*coordsView)(0,0)), &scs_areav(0,0), &error);
+         break;
+      case SCS_GRAD_OP:
+         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+         meSCS->grad_op(1, &((*coordsView)(0,0)), &dndx(0,0,0), &deriv(0), &det_j(0), &error);
+         break;
+      case SCS_SHIFTED_GRAD_OP:
+        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+        meSCS->shifted_grad_op(1, &((*coordsView)(0,0)), &dndx_shifted(0,0,0), &deriv(0), &det_j(0), &error);
+        break;
+      case SCS_GIJ:
+         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
+         meSCS->gij(&((*coordsView)(0,0)), &gijUpper(0,0,0), &gijLower(0,0,0), &deriv(0));
+         break;
+      case SCV_VOLUME:
+         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
+         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
+         meSCV->determinant(1, &((*coordsView)(0,0)), &scv_volume(0), &error);
+         break;
+      default: break;
+    }
+  }
+}
+
 ScratchViews::ScratchViews(const TeamHandleType& team,
              const stk::mesh::BulkData& bulkData,
              stk::topology topo,
              ElemDataRequests& dataNeeded)
-  : elemNodes(nullptr), scs_areav(), dndx(), dndx_shifted(), deriv(), det_j(), scv_volume(), gijUpper(), gijLower()
+  :
+    meViews(MAX_COORDS_TYPES),
+    hasCoordField(MAX_COORDS_TYPES,false)
 {
   /* master elements are allowed to be null if they are not required */
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
@@ -163,59 +271,13 @@ void ScratchViews::create_needed_master_element_views(const TeamHandleType& team
                                         int numScsIp, int numScvIp)
 {
   int numScalars = 0;
-  bool needDeriv = false;
-  bool needDetj = false;
-  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
-  for(ELEM_DATA_NEEDED data : dataEnums) {
-    switch(data)
-    {
-      case SCS_AREAV:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
-         scs_areav = get_shmem_view_2D(team, numScsIp, nDim);
-         numScalars += numScsIp * nDim;
-         break;
 
-      case SCS_GRAD_OP:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
-         dndx = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numScsIp * nDim;
-         needDeriv = true;
-         needDetj = true;
-         break;
-
-      case SCS_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_GRAD_OP is requested.");
-        dndx_shifted = get_shmem_view_3D(team, numScsIp, nodesPerElem, nDim);
-        numScalars += nodesPerElem * numScsIp * nDim;
-        needDeriv = true;
-        needDetj = true;
-        break;
-
-      case SCS_GIJ:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GIJ is requested.");
-         gijUpper = get_shmem_view_3D(team, numScsIp, nDim, nDim);
-         gijLower = get_shmem_view_3D(team, numScsIp, nDim, nDim);
-         numScalars += 2 * numScsIp * nDim * nDim;
-         needDeriv = true;
-         break;
-
-      case SCV_VOLUME:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
-         scv_volume = get_shmem_view_1D(team, numScvIp);
-         numScalars += numScvIp;
-         break;
-
-      default: break;
-    }
-  }
-  if (needDeriv) {
-    deriv = get_shmem_view_1D(team, numScsIp*nodesPerElem*nDim);
-    numScalars += numScsIp * nodesPerElem * nDim;
-  }
-
-  if (needDetj) {
-    det_j = get_shmem_view_1D(team, numScsIp);
-    numScalars += numScsIp;
+  for (auto it = dataNeeded.get_coordinates_map().begin();
+       it != dataNeeded.get_coordinates_map().end(); ++it) {
+    hasCoordField[it->first] = true;
+    numScalars += meViews[it->first].create_master_element_views(
+      team, dataNeeded.get_data_enums(it->first),
+      nDim, nodesPerElem, numScsIp, numScvIp);
   }
 
   num_bytes_required += numScalars * sizeof(double);
@@ -239,20 +301,28 @@ int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)
     ThrowAssertMsg(fieldEntityRank == stk::topology::NODE_RANK || fieldEntityRank == stk::topology::ELEM_RANK, "Currently only node and element fields are supported.");
     unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
     unsigned entitiesPerElem = fieldEntityRank==stk::topology::ELEM_RANK ? 1 : nodesPerElem;
+
+    // Catch errors if user requests nodal field but has not registered any
+    // MasterElement we need to get nodesPerElem
+    ThrowRequire(entitiesPerElem > 0);
     if (fieldInfo.scalarsDim2 > 1) {
       scalarsPerEntity *= fieldInfo.scalarsDim2;
     }
     numBytes += entitiesPerElem*scalarsPerEntity*sizeof(double);
   }
   
-  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeededBySuppAlgs.get_data_enums();
-  int dndxLength = 0, gUpperLength = 0, gLowerLength = 0;
+  for (auto it = dataNeededBySuppAlgs.get_coordinates_map().begin();
+       it != dataNeededBySuppAlgs.get_coordinates_map().end(); ++it)
+  {
+    const std::set<ELEM_DATA_NEEDED>& dataEnums =
+      dataNeededBySuppAlgs.get_data_enums(it->first);
+    int dndxLength = 0, gUpperLength = 0, gLowerLength = 0;
 
-  // Updated logic for data sharing of deriv and det_j
-  bool needDeriv = false;
-  bool needDetj = false;
-  for(ELEM_DATA_NEEDED data : dataEnums) {
-    switch(data)
+    // Updated logic for data sharing of deriv and det_j
+    bool needDeriv = false;
+    bool needDetj = false;
+    for(ELEM_DATA_NEEDED data : dataEnums) {
+      switch(data)
       {
       case SCS_AREAV: numBytes += nDim * numScsIp * sizeof(double);
         break;
@@ -273,14 +343,15 @@ int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)
         break;
       default: break;
       }
+    }
+
+    if (needDeriv)
+      numBytes += nodesPerElem*numScsIp*nDim * sizeof(double);
+
+    if (needDetj)
+      numBytes += numScsIp * sizeof(double);
   }
 
-  if (needDeriv)
-    numBytes += nodesPerElem*numScsIp*nDim * sizeof(double);
-
-  if (needDetj)
-    numBytes += numScsIp * sizeof(double);
-  
   // Add a 64 byte padding to the buffer size requested
   return numBytes + 8 * sizeof(double);
 }
@@ -290,7 +361,6 @@ void fill_pre_req_data(
   const stk::mesh::BulkData& bulkData,
   stk::topology topo,
   stk::mesh::Entity elem,
-  const stk::mesh::FieldBase* coordField,
   ScratchViews& prereqData)
 {
   int nodesPerElem = topo.num_nodes();
@@ -344,44 +414,18 @@ void fill_pre_req_data(
       ThrowRequireMsg(false, "Only node and element fields supported currently.");
     }
   } 
-      
-  SharedMemView<double**>* coordsView = nullptr;
-  if (coordField != nullptr) {
-    coordsView = &prereqData.get_scratch_view_2D(*coordField);
-  }
 
-  const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums();
-  double error = 0;
-  for(ELEM_DATA_NEEDED data : dataEnums) {
-    switch(data)
-    {
-      case SCS_AREAV:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
-         meSCS->determinant(1, &((*coordsView)(0,0)), &prereqData.scs_areav(0,0), &error);
-         break;
-      case SCS_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
-         meSCS->grad_op(1, &((*coordsView)(0,0)), &prereqData.dndx(0,0,0), &prereqData.deriv(0), &prereqData.det_j(0), &error);
-         break;
-      case SCS_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
-        meSCS->shifted_grad_op(1, &((*coordsView)(0,0)), &prereqData.dndx_shifted(0,0,0), &prereqData.deriv(0), &prereqData.det_j(0), &error);
-        break;
-      case SCS_GIJ:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
-         meSCS->gij(&((*coordsView)(0,0)), &prereqData.gijUpper(0,0,0), &prereqData.gijLower(0,0,0), &prereqData.deriv(0));
-         break;
-      case SCV_VOLUME:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
-         meSCV->determinant(1, &((*coordsView)(0,0)), &prereqData.scv_volume(0), &error);
-         break;
-      default: break;
-    }
+
+  for (auto it = dataNeeded.get_coordinates_map().begin();
+       it != dataNeeded.get_coordinates_map().end(); ++it) {
+    auto cType = it->first;
+    auto coordField = it->second;
+
+    const std::set<ELEM_DATA_NEEDED>& dataEnums = dataNeeded.get_data_enums(cType);
+    SharedMemView<double**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
+    MasterElementViews& meData = prereqData.get_me_views(cType);
+
+    meData.fill_master_element_views(dataEnums, coordsView, meSCS, meSCV);
   }
 }
 

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -81,7 +81,7 @@ MomentumNSOElemKernel<AlgTraits>::MomentumNSOElemKernel(
 
   // fields
   dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocityNm1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityN_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
@@ -94,9 +94,9 @@ MomentumNSOElemKernel<AlgTraits>::MomentumNSOElemKernel(
   dataPreReqs.add_gathered_nodal_field(*pressure_,1);
 
   // master element data
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
-  dataPreReqs.add_master_element_call(SCS_GIJ);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GIJ, CURRENT_COORDINATES);
 
   // initialize kd
   for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
@@ -135,10 +135,10 @@ MomentumNSOElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views(CURRENT_COORDINATES).gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views(CURRENT_COORDINATES).gijLower;
 
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {
 

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -81,7 +81,7 @@ MomentumNSOElemKernel<AlgTraits>::MomentumNSOElemKernel(
 
   // fields
   dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNm1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityN_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
@@ -135,10 +135,10 @@ MomentumNSOElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
 
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {
 

--- a/src/nso/MomentumNSOKeElemKernel.C
+++ b/src/nso/MomentumNSOKeElemKernel.C
@@ -68,7 +68,7 @@ MomentumNSOKeElemKernel<AlgTraits>::MomentumNSOKeElemKernel(
 
   // fields
   dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
@@ -96,10 +96,10 @@ MomentumNSOKeElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
 
   // compute nodal ke
   for ( int n = 0; n < AlgTraits::nodesPerElement_; ++n ) {

--- a/src/nso/MomentumNSOKeElemKernel.C
+++ b/src/nso/MomentumNSOKeElemKernel.C
@@ -68,7 +68,7 @@ MomentumNSOKeElemKernel<AlgTraits>::MomentumNSOKeElemKernel(
 
   // fields
   dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
@@ -76,9 +76,9 @@ MomentumNSOKeElemKernel<AlgTraits>::MomentumNSOKeElemKernel(
   dataPreReqs.add_gathered_nodal_field(*pressure_,1);
 
   // master element data
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
-  dataPreReqs.add_master_element_call(SCS_GIJ);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GIJ, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -96,10 +96,10 @@ MomentumNSOKeElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views(CURRENT_COORDINATES).gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views(CURRENT_COORDINATES).gijLower;
 
   // compute nodal ke
   for ( int n = 0; n < AlgTraits::nodesPerElement_; ++n ) {

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -64,7 +64,7 @@ MomentumNSOSijElemKernel<AlgTraits>::MomentumNSOSijElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
@@ -91,10 +91,10 @@ MomentumNSOSijElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
 
   // compute nodal ke
   for ( int n = 0; n < AlgTraits::nodesPerElement_; ++n ) {

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -64,7 +64,7 @@ MomentumNSOSijElemKernel<AlgTraits>::MomentumNSOSijElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
@@ -72,9 +72,9 @@ MomentumNSOSijElemKernel<AlgTraits>::MomentumNSOSijElemKernel(
   dataPreReqs.add_gathered_nodal_field(*pressure_,1);
 
   // master element data
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
-  dataPreReqs.add_master_element_call(SCS_GIJ);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GIJ, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -91,10 +91,10 @@ MomentumNSOSijElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views(CURRENT_COORDINATES).gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views(CURRENT_COORDINATES).gijLower;
 
   // compute nodal ke
   for ( int n = 0; n < AlgTraits::nodesPerElement_; ++n ) {

--- a/src/nso/ScalarNSOElemKernel.C
+++ b/src/nso/ScalarNSOElemKernel.C
@@ -77,7 +77,7 @@ ScalarNSOElemKernel<AlgTraits>::ScalarNSOElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjq_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQNm1_, 1);
@@ -123,10 +123,10 @@ ScalarNSOElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
 
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {
 

--- a/src/nso/ScalarNSOElemKernel.C
+++ b/src/nso/ScalarNSOElemKernel.C
@@ -77,7 +77,7 @@ ScalarNSOElemKernel<AlgTraits>::ScalarNSOElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*Gjq_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*scalarQNm1_, 1);
@@ -90,9 +90,9 @@ ScalarNSOElemKernel<AlgTraits>::ScalarNSOElemKernel(
   dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_,1);
 
   // master element data
-  dataPreReqs.add_master_element_call(SCS_AREAV);
-  dataPreReqs.add_master_element_call(SCS_GRAD_OP);
-  dataPreReqs.add_master_element_call(SCS_GIJ);
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GIJ, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -123,10 +123,10 @@ ScalarNSOElemKernel<AlgTraits>::execute(
   SharedMemView<double*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<double*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
 
-  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views().scs_areav;
-  SharedMemView<double***>& v_dndx = scratchViews.get_me_views().dndx;
-  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views().gijUpper;
-  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views().gijLower;
+  SharedMemView<double**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<double***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
+  SharedMemView<double***>& v_gijUpper = scratchViews.get_me_views(CURRENT_COORDINATES).gijUpper;
+  SharedMemView<double***>& v_gijLower = scratchViews.get_me_views(CURRENT_COORDINATES).gijLower;
 
   for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {
 

--- a/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
@@ -48,7 +48,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::SteadyThermal3dContactSrcElemKer
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_gathered_nodal_field(*coordinates_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME);
 }
 
@@ -61,7 +61,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::execute(
   ScratchViews& scratchViews)
 {
   SharedMemView<double**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<double*>& v_scv_volume = scratchViews.scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
 
   // interpolate to ips and evaluate source
   for ( int ip = 0; ip < AlgTraits::numScvIp_; ++ip ) {

--- a/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
@@ -48,8 +48,8 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::SteadyThermal3dContactSrcElemKer
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_);
-  dataPreReqs.add_master_element_call(SCV_VOLUME);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
 template<typename AlgTraits>
@@ -61,7 +61,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::execute(
   ScratchViews& scratchViews)
 {
   SharedMemView<double**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views().scv_volume;
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   // interpolate to ips and evaluate source
   for ( int ip = 0; ip < AlgTraits::numScvIp_; ++ip ) {

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -35,8 +35,10 @@ void element_discrete_laplacian_kernel_3d(
     const int* lrscv = meSCS.adjacentNodes();
 
     sierra::nalu::SharedMemView<double*>& elemNodePressures = elemData.get_scratch_view_1D(*nodalPressureField);
-    sierra::nalu::SharedMemView<double**>& scs_areav = elemData.get_me_views().scs_areav;
-    sierra::nalu::SharedMemView<double***>& dndx = elemData.get_me_views().dndx;
+    sierra::nalu::SharedMemView<double**>& scs_areav =
+      elemData.get_me_views(sierra::nalu::CURRENT_COORDINATES).scs_areav;
+    sierra::nalu::SharedMemView<double***>& dndx =
+      elemData.get_me_views(sierra::nalu::CURRENT_COORDINATES).dndx;
     const stk::mesh::Entity* elemNodes = elemData.elemNodes;
 
     for (int ip = 0; ip < numScsIp; ++ip ) {
@@ -80,9 +82,12 @@ public:
   {
     //here are the element-data pre-requisites we want computed before
     //our elem_execute method is called.
-    dataNeeded.add_coordinates_field(*coordField, 3);
-    dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV);
-    dataNeeded.add_master_element_call(sierra::nalu::SCS_GRAD_OP);
+    dataNeeded.add_coordinates_field(*coordField, 3,
+                                     sierra::nalu::CURRENT_COORDINATES);
+    dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV,
+                                       sierra::nalu::CURRENT_COORDINATES);
+    dataNeeded.add_master_element_call(sierra::nalu::SCS_GRAD_OP,
+                                       sierra::nalu::CURRENT_COORDINATES);
     dataNeeded.add_gathered_nodal_field(*nodalPressureField, 1);
 
     // add the master element

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -132,7 +132,7 @@ public:
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
           {
              fill_pre_req_data(dataNeededBySuppAlgs_, bulkData_, topo,
-                               bkt[jj], nullptr, prereqData);
+                               bkt[jj], prereqData);
             
              for(SuppAlg* alg : suppAlgs_) {
                alg->elem_execute(topo, prereqData);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -317,7 +317,7 @@ void calc_mass_flow_rate_scs(
   auto meSCS = sierra::nalu::get_surface_master_element(topo);
 
   dataNeeded.add_cvfem_surface_me(meSCS);
-  dataNeeded.add_gathered_nodal_field(coordinates, ndim);
+  dataNeeded.add_coordinates_field(coordinates, ndim);
   dataNeeded.add_gathered_nodal_field(densityNp1, 1);
   dataNeeded.add_gathered_nodal_field(velocityNp1, ndim);
   dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV);
@@ -346,7 +346,7 @@ void calc_mass_flow_rate_scs(
         Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
           stk::mesh::Entity element = b[k];
           sierra::nalu::fill_pre_req_data(
-            dataNeeded, bulk, topo, element, &coordinates, preReqData);
+            dataNeeded, bulk, topo, element, preReqData);
 
           std::vector<double> rhoU(ndim);
           std::vector<double> v_shape_function(
@@ -355,7 +355,7 @@ void calc_mass_flow_rate_scs(
           double *mdot = stk::mesh::field_data(massFlowRate, element);
           auto& v_densityNp1 = preReqData.get_scratch_view_1D(densityNp1);
           auto& v_velocityNp1 = preReqData.get_scratch_view_2D(velocityNp1);
-          auto& v_scs_areav = preReqData.scs_areav;
+          auto& v_scs_areav = preReqData.get_me_views().scs_areav;
 
           for (int ip=0; ip < meSCS->numIntPoints_; ++ip) {
             for (int j=0; j < ndim; ++j) {

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -317,10 +317,11 @@ void calc_mass_flow_rate_scs(
   auto meSCS = sierra::nalu::get_surface_master_element(topo);
 
   dataNeeded.add_cvfem_surface_me(meSCS);
-  dataNeeded.add_coordinates_field(coordinates, ndim);
+  dataNeeded.add_coordinates_field(coordinates, ndim, sierra::nalu::CURRENT_COORDINATES);
   dataNeeded.add_gathered_nodal_field(densityNp1, 1);
   dataNeeded.add_gathered_nodal_field(velocityNp1, ndim);
-  dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV);
+  dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV,
+                                     sierra::nalu::CURRENT_COORDINATES);
 
   const stk::mesh::Selector selector =
     meta.locally_owned_part() | meta.globally_shared_part();
@@ -355,7 +356,8 @@ void calc_mass_flow_rate_scs(
           double *mdot = stk::mesh::field_data(massFlowRate, element);
           auto& v_densityNp1 = preReqData.get_scratch_view_1D(densityNp1);
           auto& v_velocityNp1 = preReqData.get_scratch_view_2D(velocityNp1);
-          auto& v_scs_areav = preReqData.get_me_views().scs_areav;
+          auto& v_scs_areav = preReqData.get_me_views(
+            sierra::nalu::CURRENT_COORDINATES).scs_areav;
 
           for (int ip=0; ip < meSCS->numIntPoints_; ++ip) {
             for (int j=0; j < ndim; ++j) {

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -201,7 +201,7 @@ public:
           Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
             stk::mesh::Entity element = b[k];
             sierra::nalu::fill_pre_req_data(
-              dataNeededByKernels_, bulk_, topo_, element, coordinates_, preReqData);
+              dataNeededByKernels_, bulk_, topo_, element, preReqData);
 
             for (int i=0; i < rhsSize; i++) {
               rhs_(i) = 0.0;

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -256,6 +256,8 @@ public:
   sierra::nalu::SharedMemView<double*> rhs_;
   sierra::nalu::SharedMemView<double**> lhs_;
 
+  const VectorFieldType* coordinates() const { return coordinates_; }
+
 private:
   const stk::mesh::BulkData& bulk_;
   const stk::mesh::PartVector& partVec_;


### PR DESCRIPTION
    - Refactor Scratchviews to handle current and model coordinates and
      the relationship with master element data.

    - Remove coordinates from fill_pre_req_data and use appropriate
      coordinates registered by the user to populate MasterElement view
      arrays.

    - Extend master element data registration and retrieval methods to
      indicate the coordinates field used to compute the relevant data.

    - Update all Kernels and UnitTests to adhere to new ScratchViews
      interface.