### PR TITLE
Fix reference pressure at an interior node

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -28,7 +28,17 @@ enum AlgorithmType{
   NON_CONFORMAL = 10,
   ELEM_SOURCE = 11,
   OVERSET = 12,
-  WALL_ABL = 13
+  WALL_ABL = 13,
+
+  /** Set the reference pressure at a node.
+   *
+   *  Used only for continuity equation system. This needs to be the last
+   *  algorithm applied to the linear system because it resets the row and
+   *  overwrites contributions from other algorithms at this node.
+   *
+   * \sa FixPressureAtNodeAlgorithm
+   */
+  REF_PRESSURE = 14
 };
 
 enum BoundaryConditionType{

--- a/include/FixPressureAtNodeAlgorithm.h
+++ b/include/FixPressureAtNodeAlgorithm.h
@@ -1,0 +1,100 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef FIXPRESSUREATNODEALGORITHM_H
+#define FIXPRESSUREATNODEALGORITHM_H
+
+#include "SolverAlgorithm.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/Entity.hpp>
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+}
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+struct FixPressureAtNodeInfo;
+
+/** Set the reference pressure in the computational domain for ABL simulations.
+ *
+ *  This algorithm sets the reference pressure at an internal computational node
+ *  that is used as a reference for the Continuity equation. Reference pressure
+ *  is necessary in situations where all the boundaries are either periodic or
+ *  symmetry, e.g., _precursor_ simulations where the sides are periodic and the
+ *  top boundary is usually set to symmetry.
+ *
+ *  The reference pressure can be activated by adding the section
+ *  `abl_fix_pressure` to the `solution_options` for the relevant `realm` as
+ *  shown below:
+ *
+ *  ```
+ *  solution_options:
+ *    name: ablSimOptions
+ *
+ *    abl_fix_pressure:
+ *      value: 0.0                              # Reference pressure
+ *      location: [10.0, 10.0, 10.0]            # Spatial location where pressure is referenced
+ *      search_target_part: [Unspecified-2-HEX] # List of mesh parts to be searched
+ *      search_method: stk_kdtree               # Search method to determine nearest node
+ *  ```
+ *
+ * \sa FixPressureAtNodeInfo
+ */
+class FixPressureAtNodeAlgorithm : public SolverAlgorithm
+{
+public:
+  FixPressureAtNodeAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    EquationSystem* eqSystem);
+
+  virtual ~FixPressureAtNodeAlgorithm();
+
+  virtual void initialize_connectivity();
+
+  virtual void execute();
+
+  void initialize();
+
+  /** Determine the nearest node on the mesh to the user-specified location
+   *
+   */
+  stk::mesh::EntityId determine_nearest_node();
+
+  /** Process the node ID and determine the node where the fix is applied */
+  void process_pressure_fix_node(const stk::mesh::EntityId nodeID);
+
+  const FixPressureAtNodeInfo& info_;
+
+  //! Reference to the coordinates field
+  VectorFieldType* coordinates_{nullptr};
+
+  //! Reference to the pressure field
+  ScalarFieldType* pressure_{nullptr};
+
+  //! List of nodes where pressure is referenced/fixed. Should be a list of size = 1
+  std::vector<stk::mesh::Entity> refNodeList_;
+
+  //! Track mesh motion for reinitialization
+  const bool meshMotion_{false};
+
+  //! Track initialization tasks
+  bool doInit_{true};
+
+  bool fixPressureNode_{false};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* FIXPRESSUREATNODEALGORITHM_H */

--- a/include/FixPressureAtNodeAlgorithm.h
+++ b/include/FixPressureAtNodeAlgorithm.h
@@ -41,11 +41,25 @@ struct FixPressureAtNodeInfo;
  *  solution_options:
  *    name: ablSimOptions
  *
- *    abl_fix_pressure:
+ *    fix_pressure_at_node:
+ *      node_lookup_type: spatial_location      # Use nearest node search
  *      value: 0.0                              # Reference pressure
  *      location: [10.0, 10.0, 10.0]            # Spatial location where pressure is referenced
  *      search_target_part: [Unspecified-2-HEX] # List of mesh parts to be searched
  *      search_method: stk_kdtree               # Search method to determine nearest node
