### PR TITLE
Transition wall function to a pure edge- or element-based implementation

### DIFF
--- a/include/AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.h
+++ b/include/AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.h
@@ -1,0 +1,64 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef AssembleMomentumEdgeABLWallFunctionSolverAlgorithm_h
+#define AssembleMomentumEdgeABLWallFunctionSolverAlgorithm_h
+
+#include<SolverAlgorithm.h>
+#include<FieldTypeDef.h>
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+}
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class AssembleMomentumEdgeABLWallFunctionSolverAlgorithm : public SolverAlgorithm
+{
+public:
+
+  AssembleMomentumEdgeABLWallFunctionSolverAlgorithm(
+    Realm &realm,
+    stk::mesh::Part *part,
+    EquationSystem *eqSystem,
+    const double &gravity,
+    const double &z0,
+    const double &Tref);
+  virtual ~AssembleMomentumEdgeABLWallFunctionSolverAlgorithm() {}
+  virtual void initialize_connectivity();
+  virtual void execute();
+
+  const double z0_;
+  const double Tref_;
+  const double gravity_;
+  const double alpha_h_;
+  const double beta_m_;
+  const double beta_h_;
+  const double gamma_m_;
+  const double gamma_h_;
+  const double kappa_;
+
+  VectorFieldType *velocity_;
+  VectorFieldType *bcVelocity_;
+  ScalarFieldType *bcHeatFlux_;
+  ScalarFieldType *density_;
+  ScalarFieldType *specificHeat_;
+  GenericFieldType *exposedAreaVec_;
+  GenericFieldType *wallFrictionVelocityBip_;
+  GenericFieldType *wallNormalDistanceBip_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/AssembleMomentumEdgeWallFunctionSolverAlgorithm.h
+++ b/include/AssembleMomentumEdgeWallFunctionSolverAlgorithm.h
@@ -1,0 +1,54 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef AssembleMomentumEdgeWallFunctionSolverAlgorithm_h
+#define AssembleMomentumEdgeWallFunctionSolverAlgorithm_h
+
+#include<SolverAlgorithm.h>
+#include<FieldTypeDef.h>
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+}
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class AssembleMomentumEdgeWallFunctionSolverAlgorithm : public SolverAlgorithm
+{
+public:
+
+  AssembleMomentumEdgeWallFunctionSolverAlgorithm(
+    Realm &realm,
+    stk::mesh::Part *part,
+    EquationSystem *eqSystem);
+  virtual ~AssembleMomentumEdgeWallFunctionSolverAlgorithm() {}
+  virtual void initialize_connectivity();
+  virtual void execute();
+
+  const double yplusCrit_;
+  const double elog_;
+  const double kappa_;
+
+  VectorFieldType *velocity_;
+  VectorFieldType *bcVelocity_;
+  ScalarFieldType *density_;
+  ScalarFieldType *viscosity_;
+  GenericFieldType *exposedAreaVec_;
+  GenericFieldType *wallFrictionVelocityBip_;
+  GenericFieldType *wallNormalDistanceBip_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/AssembleMomentumElemABLWallFunctionSolverAlgorithm.h
+++ b/include/AssembleMomentumElemABLWallFunctionSolverAlgorithm.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef AssembleMomentumABLWallFunctionSolverAlgorithm_h
-#define AssembleMomentumABLWallFunctionSolverAlgorithm_h
+#ifndef AssembleMomentumElemABLWallFunctionSolverAlgorithm_h
+#define AssembleMomentumElemABLWallFunctionSolverAlgorithm_h
 
 #include<SolverAlgorithm.h>
 #include<FieldTypeDef.h>
@@ -23,11 +23,11 @@ namespace nalu{
 
 class Realm;
 
-class AssembleMomentumABLWallFunctionSolverAlgorithm : public SolverAlgorithm
+class AssembleMomentumElemABLWallFunctionSolverAlgorithm : public SolverAlgorithm
 {
 public:
 
-  AssembleMomentumABLWallFunctionSolverAlgorithm(
+  AssembleMomentumElemABLWallFunctionSolverAlgorithm(
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
@@ -35,7 +35,7 @@ public:
     const double &gravity,
     const double &z0,
     const double &Tref);
-  virtual ~AssembleMomentumABLWallFunctionSolverAlgorithm() {}
+  virtual ~AssembleMomentumElemABLWallFunctionSolverAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
 

--- a/include/AssembleMomentumElemWallFunctionSolverAlgorithm.h
+++ b/include/AssembleMomentumElemWallFunctionSolverAlgorithm.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef AssembleMomentumWallFunctionSolverAlgorithm_h
-#define AssembleMomentumWallFunctionSolverAlgorithm_h
+#ifndef AssembleMomentumElemWallFunctionSolverAlgorithm_h
+#define AssembleMomentumElemWallFunctionSolverAlgorithm_h
 
 #include<SolverAlgorithm.h>
 #include<FieldTypeDef.h>
@@ -23,16 +23,16 @@ namespace nalu{
 
 class Realm;
 
-class AssembleMomentumWallFunctionSolverAlgorithm : public SolverAlgorithm
+class AssembleMomentumElemWallFunctionSolverAlgorithm : public SolverAlgorithm
 {
 public:
 
-  AssembleMomentumWallFunctionSolverAlgorithm(
+  AssembleMomentumElemWallFunctionSolverAlgorithm(
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
     const bool &useShifted);
-  virtual ~AssembleMomentumWallFunctionSolverAlgorithm() {}
+  virtual ~AssembleMomentumElemWallFunctionSolverAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
 

--- a/src/AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.C
@@ -1,0 +1,282 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+// nalu
+#include <AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.h>
+#include <SolverAlgorithm.h>
+#include <EquationSystem.h>
+#include <LinearSystem.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+#include <ABLProfileFunction.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// basic c++
+#include <cmath>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleMomentumEdgeABLWallFunctionSolverAlgorithm - ABL edge wall function
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleMomentumEdgeABLWallFunctionSolverAlgorithm::AssembleMomentumEdgeABLWallFunctionSolverAlgorithm(
+  Realm &realm,
+  stk::mesh::Part *part,
+  EquationSystem *eqSystem,
+  const double &gravity,
+  const double &z0,
+  const double &Tref)
+  : SolverAlgorithm(realm, part, eqSystem),
+    z0_(z0), 
+    Tref_(Tref), 
+    gravity_(gravity), 
+    alpha_h_(1.0), 
+    beta_m_(16.0), 
+    beta_h_(16.0),
+    gamma_m_(5.0),
+    gamma_h_(5.0),
+    kappa_(realm.get_turb_model_constant(TM_kappa))
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  bcHeatFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc");
+  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
+  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize_connectivity -----------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumEdgeABLWallFunctionSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildFaceToNodeGraph(partVec_);
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumEdgeABLWallFunctionSolverAlgorithm::execute()
+{
+
+  ABLProfileFunction *p_ABLProfFun;
+  StableABLProfileFunction StableProfFun(gamma_m_, gamma_h_);
+  UnstableABLProfileFunction UnstableProfFun(beta_m_, beta_h_);
+  NeutralABLProfileFunction NeutralProfFun;
+
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // space for LHS/RHS; nodesPerFace*nDim*nodesPerFace*nDim and nodesPerFace*nDim
+  std::vector<double> lhs;
+  std::vector<double> rhs;
+  std::vector<int> scratchIds;
+  std::vector<double> scratchVals;
+  std::vector<stk::mesh::Entity> connected_nodes;
+
+  // bip values
+  std::vector<double> uBip(nDim);
+  std::vector<double> uBcBip(nDim);
+  std::vector<double> unitNormal(nDim);
+
+  // pointers to fixed values
+  double *p_uBip = &uBip[0];
+  double *p_uBcBip = &uBcBip[0];
+  double *p_unitNormal= &unitNormal[0];
+
+  // deal with state
+  VectorFieldType &velocityNp1 = velocity_->field_of_state(stk::mesh::StateNP1);
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // face master element
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    // resize some things; matrix related
+    const int lhsSize = nodesPerFace*nDim*nodesPerFace*nDim;
+    const int rhsSize = nodesPerFace*nDim;
+    lhs.resize(lhsSize);
+    rhs.resize(rhsSize);
+    scratchIds.resize(rhsSize);
+    scratchVals.resize(rhsSize);
+    connected_nodes.resize(nodesPerFace);
+
+    // pointers
+    double *p_lhs = &lhs[0];
+    double *p_rhs = &rhs[0];
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // zero lhs/rhs
+      for ( int p = 0; p < lhsSize; ++p )
+        p_lhs[p] = 0.0;
+      for ( int p = 0; p < rhsSize; ++p )
+        p_rhs[p] = 0.0;
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      // fill connected nodes
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      for ( int ni = 0; ni < nodesPerFace; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+        connected_nodes[ni] = node;
+      }
+
+      // pointer to face data
+      const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      const double *wallNormalDistanceBip = stk::mesh::field_data(*wallNormalDistanceBip_, face);
+      const double *wallFrictionVelocityBip = stk::mesh::field_data(*wallFrictionVelocityBip_, face);
+
+      // loop over face nodes
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        const int offSetAveraVec = ip*nDim;
+  
+        // compute aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          const double axj = areaVec[offSetAveraVec+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // assign bip values, i.e., nearest node
+        const int localFaceNode = faceIpNodeMap[ip];
+        stk::mesh::Entity nodeR = face_node_rels[localFaceNode];
+
+        double heatFluxBip = *stk::mesh::field_data(*bcHeatFlux_, nodeR);
+        double rhoBip =  *stk::mesh::field_data(*density_, nodeR);
+        double CpBip =  *stk::mesh::field_data(*specificHeat_, nodeR);
+
+        for ( int j = 0; j < nDim; ++j ) {
+          const double *uNp1 = stk::mesh::field_data(velocityNp1, nodeR);
+          const double *uBc = stk::mesh::field_data(*bcVelocity_, nodeR);
+          p_uBip[j] = uNp1[j];
+          p_uBcBip[j] = uBc[j];
+        }
+
+        // form unit normal
+        for ( int j = 0; j < nDim; ++j ) {
+          p_unitNormal[j] = areaVec[offSetAveraVec+j]/aMag;
+        }
+
+        // extract bip data
+        const double yp = wallNormalDistanceBip[ip];
+        const double utau= wallFrictionVelocityBip[ip];
+
+        // determine lambda = tau_w / (rho * u_* * u_tan)
+        // NOTE:
+        // density should be obtained from the wall function for
+        // temperature and a relation rho = rho(T)
+        const double TfluxBip = heatFluxBip / (rhoBip * CpBip);
+
+        const double eps_heat_flux = 1.0e-8;
+        const double largenum = 1.0e8;
+        double Lfac;
+        if (TfluxBip < eps_heat_flux) {
+          p_ABLProfFun = &StableProfFun;
+        }
+        else if (TfluxBip > eps_heat_flux) {
+          p_ABLProfFun = &UnstableProfFun;
+        }
+        else {
+          p_ABLProfFun = &NeutralProfFun;
+        }
+        if (std::abs(TfluxBip) < eps_heat_flux) {
+          Lfac = largenum;
+        }
+        else {
+          Lfac = -Tref_ / (kappa_ * gravity_ * TfluxBip);
+        }
+        double L = utau*utau*utau * Lfac;
+        // limit the values of L...
+        //   to be negative and finite for q>0 (unstable)
+        //   to be positive and finite for q<0 (stable)
+        double sgnq = (TfluxBip > 0.0)?1.0:-1.0;
+        L = - sgnq * std::max(1.0e-10,std::abs(L));
+
+        //const double theta_star = -TfluxBip / utau;
+        //need TBip from temperature field - this is T(yp);
+        //const double Tsurf = TBip - theta_star/kappa_*(alpha_h_*std::log(yp/z0_) + gamma_h_*yp/L);
+        // evaluate rhosurf = f(Tsurf) and use rhosurf in place of rhoBip below
+        double lambda = rhoBip*kappa_*utau/(std::log(yp/z0_) - p_ABLProfFun->velocity(yp/L));
+
+        // start the lhs assembly
+        for ( int i = 0; i < nDim; ++i ) {
+
+          int indexR = localFaceNode*nDim + i;
+          int rowR = indexR*nodesPerFace*nDim;
+
+          double uiTan = 0.0;
+          double uiBcTan = 0.0;
+          for ( int j = 0; j < nDim; ++j ) {
+            const double ninj = p_unitNormal[i]*p_unitNormal[j];
+            if ( i==j ) {
+              const double om_nini = 1.0 - ninj;
+              uiTan += om_nini*p_uBip[j];
+              uiBcTan += om_nini*p_uBcBip[j];
+              p_lhs[rowR+localFaceNode*nDim+i] += lambda*om_nini;
+            }
+            else {
+              uiTan -= ninj*p_uBip[j];
+              uiBcTan -= ninj*p_uBcBip[j];
+              p_lhs[rowR+localFaceNode*nDim+j] -= lambda*ninj;
+            }
+          }
+          p_rhs[indexR] -= lambda*(uiTan-uiBcTan);
+        }
+      }
+      
+      apply_coeff(connected_nodes, scratchIds, scratchVals, rhs, lhs, __FILE__);
+      
+    }
+  }
+}
+
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/AssembleMomentumElemABLWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumElemABLWallFunctionSolverAlgorithm.C
@@ -7,7 +7,7 @@
 
 
 // nalu
-#include <AssembleMomentumABLWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumElemABLWallFunctionSolverAlgorithm.h>
 #include <SolverAlgorithm.h>
 #include <EquationSystem.h>
 #include <LinearSystem.h>
@@ -34,12 +34,12 @@ namespace nalu{
 //==========================================================================
 // Class Definition
 //==========================================================================
-// AssembleMomentumABLWallFunctionSolverAlgorithm - ABL utau at wall bc
+// AssembleMomentumElemABLWallFunctionSolverAlgorithm - ABL elem wall function
 //==========================================================================
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-AssembleMomentumABLWallFunctionSolverAlgorithm::AssembleMomentumABLWallFunctionSolverAlgorithm(
+AssembleMomentumElemABLWallFunctionSolverAlgorithm::AssembleMomentumElemABLWallFunctionSolverAlgorithm(
   Realm &realm,
   stk::mesh::Part *part,
   EquationSystem *eqSystem,
@@ -75,7 +75,7 @@ AssembleMomentumABLWallFunctionSolverAlgorithm::AssembleMomentumABLWallFunctionS
 //-------- initialize_connectivity -----------------------------------------
 //--------------------------------------------------------------------------
 void
-AssembleMomentumABLWallFunctionSolverAlgorithm::initialize_connectivity()
+AssembleMomentumElemABLWallFunctionSolverAlgorithm::initialize_connectivity()
 {
   eqSystem_->linsys_->buildFaceToNodeGraph(partVec_);
 }
@@ -84,7 +84,7 @@ AssembleMomentumABLWallFunctionSolverAlgorithm::initialize_connectivity()
 //-------- execute ---------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-AssembleMomentumABLWallFunctionSolverAlgorithm::execute()
+AssembleMomentumElemABLWallFunctionSolverAlgorithm::execute()
 {
 
   ABLProfileFunction *p_ABLProfFun;

--- a/src/AssembleMomentumElemWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumElemWallFunctionSolverAlgoirthm.C
@@ -1,0 +1,288 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+// nalu
+#include <AssembleMomentumElemWallFunctionSolverAlgorithm.h>
+#include <SolverAlgorithm.h>
+#include <EquationSystem.h>
+#include <LinearSystem.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// basic c++
+#include <cmath>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleMomentumElemWallFunctionSolverAlgorithm - elem wall function
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleMomentumElemWallFunctionSolverAlgorithm::AssembleMomentumElemWallFunctionSolverAlgorithm(
+  Realm &realm,
+  stk::mesh::Part *part,
+  EquationSystem *eqSystem,
+  const bool &useShifted)
+  : SolverAlgorithm(realm, part, eqSystem),
+    useShifted_(useShifted),
+    yplusCrit_(11.63),
+    elog_(9.8),
+    kappa_(realm.get_turb_model_constant(TM_kappa))
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize_connectivity -----------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumElemWallFunctionSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildFaceToNodeGraph(partVec_);
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMomentumElemWallFunctionSolverAlgorithm::execute()
+{
+
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // space for LHS/RHS; nodesPerFace*nDim*nodesPerFace*nDim and nodesPerFace*nDim
+  std::vector<double> lhs;
+  std::vector<double> rhs;
+  std::vector<int> scratchIds;
+  std::vector<double> scratchVals;
+  std::vector<stk::mesh::Entity> connected_nodes;
+
+  // bip values
+  std::vector<double> uBip(nDim);
+  std::vector<double> uBcBip(nDim);
+  std::vector<double> unitNormal(nDim);
+
+  // pointers to fixed values
+  double *p_uBip = &uBip[0];
+  double *p_uBcBip = &uBcBip[0];
+  double *p_unitNormal= &unitNormal[0];
+
+  // nodal fields to gather
+  std::vector<double> ws_velocityNp1;
+  std::vector<double> ws_bcVelocity;
+  std::vector<double> ws_density;
+  std::vector<double> ws_viscosity;
+
+  // master element
+  std::vector<double> ws_shape_function;
+  std::vector<double> ws_face_shape_function;
+
+  // deal with state
+  VectorFieldType &velocityNp1 = velocity_->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // face master element
+    MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->numIntPoints_;
+
+    // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)
+    const int *faceIpNodeMap = meFC->ipNodeMap();
+
+    // resize some things; matrix related
+    const int lhsSize = nodesPerFace*nDim*nodesPerFace*nDim;
+    const int rhsSize = nodesPerFace*nDim;
+    lhs.resize(lhsSize);
+    rhs.resize(rhsSize);
+    scratchIds.resize(rhsSize);
+    scratchVals.resize(rhsSize);
+    connected_nodes.resize(nodesPerFace);
+
+    // algorithm related; element
+    ws_velocityNp1.resize(nodesPerFace*nDim);
+    ws_bcVelocity.resize(nodesPerFace*nDim);
+    ws_density.resize(nodesPerFace);
+    ws_viscosity.resize(nodesPerFace);
+    ws_face_shape_function.resize(numScsBip*nodesPerFace);
+
+    // pointers
+    double *p_lhs = &lhs[0];
+    double *p_rhs = &rhs[0];
+    double *p_velocityNp1 = &ws_velocityNp1[0];
+    double *p_bcVelocity = &ws_bcVelocity[0];
+    double *p_density = &ws_density[0];
+    double *p_viscosity = &ws_viscosity[0];
+    double *p_face_shape_function = &ws_face_shape_function[0];
+
+    // shape functions
+    if ( useShifted_ )
+      meFC->shifted_shape_fcn(&p_face_shape_function[0]);
+    else
+      meFC->shape_fcn(&p_face_shape_function[0]);
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // zero lhs/rhs
+      for ( int p = 0; p < lhsSize; ++p )
+        p_lhs[p] = 0.0;
+      for ( int p = 0; p < rhsSize; ++p )
+        p_rhs[p] = 0.0;
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      for ( int ni = 0; ni < nodesPerFace; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+        connected_nodes[ni] = node;
+
+        // gather scalars
+        p_density[ni]    = *stk::mesh::field_data(densityNp1, node);
+        p_viscosity[ni] = *stk::mesh::field_data(*viscosity_, node);
+
+        // gather vectors
+        double * uNp1 = stk::mesh::field_data(velocityNp1, node);
+        double * uBc = stk::mesh::field_data(*bcVelocity_, node);
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_velocityNp1[offSet+j] = uNp1[j];
+          p_bcVelocity[offSet+j] = uBc[j];
+        }
+      }
+
+      // pointer to face data
+      const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      const double *wallNormalDistanceBip = stk::mesh::field_data(*wallNormalDistanceBip_, face);
+      const double *wallFrictionVelocityBip = stk::mesh::field_data(*wallFrictionVelocityBip_, face);
+
+      // loop over face nodes
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        const int offSetAveraVec = ip*nDim;
+        const int offSetSF_face = ip*nodesPerFace;
+
+        const int localFaceNode = faceIpNodeMap[ip];
+
+        // zero out vector quantities; squeeze in aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          p_uBip[j] = 0.0;
+          p_uBcBip[j] = 0.0;
+          const double axj = areaVec[offSetAveraVec+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // interpolate to bip
+        double rhoBip = 0.0;
+        double muBip = 0.0;
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const double r = p_face_shape_function[offSetSF_face+ic];
+          rhoBip += r*p_density[ic];
+          muBip += r*p_viscosity[ic];
+          const int offSetFN = ic*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            p_uBip[j] += r*p_velocityNp1[offSetFN+j];
+            p_uBcBip[j] += r*p_bcVelocity[offSetFN+j];
+          }
+        }
+
+        // form unit normal
+        for ( int j = 0; j < nDim; ++j ) {
+          p_unitNormal[j] = areaVec[offSetAveraVec+j]/aMag;
+        }
+
+        // extract bip data
+        const double yp = wallNormalDistanceBip[ip];
+        const double utau= wallFrictionVelocityBip[ip];
+
+        // determine yplus
+        const double yplus = rhoBip*yp*utau/muBip;
+
+        double lambda = muBip/yp*aMag;
+        if ( yplus > yplusCrit_)
+          lambda = rhoBip*kappa_*utau/std::log(elog_*yplus)*aMag;
+
+        // start the lhs assembly
+        for ( int i = 0; i < nDim; ++i ) {
+
+          int indexR = localFaceNode*nDim + i;
+          int rowR = indexR*nodesPerFace*nDim;
+
+          double uiTan = 0.0;
+          double uiBcTan = 0.0;
+          for ( int j = 0; j < nDim; ++j ) {
+            const double ninj = p_unitNormal[i]*p_unitNormal[j];
+            if ( i==j ) {
+              const double om_nini = 1.0 - ninj;
+              uiTan += om_nini*p_uBip[j];
+              uiBcTan += om_nini*p_uBcBip[j];
+              for (int ic = 0; ic < nodesPerFace; ++ic)
+                p_lhs[rowR+ic*nDim+i] += lambda*om_nini*p_face_shape_function[offSetSF_face+ic];
+            }
+            else {
+              uiTan -= ninj*p_uBip[j];
+              uiBcTan -= ninj*p_uBcBip[j];
+              for (int ic = 0; ic < nodesPerFace; ++ic)
+                p_lhs[rowR+ic*nDim+j] -= lambda*ninj*p_face_shape_function[offSetSF_face+ic];
+            }
+          }
+          p_rhs[indexR] -= lambda*(uiTan-uiBcTan);
+        }
+      }
+
+      apply_coeff(connected_nodes, scratchIds, scratchVals, rhs, lhs, __FILE__);
+
+    }
+  }
+}
+
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -22,8 +22,10 @@
 #include <AssembleMomentumElemOpenSolverAlgorithm.h>
 #include <AssembleMomentumEdgeSymmetrySolverAlgorithm.h>
 #include <AssembleMomentumElemSymmetrySolverAlgorithm.h>
-#include <AssembleMomentumWallFunctionSolverAlgorithm.h>
-#include <AssembleMomentumABLWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumEdgeWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumElemWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumElemABLWallFunctionSolverAlgorithm.h>
+#include <AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.h>
 #include <AssembleMomentumNonConformalSolverAlgorithm.h>
 #include <AssembleNodalGradAlgorithmDriver.h>
 #include <AssembleNodalGradEdgeAlgorithm.h>
@@ -1718,8 +1720,15 @@ MomentumEquationSystem::register_wall_bc(
       std::map<AlgorithmType, SolverAlgorithm *>::iterator it_wf =
         solverAlgDriver_->solverAlgMap_.find(wfAlgType);
       if ( it_wf == solverAlgDriver_->solverAlgMap_.end() ) {
-        AssembleMomentumABLWallFunctionSolverAlgorithm *theAlg
-          = new AssembleMomentumABLWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_, grav, z0, referenceTemperature);
+        SolverAlgorithm *theAlg = NULL;
+        if ( realm_.realmUsesEdges_ ) {
+          theAlg = new AssembleMomentumEdgeABLWallFunctionSolverAlgorithm(realm_, part, this, 
+                                                                          grav, z0, referenceTemperature);
+        }
+        else {
+          theAlg = new AssembleMomentumElemABLWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_, 
+                                                                          grav, z0, referenceTemperature);     
+        }
         solverAlgDriver_->solverAlgMap_[wfAlgType] = theAlg;
       }
       else {
@@ -1747,8 +1756,13 @@ MomentumEquationSystem::register_wall_bc(
       std::map<AlgorithmType, SolverAlgorithm *>::iterator it_wf =
         solverAlgDriver_->solverAlgMap_.find(wfAlgType);
       if ( it_wf == solverAlgDriver_->solverAlgMap_.end() ) {
-        AssembleMomentumWallFunctionSolverAlgorithm *theAlg
-          = new AssembleMomentumWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_);
+        SolverAlgorithm *theAlg = NULL;
+        if ( realm_.realmUsesEdges_ ) {
+          theAlg = new AssembleMomentumEdgeWallFunctionSolverAlgorithm(realm_, part, this);
+        }
+        else {
+          theAlg = new AssembleMomentumElemWallFunctionSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_);
+        }
         solverAlgDriver_->solverAlgMap_[wfAlgType] = theAlg;
       }
       else {


### PR DESCRIPTION
* convert standard wall function flavor

* convert ABL wall function flavor

Notes:

a) The motivation of this push is to increment towards allowing the
element-based scheme to assemble the pressure gradient term within
interior and boundary contributions rather than applying a nodal source
term in time. With this commit, all adv/diff edge- and element-based matrix
contributions are in seperate implementations. The next step will be to add
a total advection term to Elem-based algoirthms, i.e., rho*ui*uj + p*del_ij