### PR TITLE
Add fix for detJ at Pyr5SCS::shifted_face_grad_op

### DIFF
--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -3938,12 +3938,14 @@ void PyrSCS::shifted_face_grad_op(
   // ordinal four is a quad4
   const int npf = (face_ordinal < 4 ) ? 3 : 4;
 
+  // quad4 is the only face that can be safely shifted
+  const double *p_intgExp = (face_ordinal < 4 ) ? &intgExpFace_[0] : &intgExpFaceShift_[0];
   for ( int n=0; n<nelem; n++ ) {
 
     for ( int k=0; k<npf; k++ ) {
 
       const int row = 9*face_ordinal + k*ndim;
-      pyr_derivative(nface, &intgExpFaceShift_[row], dpsi);
+      pyr_derivative(nface, &p_intgExp[row], dpsi);
 
       SIERRA_FORTRAN(pyr_gradient_operator)
         ( &nface,


### PR DESCRIPTION
As we wait and learn more about shifting gradient_operators for wedges and, especially, pyramids, we know that Pyr5::Tri3 faces at exposed surfaces have a zero detJ at the apex node. 

This pull request manages this as we learn how to proceed.