+ *  ```
+ *
+ *  Alternately, the user can specify an STK node identifier instead of
+ *  performing a search for the nearest node.
+ *
+ *  ```
+ *  solution_options:
+ *    name: ablSimOptions
+ *
+ *    fix_pressure_at_node:
+ *      node_lookup_type: stk_node_id           # Use STK node identifier
+ *      node_identifier: 33662                  # STK Node ID
+ *      value: 0.0                              # Reference pressure
  *  ```
  *
  * \sa FixPressureAtNodeInfo

--- a/include/FixPressureAtNodeInfo.h
+++ b/include/FixPressureAtNodeInfo.h
@@ -1,0 +1,72 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef FIXPRESSUREATNODEINFO_H
+#define FIXPRESSUREATNODEINFO_H
+
+#include "stk_mesh/base/MetaData.hpp"
+#include "stk_search/SearchMethod.hpp"
+
+#include <vector>
+#include <string>
+
+namespace sierra {
+namespace nalu {
+
+/** Input data for fixing pressure during ABL simulations.
+ *
+ *  This class holds the user data parsed from Nalu input file to fix pressure
+ *  at a spatial location for ABL simulations. This is especially necessary for
+ *  precursor simulations where the inlet/outlet boundaries are periodic and the
+ *  top boundary is symmetric. In this case, there is no pressure specified for
+ *  the continuity solve.
+ */
+struct FixPressureAtNodeInfo
+{
+  /** Options for specifying the node where pressure is fixed
+   *
+   */
+  enum NodeLookupType {
+    STK_NODE_ID = 0,      //!< STK Global Node ID provided in input file
+    SPATIAL_LOCATION = 1, //!< Spatial location used to search nearest node
+  };
+
+  void create_part_vector(const stk::mesh::MetaData& meta)
+  {
+    auto nParts = searchParts_.size();
+    for (size_t i=0; i < nParts; i++) {
+      stk::mesh::Part* part = meta.get_part(searchParts_[i]);
+      if (nullptr != part)
+        partVec_.push_back(part);
+      else
+        throw std::runtime_error("FixPressureAtNodeInfo: Target search part is null "
+                                 + searchParts_[i]);
+    }
+  }
+
+  //! Reference pressure for ABL simulations
+  double refPressure_{0.0};
+
+  //! Location for ABL reference pressure
+  std::vector<double> location_{0.0, 0.0, 0.0};
+
+  std::vector<std::string> searchParts_;
+
+  stk::mesh::PartVector partVec_;
+
+  //! Search method for determining the nearest node to the prescribed location
+  stk::search::SearchMethod searchMethod_{stk::search::KDTREE};
+
+  NodeLookupType lookupType_{SPATIAL_LOCATION};
+
+  stk::mesh::EntityId stkNodeId_;
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* FIXPRESSUREATNODEINFO_H */

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -93,6 +93,17 @@ public:
     const unsigned beginPos,
     const unsigned endPos)=0;
 
+  /** Reset LHS and RHS for the given set of nodes to 0
+   *
+   *  @param nodeList A list of STK node entities whose rows are zeroed out
+   *  @param beginPos Starting index (usually 0)
+   *  @param endPos Terminating index (1 for scalar quantities; nDim for vectors)
+   */
+  virtual void resetRows(
+    std::vector<stk::mesh::Entity> nodeList,
+    const unsigned beginPos,
+    const unsigned endPos) = 0;
+
   // Solve
   virtual int solve(stk::mesh::FieldBase * linearSolutionField)=0;
   virtual void loadComplete()=0;

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -16,11 +16,13 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <memory>
 
 namespace sierra{
 namespace nalu{
 
 class MeshMotionInfo;
+struct FixPressureAtNodeInfo;
 
 enum ErrorIndicatorType {
   EIT_NONE                = 0,
@@ -188,6 +190,11 @@ public:
   // Coriolis source term
   std::vector<double> eastVector_;
   std::vector<double> northVector_;
+
+  //! Flag indicating whether the user has requested pressure referencing
+  bool needPressureReference_{false};
+
+  std::unique_ptr<FixPressureAtNodeInfo> fixPressureInfo_;
 
   std::string name_;
 

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -97,6 +97,17 @@ public:
     const unsigned beginPos,
     const unsigned endPos);
 
+  /** Reset LHS and RHS for the given set of nodes to 0
+   *
+   *  @param nodeList A list of STK node entities whose rows are zeroed out
+   *  @param beginPos Starting index (usually 0)
+   *  @param endPos Terminating index (1 for scalar quantities; nDim for vectors)
+   */
+  virtual void resetRows(
+    const std::vector<stk::mesh::Entity> nodeList,
+    const unsigned beginPos,
+    const unsigned endPos);
+
   // Solve
   int solve(stk::mesh::FieldBase * linearSolutionField);
   void loadComplete();

--- a/src/FixPressureAtNodeAlgorithm.C
+++ b/src/FixPressureAtNodeAlgorithm.C
@@ -1,0 +1,201 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "FixPressureAtNodeAlgorithm.h"
+#include "FixPressureAtNodeInfo.h"
+#include "Realm.h"
+#include "EquationSystem.h"
+#include "TpetraLinearSystem.h"
+#include "SolutionOptions.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+#include <stk_util/parallel/ParallelReduce.hpp>
+
+#include <limits>
+
+namespace sierra {
+namespace nalu {
+
+FixPressureAtNodeAlgorithm::FixPressureAtNodeAlgorithm(
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem)
+  : SolverAlgorithm(realm, part, eqSystem),
+    info_(*(realm.solutionOptions_->fixPressureInfo_)),
+    meshMotion_(realm.does_mesh_move())
+{
+  auto& meta = realm_.meta_data();
+
+  coordinates_ = meta.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "pressure");
+}
+
+
+FixPressureAtNodeAlgorithm::~FixPressureAtNodeAlgorithm()
+{}
+
+void
+FixPressureAtNodeAlgorithm::initialize_connectivity()
+{
+  // Element to node graph must've been already populated by interior algorithm
+}
+
+void
+FixPressureAtNodeAlgorithm::execute()
+{
+  if (doInit_)
+    initialize();
+
+  // Reset LHS and RHS for this matrix
+  eqSystem_->linsys_->resetRows(refNodeList_, 0, 1);
+
+  int numNodes = refNodeList_.size();
+  ThrowAssertMsg(numNodes <= 1,
+                 "Invalid number of nodes encountered in FixPressureAtNodeAlgorithm");
+
+  // Fix the pressure for this node only if this is proc is owner
+  if (numNodes > 0 && fixPressureNode_) {
+    std::vector<double> lhs(1);
+    std::vector<double> rhs(1);
+    std::vector<int> scratchIds(1);
+    std::vector<double> scratchVals(1);
+    stk::mesh::Entity node = refNodeList_[0];
+    const double pressureN = *stk::mesh::field_data(*pressure_, node);
+
+    lhs[0] = 1.0; // Set diagonal entry to 1.0
+    rhs[0] = info_.refPressure_ - pressureN;
+
+    apply_coeff(refNodeList_, scratchIds, scratchVals, rhs, lhs, __FILE__);
+  }
+}
+
+void
+FixPressureAtNodeAlgorithm::initialize()
+{
+  // Reset data structures
+  refNodeList_.clear();
+
+  if (info_.lookupType_ == FixPressureAtNodeInfo::SPATIAL_LOCATION) {
+    // Determine the nearest node where pressure is referenced
+    auto nodeID = determine_nearest_node();
+    process_pressure_fix_node(nodeID);
+  }
+  else if (info_.lookupType_ == FixPressureAtNodeInfo::STK_NODE_ID) {
+    process_pressure_fix_node(info_.stkNodeId_);
+  }
+
+  // Flip init flag
+  doInit_ = false;
+}
+
+stk::mesh::EntityId
+FixPressureAtNodeAlgorithm::determine_nearest_node()
+{
+  auto& meta = realm_.meta_data();
+  auto& bulk = realm_.bulk_data();
+  int nDim = meta.spatial_dimension();
+  auto& refLoc = info_.location_;
+
+  // Get the target search part vector
+  auto& partNames = info_.searchParts_;
+  auto nParts = partNames.size();
+  stk::mesh::PartVector parts(nParts);
+  for (size_t i=0; i<nParts; i++) {
+    stk::mesh::Part* part = meta.get_part(partNames[i]);
+    if ( nullptr != part)
+      parts[i] = part;
+    else
+      throw std::runtime_error("FixPressureAtNodeAlgorithm: Target search part is null " +
+                               partNames[i]);
+  }
+
+  // Determine the nearest node in this processor
+  stk::mesh::Entity nearestNode;
+  stk::mesh::Selector sel = meta.locally_owned_part() &
+    stk::mesh::selectUnion(parts);
+  auto& buckets = bulk.get_buckets(stk::topology::NODE_RANK, sel);
+
+  double distSqr = std::numeric_limits<double>::max();
+  for (auto b: buckets) {
+    auto length = b->size();
+
+    for (size_t i=0; i < length; i++) {
+      auto node = (*b)[i];
+      const double* coords = stk::mesh::field_data(*coordinates_, node);
+
+      double dist = 0.0;
+      for (int j=0; j<nDim; j++) {
+        double xdiff = (refLoc[j]-coords[j]);
+        dist += xdiff * xdiff;
+      }
+      if (dist < distSqr) {
+        distSqr = dist;
+        nearestNode = node;
+      }
+    }
+  }
+
+  // Determine the global minimum
+  std::vector<double> minDistList(bulk.parallel_size());
+  MPI_Allgather(&distSqr, 1, MPI_DOUBLE, minDistList.data(), 1, MPI_DOUBLE,
+                bulk.parallel());
+  int minDistProc = -1;
+  double minDist = std::numeric_limits<double>::max();
+  for (int i=0; i < bulk.parallel_size(); i++) {
+    if (minDistList[i] < minDist) {
+      minDist = minDistList[i];
+      minDistProc = i;
+    }
+  }
+
+  // Communicate the nearest node ID to all processors.
+  stk::mesh::EntityId nodeID = 0;
+  stk::mesh::EntityId g_nodeID;
+  if (minDistProc == bulk.parallel_rank())
+    nodeID = bulk.identifier(nearestNode);
+  stk::all_reduce_max(bulk.parallel(), &nodeID, &g_nodeID, 1);
+
+  return g_nodeID;
+}
+
+void
+FixPressureAtNodeAlgorithm::process_pressure_fix_node(
+  const stk::mesh::EntityId nodeID)
+{
+  auto& bulk = realm_.bulk_data();
+
+  // Store the target node on the owning processor as well as the shared processors.
+  stk::mesh::Entity targetNode = bulk.get_entity(stk::topology::NODE_RANK, nodeID);
+  if (bulk.is_valid(targetNode) &&
+      (bulk.bucket(targetNode).owned() ||
+       bulk.bucket(targetNode).shared())) {
+    refNodeList_.push_back(targetNode);
+
+    // Only apply pressure correction on the owning processor
+    fixPressureNode_ = bulk.bucket(targetNode).owned();
+
+#if 0
+    if (bulk.parallel_owner_rank(targetNode) == bulk.parallel_rank()) {
+      std::cerr
+        << "FixPressureAtNodeAlgorithm: Node ID = "
+        << nodeID << "; Proc ID = " << bulk.parallel_rank() << std::endl;
+    }
+#endif
+  } else {
+    fixPressureNode_ = false;
+  }
+}
+
+
+}  // nalu
+}  // sierra

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -10,6 +10,7 @@
 #include <Enums.h>
 #include <NaluEnv.h>
 #include <MeshMotionInfo.h>
+#include <FixPressureAtNodeInfo.h>
 
 // basic c++
 #include <stdexcept>
@@ -427,6 +428,44 @@ SolutionOptions::load(const YAML::Node & y_node)
           // set the map
           meshMotionInfoMap_[motionName] = meshInfo;
         }
+      }
+    }
+
+    const YAML::Node fix_pressure = expect_map(y_solution_options, "fix_pressure_at_node", optional);
+    if (fix_pressure) {
+      needPressureReference_ = true;
+      fixPressureInfo_.reset(new FixPressureAtNodeInfo);
+
+      fixPressureInfo_->refPressure_ = fix_pressure["value"].as<double>();
+      if (fix_pressure["node_lookup_type"])
+      {
+        std::string lookupTypeName = fix_pressure["node_lookup_type"].as<std::string>();
+        if (lookupTypeName == "stk_node_id")
+          fixPressureInfo_->lookupType_ = FixPressureAtNodeInfo::STK_NODE_ID;
+        else if (lookupTypeName == "spatial_location")
+          fixPressureInfo_->lookupType_ = FixPressureAtNodeInfo::SPATIAL_LOCATION;
+        else
+          throw std::runtime_error("FixPressureAtNodeInfo: Invalid option specified for "
+                                   "'node_lookup_type' in input file.");
+      }
+
+      if (fixPressureInfo_->lookupType_ == FixPressureAtNodeInfo::SPATIAL_LOCATION) {
+        fixPressureInfo_->location_ = fix_pressure["location"].as<std::vector<double>>();
+        fixPressureInfo_->searchParts_ =
+          fix_pressure["search_target_part"].as<std::vector<std::string>>();
+        if (fix_pressure["search_method"]) {
+          std::string searchMethodName = fix_pressure["search_method"].as<std::string>();
+          if (searchMethodName == "boost_rtree")
+            fixPressureInfo_->searchMethod_ = stk::search::BOOST_RTREE;
+          else if (searchMethodName == "stk_kdtree")
+            fixPressureInfo_->searchMethod_ = stk::search::KDTREE;
+          else
+            NaluEnv::self().naluOutputP0() << "ABL Fix Pressure: Search will use stk_kdtree"
+                                           << std::endl;
+        }
+      }
+      else {
+        fixPressureInfo_->stkNodeId_ = fix_pressure["node_identifier"].as<unsigned int>();
       }
     }
 


### PR DESCRIPTION
Allow user to fix the reference pressure at an arbitrary location within
the computational domain during simulations.

This capability is important for the pressure Poisson solve during
ABL precursor simulations where the side boundaries are usually set to
periodic and the top boundary is specified with a symmetry BC to allow
the flow to adjust naturally when targeting a specified wind
speed/direction at hub height.