### PR TITLE
Update header file locations of STK fixtures.

### DIFF
--- a/unit_tests/UnitTestHexElementPromotion.C
+++ b/unit_tests/UnitTestHexElementPromotion.C
@@ -12,8 +12,8 @@
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
-#include <stk_mesh/fixtures/HexFixture.hpp>
 #include <stk_mesh/base/SkinMesh.hpp>
+#include <stk_unit_tests/stk_mesh_fixtures/HexFixture.hpp>
 
 #include <element_promotion/MasterElementHO.h>
 #include <element_promotion/PromotedPartHelper.h>

--- a/unit_tests/UnitTestHexElementPromotion.C
+++ b/unit_tests/UnitTestHexElementPromotion.C
@@ -12,8 +12,8 @@
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
-#include <stk_mesh/base/SkinMesh.hpp>
 #include <stk_unit_tests/stk_mesh_fixtures/HexFixture.hpp>
+#include <stk_mesh/base/SkinMesh.hpp>
 
 #include <element_promotion/MasterElementHO.h>
 #include <element_promotion/PromotedPartHelper.h>

--- a/unit_tests/UnitTestQuadElementPromotion.C
+++ b/unit_tests/UnitTestQuadElementPromotion.C
@@ -11,7 +11,7 @@
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
-#include <stk_mesh/fixtures/QuadFixture.hpp>
+#include <stk_unit_tests/stk_mesh_fixtures/QuadFixture.hpp>
 #include <stk_mesh/base/SkinMesh.hpp>
 
 #include <element_promotion/MasterElementHO.h>


### PR DESCRIPTION
This should fix the errors involving the change of STK header file locations in Trilinos once the fix in https://github.com/trilinos/Trilinos/issues/1433 is merged. Probably doesn't make much difference if we merge this PR now or after the Trilinos fix is merged.