### PR TITLE
Add body force element source kernel

### DIFF
--- a/include/MomentumBodyForceSrcElemKernel.h
+++ b/include/MomentumBodyForceSrcElemKernel.h
@@ -1,0 +1,62 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef MOMENTUMBODYFORCESRCELEMKERNEL_H
+#define MOMENTUMBODYFORCESRCELEMKERNEL_H
+
+#include "Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+class ScratchViews;
+
+/** CMM BodyForce term for momentum equation (velocity DOF)
+ */
+template<typename AlgTraits>
+class MomentumBodyForceSrcElemKernel: public Kernel
+{
+public:
+  MomentumBodyForceSrcElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&);
+
+  virtual ~MomentumBodyForceSrcElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<double**>&,
+    SharedMemView<double*>&,
+    stk::mesh::Entity,
+    ScratchViews&);
+
+private:
+  MomentumBodyForceSrcElemKernel() = delete;
+
+  VectorFieldType *coordinates_{nullptr};
+
+  Kokkos::View<double[AlgTraits::nDim_]> v_body_force_{ "v_body_force"};
+
+  const int* ipNodeMap_;
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* MOMENTUMBODYFORCESRCELEMKERNEL_H */

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -97,6 +97,7 @@
 #include <ContinuityMassElemKernel.h>
 #include <MomentumAdvDiffElemKernel.h>
 #include <MomentumBuoyancySrcElemKernel.h>
+#include <MomentumBodyForceSrcElemKernel.h>
 #include <MomentumMassElemKernel.h>
 
 // nso
@@ -1184,6 +1185,11 @@ MomentumEquationSystem::register_interior_algorithm(
       build_topo_kernel_if_requested<MomentumNSOKeElemKernel>
         (partTopo, *this, activeKernels, "NSO_4TH_KE",
          realm_.bulk_data(), *realm_.solutionOptions_, velocity_, dudx_, 1.0, dataPreReqs);
+
+      // extract params for special kernels
+      build_topo_kernel_if_requested<MomentumBodyForceSrcElemKernel>
+        (partTopo, *this, activeKernels, "body_force",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs);
  
       report_invalid_supp_alg_names();
       report_built_supp_alg_names();

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1186,7 +1186,6 @@ MomentumEquationSystem::register_interior_algorithm(
         (partTopo, *this, activeKernels, "NSO_4TH_KE",
          realm_.bulk_data(), *realm_.solutionOptions_, velocity_, dudx_, 1.0, dataPreReqs);
 
-      // extract params for special kernels
       build_topo_kernel_if_requested<MomentumBodyForceSrcElemKernel>
         (partTopo, *this, activeKernels, "body_force",
          realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs);

--- a/src/MomentumBodyForceSrcElemKernel.C
+++ b/src/MomentumBodyForceSrcElemKernel.C
@@ -1,0 +1,85 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "MomentumBodyForceSrcElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<class AlgTraits>
+MomentumBodyForceSrcElemKernel<AlgTraits>::MomentumBodyForceSrcElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ElemDataRequests& dataPreReqs)
+  : Kernel(),
+    ipNodeMap_(sierra::nalu::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  auto isrc = solnOpts.srcTermParamMap_.find("body_force");
+  std::vector<double> theParams = (isrc != solnOpts.srcTermParamMap_.end()) ? isrc->second : std::vector<double>();
+  if (theParams.empty()) {
+    std::string msg = "Body force vector not set.  Must specify source_term_parameters for body force in input file";
+    throw std::runtime_error(msg);
+  }
+
+  ThrowRequireMsg(theParams.size() == AlgTraits::nDim_, "Body force vector has an incorrect number of components");
+  for (int j = 0; j < AlgTraits::nDim_; ++j) {
+    v_body_force_(j) = theParams[j];
+  }
+
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement* meSCV = sierra::nalu::get_volume_master_element(AlgTraits::topo_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+}
+
+template<class AlgTraits>
+MomentumBodyForceSrcElemKernel<AlgTraits>::~MomentumBodyForceSrcElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+MomentumBodyForceSrcElemKernel<AlgTraits>::execute(
+  SharedMemView<double**>& /* lhs */,
+  SharedMemView<double*>& rhs,
+  stk::mesh::Entity /*element*/,
+  ScratchViews& scratchViews)
+{
+  SharedMemView<double*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+    const int nearestNode = ipNodeMap_[ip];
+
+    const double scV = v_scv_volume(ip);
+    const int nnNdim = nearestNode * AlgTraits::nDim_;
+    for (int j=0; j < AlgTraits::nDim_; j++) {
+      rhs(nnNdim + j) += scV * v_body_force_(j);
+    }
+  }
+}
+INSTANTIATE_KERNEL(MomentumBodyForceSrcElemKernel);
+
+}  // nalu
+}  // sierra

--- a/unit_tests/kernels/UnitTestMomentumBodyForceSrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumBodyForceSrcElem.C
@@ -1,0 +1,58 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+
+#include "MomentumBodyForceSrcElemKernel.h"
+
+#include <random>
+
+TEST_F(MomentumKernelHex8Mesh, body_force)
+{
+  std::mt19937 rng;
+  rng.seed(0); // fixed seed
+  std::uniform_real_distribution<double> coeff(-1, +1);
+
+  fill_mesh_and_init_fields();
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+
+  std::vector<double> bfVec = { coeff(rng), coeff(rng), coeff(rng) };
+  solnOpts_.srcTermParamMap_.insert({"body_force", bfVec});
+
+  // Initialize the kernel driver
+  unit_test_kernel_utils::TestKernelDriver assembleKernels(
+    bulk_, partVec_, coordinates_, spatialDim_, stk::topology::HEX_8);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::MomentumBodyForceSrcElemKernel<sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, assembleKernels.dataNeededByKernels_));
+
+  // Add to kernels to be tested
+  assembleKernels.activeKernels_.push_back(kernel.get());
+
+  EXPECT_NO_THROW(assembleKernels.execute());
+
+  EXPECT_EQ(assembleKernels.lhs_.dimension(0), 24u);
+  EXPECT_EQ(assembleKernels.lhs_.dimension(1), 24u);
+  EXPECT_EQ(assembleKernels.rhs_.dimension(0), 24u);
+
+  // Exact solution
+  std::vector<double> rhsExact(24,0.0);
+  for (size_t i= 0; i < 24; i += 3) {
+    rhsExact[i + 0] = 0.125 * bfVec[0];
+    rhsExact[i + 1] = 0.125 * bfVec[1];
+    rhsExact[i + 2] = 0.125 * bfVec[2];
+  }
+
+  unit_test_kernel_utils::expect_all_near(assembleKernels.rhs_,rhsExact.data());
+}


### PR DESCRIPTION
Adds a consolidate approach kernel for computing the contribution of a specified body force with a consistent mass matrix

Activate like

>        - element_source_terms:
>            momentum: [momentum_time_derivative, advection_diffusion, body_force]
>            continuity: [density_time_derivative, advection]
>
>        - source_term_parameters:
>            body_force: [1.0,0.0,0.0]

