### PR TITLE
WIP Master element HexSCS SIMD

### DIFF
--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -11,6 +11,10 @@
 
 #include <AlgTraits.h>
 
+// NGP-based includes
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
 #include <vector>
 #include <cstdlib>
 #include <stdexcept>
@@ -60,6 +64,37 @@ public:
   MasterElement();
   virtual ~MasterElement();
 
+  // NGP-ready methods first
+  virtual void shape_fcn(
+    SharedMemView<DoubleType**> &shpfc) {
+    throw std::runtime_error("shape_fcn using SharedMemView is not implemented");}
+
+  virtual void shifted_shape_fcn(
+    SharedMemView<DoubleType**> &shpfc) {
+    throw std::runtime_error("shifted_shape_fcn using SharedMemView is not implemented");}
+
+  virtual void grad_op(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType***>&gradop,
+    SharedMemView<DoubleType***>&deriv,
+    SharedMemView<DoubleType*>&det_j,
+    DoubleType &error) {
+    throw std::runtime_error("grad_op using SharedMemView is not implemented");}
+
+  virtual void shifted_grad_op(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType***>&gradop,
+    SharedMemView<DoubleType***>&deriv,
+    SharedMemView<DoubleType*>&det_j,
+    DoubleType &error) {
+    throw std::runtime_error("shifted_grad_op using SharedMemView is not implemented");}
+
+  virtual void determinant(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType**>&areav) {
+    throw std::runtime_error("determinant using SharedMemView is not implemented");}
+
+  // non-NGP-ready methods second
   virtual void determinant(
     const int nelem,
     const double *coords,
@@ -106,7 +141,6 @@ public:
     double *det_j,
     double * error ) {
     throw std::runtime_error("face_grad_op not implemented; avoid this element type at open bcs, walls and symms");}
-  
 
   virtual void shifted_face_grad_op(
      const int nelem,
@@ -255,6 +289,52 @@ public:
 
   const int * ipNodeMap(int ordinal = 0);
 
+  // NGP-ready methods first
+  void shape_fcn(
+    SharedMemView<DoubleType**> &shpfc);
+
+  void shifted_shape_fcn(
+    SharedMemView<DoubleType**> &shpfc);
+
+  void hex8_shape_fcn(
+    const int  &numIp,
+    const double *isoParCoord,
+    SharedMemView<DoubleType**> &shpfc);
+
+  void hex8_derivative(
+    const int npt, 
+    const double *par_coord,
+    SharedMemView<DoubleType***> &deriv);
+
+  void hex8_gradient_operator(
+    const int nodesPerElem, 
+    const int numIntgPts, 
+    SharedMemView<DoubleType***> &deriv, 
+    SharedMemView<DoubleType**> cordel, 
+    SharedMemView<DoubleType***>gradop, 
+    SharedMemView<DoubleType*>det_j, 
+    DoubleType &error, 
+    int &lerr);
+
+  void grad_op(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType***>&gradop,
+    SharedMemView<DoubleType***>&deriv,
+    SharedMemView<DoubleType*>&det_j,
+    DoubleType &error);
+
+  void shifted_grad_op(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType***>&gradop,
+    SharedMemView<DoubleType***>&deriv,
+    SharedMemView<DoubleType*>&det_j,
+    DoubleType &error );
+
+  void determinant(
+    SharedMemView<DoubleType**>&coords,
+    SharedMemView<DoubleType**>&areav);
+
+  // non NGP-ready methods second
   void determinant(
     const int nelem,
     const double *coords,

--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -669,14 +669,14 @@ HexSCS::hex8_shape_fcn(
   const double *isoParCoord, 
   SharedMemView<DoubleType**> &shape_fcn)
 {
-  const double half = 0.50;
-  const double one4th = 0.25;
-  const double one8th = 0.125;
+  const DoubleType half = 0.50;
+  const DoubleType one4th = 0.25;
+  const DoubleType one8th = 0.125;
   for ( int j = 0; j < numIntPoints_; ++j ) {
 
-    const double s1 = isoParCoord[j*3];
-    const double s2 = isoParCoord[j*3+1];
-    const double s3 = isoParCoord[j*3+2];
+    const DoubleType s1 = isoParCoord[j*3];
+    const DoubleType s2 = isoParCoord[j*3+1];
+    const DoubleType s3 = isoParCoord[j*3+2];
     
     shape_fcn(j,0) = one8th + one4th*(-s1 - s2 - s3)
       + half*( s2*s3 + s3*s1 + s1*s2 ) - s1*s2*s3;
@@ -705,15 +705,15 @@ void HexSCS::hex8_derivative(
   const double *intgLoc,
   SharedMemView<DoubleType***> &deriv)
 {
-  const double half = 0.50;
-  const double one4th = 0.25;
+  const DoubleType half = 0.50;
+  const DoubleType one4th = 0.25;
   for (int  ip = 0; ip < npts; ++ip) {
-    const double s1 = intgLoc[ip*3];
-    const double s2 = intgLoc[ip*3+1];
-    const double s3 = intgLoc[ip*3+2];
-    const double s1s2 = s1*s2;
-    const double s2s3 = s2*s3;
-    const double s1s3 = s1*s3;
+    const DoubleType s1 = intgLoc[ip*3];
+    const DoubleType s2 = intgLoc[ip*3+1];
+    const DoubleType s3 = intgLoc[ip*3+2];
+    const DoubleType s1s2 = s1*s2;
+    const DoubleType s2s3 = s2*s3;
+    const DoubleType s1s3 = s1*s3;
 
     // shape function derivative in the s1 direction -
     deriv(ip,0,0) = half*( s3 + s2 ) - s2s3 - one4th;

--- a/unit_tests/UnitTestHexMasterElements.C
+++ b/unit_tests/UnitTestHexMasterElements.C
@@ -13,6 +13,10 @@
 
 #include <master_element/MasterElement.h>
 
+// NGP-based includes
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
 #include "UnitTestUtils.h"
 
 namespace {
@@ -87,7 +91,8 @@ void check_interpolation(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   sierra::nalu::MasterElement& me,
-  unsigned poly_order)
+  unsigned poly_order,
+  bool usingNGP = false)
 {
   // Check that we can interpolate a random 3D polynomial
   // to the integration points
@@ -130,13 +135,13 @@ void check_interpolation(
   std::vector<double> meResult(me.numIntPoints_, 0.0);
   std::vector<double> meShapeFunctions(me.numIntPoints_ * topo.num_nodes());
   me.shape_fcn(meShapeFunctions.data());
-
+  
   for (int j = 0; j < me.numIntPoints_; ++j) {
     for (unsigned i = 0; i < topo.num_nodes(); ++i) {
       meResult[j] += meShapeFunctions[j*topo.num_nodes()+i] * ws_field[i];
     }
   }
-
+  
   for (unsigned j = 0 ; j < meResult.size(); ++j) {
     EXPECT_NEAR(meResult[j], polyResult[j], 1.0e-12);
   }


### PR DESCRIPTION
I added the HexSCS new calls. I still need to convert HexSCV, however, that should only be a few methods.

At present, I do not have a unit test approach for these new methods. Will work with @sayerhs tomorrow on that.

@alanw0 can use this for unit testing or in crafting the new Solver interface. As noted, anything with SCV_VOLUME will not yet work. That means source terms.

@rcknaus can also massage the newly defined call signatures for grad_op, determinant, etc.