### PR TITLE
Activate stk-simd support in Trilinos configuration.

### DIFF
--- a/build/do-configTrilinos_debug
+++ b/build/do-configTrilinos_debug
@@ -63,6 +63,7 @@ cmake \
 -DTrilinos_ENABLE_Amesos:BOOL=OFF \
 -DTrilinos_ENABLE_Zoltan:BOOL=ON \
 -DTrilinos_ENABLE_STKMesh:BOOL=ON \
+-DTrilinos_ENABLE_STKSimd:BOOL=ON \
 -DTrilinos_ENABLE_STKIO:BOOL=ON \
 -DTrilinos_ENABLE_STKTransfer:BOOL=ON \
 -DTrilinos_ENABLE_STKSearch:BOOL=ON \

--- a/build/do-configTrilinos_release
+++ b/build/do-configTrilinos_release
@@ -63,6 +63,7 @@ cmake \
 -DTrilinos_ENABLE_Amesos:BOOL=OFF \
 -DTrilinos_ENABLE_Zoltan:BOOL=ON \
 -DTrilinos_ENABLE_STKMesh:BOOL=ON \
+-DTrilinos_ENABLE_STKSimd:BOOL=ON \
 -DTrilinos_ENABLE_STKIO:BOOL=ON \
 -DTrilinos_ENABLE_STKTransfer:BOOL=ON \
 -DTrilinos_ENABLE_STKSearch:BOOL=ON \


### PR DESCRIPTION
This is a pre-requisite for doing any simd work in nalu.

@spdomin what is the process, apart from changing these do-configTrilinos* files, for getting a configuration change pushed out across the nalu project?
