### PR TITLE
WIP. Added NGP Hex8SCS class

### DIFF
--- a/include/master_element/ngp/hex8/Hex8SCS.h
+++ b/include/master_element/ngp/hex8/Hex8SCS.h
@@ -1,0 +1,50 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef Hex8SCS_h
+#define Hex8SCS_h
+
+#include "master_element/MasterElement.h"
+#include "SimdInterface.h"
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra{
+namespace nalu{
+
+// Hex 8 SCS; -1.0/2 : 1.0/2 range
+class Hex8SCS : public HexSCS
+{
+public:
+
+  Hex8SCS();
+  virtual ~Hex8SCS();
+
+  void shape_fcn(
+    SharedMemView<DoubleType**> &shpfc);
+
+  void shifted_shape_fcn(
+    SharedMemView<DoubleType**> &shpfc);
+
+private:
+
+  void hex8_shape_fcn(
+    const int  &numIp,
+    const double *isoParCoord,
+    SharedMemView<DoubleType**> &shpfc);
+
+  void hex8_derivative(
+    const int npt, 
+    const double* par_coord,
+    SharedMemView<DoubleType*8*> &deriv);
+};
+    
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/master_element/ngp/hex8/Hex8SCS.C
+++ b/src/master_element/ngp/hex8/Hex8SCS.C
@@ -1,0 +1,144 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include "master_element/ngp/hex8/Hex8SCS.h"
+#include "master_element/MasterElement.h"
+#include "AlgTraits.h"
+#include "NaluEnv.h"
+
+#include <cmath>
+#include <limits>
+
+namespace sierra{
+namespace nalu{
+
+
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+Hex8SCS::Hex8SCS()
+  : HexSCS()
+{
+  // nothing to do as it is all in HexSCS
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+Hex8SCS::~Hex8SCS()
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- hex8_derivative -------------------------------------------------
+//--------------------------------------------------------------------------
+void Hex8SCS::hex8_derivative(
+  const int npts,
+  SharedMemView<DoubleType**> &intgLoc,
+  SharedMemView<DoubleType***> &deriv)
+{
+  const double half = 0.50;
+  const double one4th = 0.25;
+  for (int  j = 0; j < npts; ++j) {
+
+    const double s1 = intgLoc_(j,0);
+    const double s2 = intgLoc_(j,1);
+    const double s3 = intgLoc_(j,2);
+    const double s1s2 = s1*s2;
+    const double s2s3 = s2*s3;
+    const double s1s3 = s1*s3;
+
+    // shape function derivative in the s1 direction -
+    deriv(j,0,0) = half*( s3 + s2 ) - s2s3 - one4th;
+    deriv(j,1,0) = half*(-s3 - s2 ) + s2s3 + one4th;
+    deriv(j,2,0) = half*(-s3 + s2 ) - s2s3 + one4th;
+    deriv(j,3,0) = half*(+s3 - s2 ) + s2s3 - one4th;
+    deriv(j,4,0) = half*(-s3 + s2 ) + s2s3 - one4th;
+    deriv(j,5,0) = half*(+s3 - s2 ) - s2s3 + one4th;
+    deriv(j,6,0) = half*(+s3 + s2 ) + s2s3 + one4th;
+    deriv(j,7,0) = half*(-s3 - s2 ) - s2s3 - one4th;
+
+    // shape function derivative in the s2 direction -
+    deriv(j,0,1) = half*( s3 + s1 ) - s1s3 - one4th;
+    deriv(j,1,1) = half*( s3 - s1 ) + s1s3 - one4th;
+    deriv(j,2,1) = half*(-s3 + s1 ) - s1s3 + one4th;
+    deriv(j,3,1) = half*(-s3 - s1 ) + s1s3 + one4th;
+    deriv(j,4,1) = half*(-s3 + s1 ) + s1s3 - one4th;
+    deriv(j,5,1) = half*(-s3 - s1 ) - s1s3 - one4th;
+    deriv(j,6,1) = half*( s3 + s1 ) + s1s3 + one4th;
+    deriv(j,7,1) = half*( s3 - s1 ) - s1s3 + one4th;
+    
+    // shape function derivative in the s3 direction -
+    deriv(j,0,2) = half*( s2 + s1 ) - s1s2 - one4th;
+    deriv(j,1,2) = half*( s2 - s1 ) + s1s2 - one4th;
+    deriv(j,2,2) = half*(-s2 - s1 ) - s1s2 - one4th;
+    deriv(j,3,2) = half*(-s2 + s1 ) + s1s2 - one4th;
+    deriv(j,4,2) = half*(-s2 - s1 ) + s1s2 + one4th;
+    deriv(j,5,2) = half*(-s2 + s1 ) - s1s2 + one4th;
+    deriv(j,6,2) = half*( s2 + s1 ) + s1s2 + one4th;
+    deriv(j,7,2) = half*( s2 - s1 ) - s1s2 + one4th;
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- shape_fcn -------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+Hex8SCS::shape_fcn(SharedMemView<DoubleType**> &shpfc)
+{
+  hex_shape_fcn(&numIntPoints_, &intgLoc_, shpfc);
+}
+
+//--------------------------------------------------------------------------
+//-------- hex8_shape_fcn --------------------------------------------------
+//--------------------------------------------------------------------------
+void
+Hex8SCS::hex8_shape_fcn(
+  const int  &npts,
+  const double *isoParCoord, 
+  SharedMemView<DoubleType**> &shape_fcn)
+{
+  const double one8th = 0.125;
+  const double half = 0.50;
+  for ( int j = 0; j < numIntPoints_; ++j ) {
+    
+    const double s1 = isoParCoord(j,0);
+    const double s2 = isoParCoord(j,1);
+    const double s3 = isoParCoord(j,2);
+    
+    shape_fcn(j,0) = one8th + one4th*(-s1 - s2 - s3)
+      + half*( s2*s3 + s3*s1 + s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,1) = one8th + one4th*( s1 - s2 - s3)
+      + half*( s2*s3 - s3*s1 - s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,2) = one8th + one4th*( s1 + s2 - s3)
+      + half*(-s2*s3 - s3*s1 + s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,3) = one8th + one4th*(-s1 + s2 - s3)
+      + half*(-s2*s3 + s3*s1 - s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,4) = one8th + one4th*(-s1 - s2 + s3)
+      + half*(-s2*s3 - s3*s1 + s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,5) = one8th + one4th*( s1 - s2 + s3)
+      + half*(-s2*s3 + s3*s1 - s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,6) = one8th + one4th*( s1 + s2 + s3)
+      + half*( s2*s3 + s3*s1 + s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,7) = one8th + one4th*(-s1 + s2 + s3)
+      + half*( s2*s3 - s3*s1 - s1*s2 ) - s1*s2*s3;    
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- shifted_shape_fcn -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+Hex8SCS::shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc)
+{
+  hex_shape_fcn(&numIntPoints_, &intgLocShift_[0], shpfc);
+}
+
+}
+}


### PR DESCRIPTION
I added the HexSCS new calls. I still need to convert HexSCV, however, that should only be a few methods.

At present, I do not have a unit test approach for these new methods. Will work with @sayerhs tomorrow on that.

@alanw0 can use this for unit testing or in crafting the new Solver interface. As noted, anything with SCV_VOLUME will not yet work. That means source terms.

@rcknaus can also massage the newly defined call signatures for grad_op, determinant, etc.