### PR TITLE
Fix segfault in Continuity Advection Kernel

### DIFF
--- a/src/ContinuityAdvElemKernel.C
+++ b/src/ContinuityAdvElemKernel.C
@@ -105,7 +105,7 @@ ContinuityAdvElemKernel<AlgTraits>::execute(
 
   SharedMemView<double***>& v_dndx = shiftPoisson_ ?
     scratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted : scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
-  SharedMemView<double***>& v_dndx_lhs = (!shiftPoisson_ && reducedSensitivities_)?
+  SharedMemView<double***>& v_dndx_lhs = (shiftPoisson_ || reducedSensitivities_)?
     scratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted : scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
 
   for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {

--- a/unit_tests/kernels/UnitTestContinuityAdvElem.C
+++ b/unit_tests/kernels/UnitTestContinuityAdvElem.C
@@ -137,3 +137,45 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_sens_cvfem_poisson)
   unit_test_kernel_utils::expect_all_near(assembleKernels.rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(assembleKernels.lhs_, gold_values::lhs);
 }
+
+/// Continuity advection kernel
+///
+/// `shift_cvfem_poisson: true`
+///
+TEST_F(ContinuityKernelHex8Mesh, advection_reduced_shift_cvfem_poisson)
+{
+  fill_mesh_and_init_fields();
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.cvfemShiftMdot_ = false;
+  solnOpts_.cvfemShiftPoisson_ = true;
+  solnOpts_.cvfemReducedSensPoisson_ = true;
+  solnOpts_.mdotInterpRhoUTogether_ = true;
+
+  // Initialize the kernel driver
+  unit_test_kernel_utils::TestKernelDriver assembleKernels(
+    bulk_, partVec_, coordinates_, 1, stk::topology::HEX_8);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> advKernel(
+    new sierra::nalu::ContinuityAdvElemKernel<sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, assembleKernels.dataNeededByKernels_));
+
+  // Register the kernel for execution
+  assembleKernels.activeKernels_.push_back(advKernel.get());
+
+  // Populate LHS and RHS
+  assembleKernels.execute();
+
+  EXPECT_EQ(assembleKernels.lhs_.dimension(0), 8u);
+  EXPECT_EQ(assembleKernels.lhs_.dimension(1), 8u);
+  EXPECT_EQ(assembleKernels.rhs_.dimension(0), 8u);
+
+  namespace gold_values = hex8_golds::advection_reduced_sensitivities;
+
+  unit_test_kernel_utils::expect_all_near(assembleKernels.rhs_, gold_values::rhs);
+  unit_test_kernel_utils::expect_all_near<8>(assembleKernels.lhs_, gold_values::lhs);
+}


### PR DESCRIPTION
- The logic for `shift_cvfem_poisson = true` was not reflected correctly
in advection kernel and caused a segfault accessing ME views that
weren't registered in construction phase.

- Added a unit test to test this flag. 

Proposed fix for #143. 