### PR TITLE
Shifted pyr fix at exposed bcs that are of type tri3

### DIFF
--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -3939,13 +3939,13 @@ void PyrSCS::shifted_face_grad_op(
   const int npf = (face_ordinal < 4 ) ? 3 : 4;
 
   // quad4 is the only face that can be safely shifted
-  const double *p_intgExp = (face_ordinal < 4 ) ? &intgExpFace_[0] ? &intgExpFaceShift_[0];
+  const double *p_intgExp = (face_ordinal < 4 ) ? &intgExpFace_[0] : &intgExpFaceShift_[0];
   for ( int n=0; n<nelem; n++ ) {
 
     for ( int k=0; k<npf; k++ ) {
 
       const int row = 9*face_ordinal + k*ndim;
-      pyr_derivative(nface, p_intgExp[row], dpsi);
+      pyr_derivative(nface, &p_intgExp[row], dpsi);
 
       SIERRA_FORTRAN(pyr_gradient_operator)
         ( &nface,

--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -3938,12 +3938,14 @@ void PyrSCS::shifted_face_grad_op(
   // ordinal four is a quad4
   const int npf = (face_ordinal < 4 ) ? 3 : 4;
 
+  // quad4 is the only face that can be safely shifted
+  const double *p_intgExp = (face_ordinal < 4 ) ? &intgExpFace_[0] ? &intgExpFaceShift_[0];
   for ( int n=0; n<nelem; n++ ) {
 
     for ( int k=0; k<npf; k++ ) {
 
       const int row = 9*face_ordinal + k*ndim;
-      pyr_derivative(nface, &intgExpFaceShift_[row], dpsi);
+      pyr_derivative(nface, p_intgExp[row], dpsi);
 
       SIERRA_FORTRAN(pyr_gradient_operator)
         ( &nface,


### PR DESCRIPTION
I think that this commit should be populated ASAP. Specifically, we know that detJ is off a tri3 surfaces of a pyramid when the shifted operator is applied at the bcs.

While we sort out shifting for pyramids in general, this push should be applied.