### PR TITLE
Making the turbulence tests threadsafe.

### DIFF
--- a/unit_tests/UnitTestFieldUtils.h
+++ b/unit_tests/UnitTestFieldUtils.h
@@ -14,10 +14,6 @@
 
 namespace unit_test_utils {
 
-double field_max(const ScalarFieldType& field, const stk::mesh::BulkData& bulk, stk::mesh::Selector selector);
-
-double field_min(const ScalarFieldType& field, const stk::mesh::BulkData& bulk, stk::mesh::Selector selector);
-
 double field_norm(const ScalarFieldType& field, const stk::mesh::BulkData& bulk, stk::mesh::Selector selector);
 
 }

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -479,6 +479,18 @@ double vector_norm(const std::vector<double> & vec, const stk::ParallelMachine& 
   return g_norm;
 }
 
+double global_norm(const double & norm, const size_t & N, const stk::ParallelMachine& comm)
+{
+  size_t g_N = 0;
+  double g_norm = 0.0;
+
+  stk::all_reduce_sum(comm, &N, &g_N, 1);
+  stk::all_reduce_sum(comm, &norm, &g_norm, 1);
+  g_norm = std::sqrt(g_norm/g_N);
+
+  return g_norm;
+}
+
 #ifndef KOKKOS_HAVE_CUDA
 
 double initialize_linear_scalar_field(

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -43,6 +43,8 @@ double quadratic(double a, const double* b, const double* H, const double* x);
 
 double vector_norm(const std::vector<double> & vec, const stk::ParallelMachine& comm = MPI_COMM_WORLD);
 
+double global_norm(const double & norm, const size_t & N, const stk::ParallelMachine& comm = MPI_COMM_WORLD);
+
 double initialize_quadratic_scalar_field(const stk::mesh::BulkData& bulk,
                                       const VectorFieldType& coordField,
                                       const ScalarFieldType& qField);

--- a/unit_tests/algorithms/UnitTestAlgorithm.C
+++ b/unit_tests/algorithms/UnitTestAlgorithm.C
@@ -24,26 +24,6 @@ TestAlgorithm::fill_mesh(const std::string mesh_spec)
 }
 
 double
-TestAlgorithm::field_max(const ScalarFieldType & field, stk::mesh::Selector* selector)
-{
-  auto& meta = this->meta();
-  auto& bulk = this->bulk();
-  auto sel = (selector == nullptr)? meta.locally_owned_part() : *selector;
-
-  return unit_test_utils::field_max(field, bulk, sel);
-}
-
-double
-TestAlgorithm::field_min(const ScalarFieldType & field, stk::mesh::Selector* selector)
-{
-  auto& meta = this->meta();
-  auto& bulk = this->bulk();
-  auto sel = (selector == nullptr)? meta.locally_owned_part() : *selector;
-
-  return unit_test_utils::field_min(field, bulk, sel);
-}
-
-double
 TestAlgorithm::field_norm(const ScalarFieldType & field, stk::mesh::Selector* selector)
 {
 

--- a/unit_tests/algorithms/UnitTestAlgorithm.h
+++ b/unit_tests/algorithms/UnitTestAlgorithm.h
@@ -66,10 +66,6 @@ public:
     return realm().bulk_data();
   }
 
-  double field_max(const ScalarFieldType & field, stk::mesh::Selector* selector = nullptr);
-
-  double field_min(const ScalarFieldType & field, stk::mesh::Selector* selector = nullptr);
-
   double field_norm(const ScalarFieldType & field, stk::mesh::Selector* selector = nullptr);
 
   //! Reference to test Nalu instance used to hold Simulation and Realm

--- a/unit_tests/algorithms/UnitTestSSTAlgorithms.C
+++ b/unit_tests/algorithms/UnitTestSSTAlgorithms.C
@@ -29,10 +29,9 @@ TEST_F(TestTurbulenceAlgorithm, computesstmaxlengthscaleelemalgorithm)
 
   // Perform tests
   const double tol = 1e-14;
-  double maxVal = field_max(*maxLengthScale_);
-  double minVal = field_min(*maxLengthScale_);
-  EXPECT_NEAR(maxVal, 1.0, tol);
-  EXPECT_NEAR(minVal, 1.0, tol);
+  double norm = field_norm(*maxLengthScale_);
+  const double gold_norm = 1.0;
+  EXPECT_NEAR(norm, gold_norm, tol);
 }
 
 TEST_F(TestTurbulenceAlgorithm, testturbviscsstalgorithm)


### PR DESCRIPTION
The turbulence unit tests were not thread-safe so `export OMP_NUM_THREADS=2; ctest -R unit` failed with a segfault. This commit makes the turbulence unit tests thread-safe.