### PR TITLE
Activate mdot correction at open bcs

### DIFF
--- a/include/ComputeMdotAlgorithmDriver.h
+++ b/include/ComputeMdotAlgorithmDriver.h
@@ -28,6 +28,8 @@ public:
   ~ComputeMdotAlgorithmDriver();
 
   double compute_accumulation();
+  void correct_open_mdot(const double finalCorrection);
+  void provide_output();
 
   SolutionOptions &solnOpts_;
   bool hasMass_;

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -137,11 +137,17 @@ public:
   double earthAngularVelocity_;
   double latitude_;
 
-  // global mdot correction alg
+  // mdot post processing
   double mdotAlgAccumulation_;
   double mdotAlgInflow_;
   double mdotAlgOpen_;
  
+  // global mdot correction alg
+  bool activateOpenMdotCorrection_;
+  double mdotAlgOpenCorrection_;
+  size_t mdotAlgOpenIpCount_;
+  double mdotAlgOpenPost_;
+
   // turbulence model coeffs
   std::map<TurbulenceModelConstant, double> turbModelConstantMap_;
   

--- a/src/AssembleContinuityInflowSolverAlgorithm.C
+++ b/src/AssembleContinuityInflowSolverAlgorithm.C
@@ -7,12 +7,13 @@
 
 
 // nalu
-#include <AssembleContinuityInflowSolverAlgorithm.h>
-#include <EquationSystem.h>
-#include <FieldTypeDef.h>
-#include <LinearSystem.h>
-#include <Realm.h>
-#include <master_element/MasterElement.h>
+#include "AssembleContinuityInflowSolverAlgorithm.h"
+#include "EquationSystem.h"
+#include "FieldTypeDef.h"
+#include "LinearSystem.h"
+#include "Realm.h"
+#include "SolutionOptions.h"
+#include "master_element/MasterElement.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
@@ -47,7 +48,8 @@ AssembleContinuityInflowSolverAlgorithm::AssembleContinuityInflowSolverAlgorithm
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.solutionOptions_->activateOpenMdotCorrection_ 
+                                                     ? "velocity_bc" : "cont_velocity_bc");
   // variable density will need density as a function of user inflow conditions
   densityBC_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
 }

--- a/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
@@ -144,7 +144,6 @@ AssembleMomentumEdgeOpenSolverAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    
 
     const stk::mesh::Bucket::size_type length = b.size();
 

--- a/src/AssembleMomentumEdgeWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumEdgeWallFunctionSolverAlgoirthm.C
@@ -155,7 +155,7 @@ AssembleMomentumEdgeWallFunctionSolverAlgorithm::execute()
       const double *wallNormalDistanceBip = stk::mesh::field_data(*wallNormalDistanceBip_, face);
       const double *wallFrictionVelocityBip = stk::mesh::field_data(*wallFrictionVelocityBip_, face);
 
-      // loop over face nodes
+      // loop over boundary ips
       for ( int ip = 0; ip < numScsBip; ++ip ) {
 
         const int offSetAveraVec = ip*nDim;

--- a/src/ComputeMdotAlgorithmDriver.C
+++ b/src/ComputeMdotAlgorithmDriver.C
@@ -116,10 +116,14 @@ ComputeMdotAlgorithmDriver::~ComputeMdotAlgorithmDriver()
 void
 ComputeMdotAlgorithmDriver::pre_work()
 {
-  // set correction to zero
+  // set post processing to zero
   solnOpts_.mdotAlgAccumulation_ = 0.0;
   solnOpts_.mdotAlgInflow_ = 0.0;
   solnOpts_.mdotAlgOpen_ = 0.0;
+
+  // also global correction algorithm
+  solnOpts_.mdotAlgOpenCorrection_ = 0.0;
+  solnOpts_.mdotAlgOpenIpCount_= 0.0;
 }
 
 //--------------------------------------------------------------------------
@@ -141,6 +145,18 @@ ComputeMdotAlgorithmDriver::post_work()
   solnOpts_.mdotAlgAccumulation_ = g_sum[0];
   solnOpts_.mdotAlgInflow_ = g_sum[1];
   solnOpts_.mdotAlgOpen_ = g_sum[2];
+
+  // deal with global correction algorithm
+  if ( solnOpts_.activateOpenMdotCorrection_ ) {
+    size_t l_ip = solnOpts_.mdotAlgOpenIpCount_;
+    size_t g_ip = 0;
+    stk::all_reduce_sum(comm, &l_ip, &g_ip, 1);
+    solnOpts_.mdotAlgOpenIpCount_ = g_ip;
+    const double finalCorrection = (g_sum[0] + g_sum[1] + g_sum[2])/g_ip;
+    solnOpts_.mdotAlgOpenCorrection_ = finalCorrection;
+    solnOpts_.mdotAlgOpenIpCount_ = g_ip;
+    correct_open_mdot(finalCorrection);
+  }
 }
 
 //--------------------------------------------------------------------------
@@ -149,9 +165,10 @@ ComputeMdotAlgorithmDriver::post_work()
 double
 ComputeMdotAlgorithmDriver::compute_accumulation()
 {
-  const double dt = realm_.get_time_step();
+  stk::mesh::MetaData & metaData = realm_.meta_data();
 
-  const int nDim = realm_.meta_data().spatial_dimension();
+  const double dt = realm_.get_time_step();
+  const int nDim = metaData.spatial_dimension();
 
   // initialize accumulation term to zero
   double accumulation = 0.0;
@@ -162,7 +179,6 @@ ComputeMdotAlgorithmDriver::compute_accumulation()
   const double gamma3 = realm_.get_gamma3(); // gamma3 may be zero
 
   // extract fields
-  stk::mesh::MetaData & metaData = realm_.meta_data();
   ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "density");
   ScalarFieldType &densityNp1 = density->field_of_state(stk::mesh::StateNP1);
@@ -269,6 +285,81 @@ ComputeMdotAlgorithmDriver::compute_accumulation()
     }
   }
   return accumulation;
+}
+
+//--------------------------------------------------------------------------
+//-------- correct_open_mdot -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+ComputeMdotAlgorithmDriver::correct_open_mdot(const double finalCorrection)
+{
+  // extract field
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+  GenericFieldType *openMassFlowRate = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
+  if ( NULL != openMassFlowRate ) {
+    
+    double mdotSum = 0.0;
+
+    // selector (everywhere density lives, locally owned and active) 
+    stk::mesh::Selector s_locally_owned = stk::mesh::selectField(*openMassFlowRate)    
+      & !(realm_.get_inactive_selector());
+    
+    stk::mesh::BucketVector const& face_buckets =
+      realm_.get_buckets( metaData.side_rank(), s_locally_owned );
+    for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+          ib != face_buckets.end() ; ++ib ) {
+      stk::mesh::Bucket & b = **ib ;
+      
+      // face master element
+      MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
+      const int numScsBip = meFC->numIntPoints_;
+      
+      const stk::mesh::Bucket::size_type length   = b.size();
+      
+      for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+        
+        double * mdot    = stk::mesh::field_data(*openMassFlowRate, b, k);
+
+        // loop over boundary ips and correct open mdot
+        for ( int ip = 0; ip < numScsBip; ++ip ) {
+          mdot[ip] -= finalCorrection;
+          mdotSum += mdot[ip];
+        }
+      }
+    }
+
+    // provide post corrected mdot
+    double g_mdotSum = 0.0;
+    stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
+    stk::all_reduce_sum(comm, &mdotSum, &g_mdotSum, 1);
+    solnOpts_.mdotAlgOpenPost_ = g_mdotSum;
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- provide_output -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+ComputeMdotAlgorithmDriver::provide_output()
+{
+  // output mass closure
+  const double integratedAccumulation = solnOpts_.mdotAlgAccumulation_;
+  const double integratedInflow = solnOpts_.mdotAlgInflow_ ;
+  const double integratedOpen = solnOpts_.mdotAlgOpen_;
+  const double totalMassClosure = integratedAccumulation + integratedInflow + integratedOpen;
+  NaluEnv::self().naluOutputP0() << "Mass Balance Review:  " << std::endl;  
+  NaluEnv::self().naluOutputP0() << "Density accumulation: " << integratedAccumulation << std::endl;
+  NaluEnv::self().naluOutputP0() << "Integrated inflow:    " << integratedInflow << std::endl;
+  NaluEnv::self().naluOutputP0() << "Integrated open:      " << integratedOpen << std::endl;
+  NaluEnv::self().naluOutputP0() << "Total mass closure:   " << totalMassClosure << std::endl;
+  if ( solnOpts_.activateOpenMdotCorrection_ ) {
+    const size_t ipCount = solnOpts_.mdotAlgOpenIpCount_;
+    const double ipCorrection = solnOpts_.mdotAlgOpenCorrection_;
+    NaluEnv::self().naluOutputP0() << "A mass correction of: " << ipCorrection 
+                                   << " occurred on: " << ipCount
+                                   << " boundary integration points: "  << std::endl;
+    NaluEnv::self().naluOutputP0() << "Post-corrected integrated open: " << solnOpts_.mdotAlgOpenPost_ << std::endl;
+  }
 }
 
 } // namespace nalu

--- a/src/ComputeMdotElemOpenAlgorithm.C
+++ b/src/ComputeMdotElemOpenAlgorithm.C
@@ -61,7 +61,7 @@ ComputeMdotElemOpenAlgorithm::ComputeMdotElemOpenAlgorithm(
   density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
   openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, realm_.solutionOptions_->activateOpenMdotCorrection_ ? "pressure" : "pressure_bc");
 }
 
 //--------------------------------------------------------------------------
@@ -89,6 +89,11 @@ ComputeMdotElemOpenAlgorithm::execute()
   const double includeNOC 
     = (realm_.get_noc_usage(dofName) == true) ? 1.0 : 0.0;
 
+  // extract global algorithm options, if active
+  const double pstabFac = realm_.solutionOptions_->activateOpenMdotCorrection_ 
+    ? 0.0
+    : 1.0;
+
   // ip values; both boundary and opposing surface
   std::vector<double> uBip(nDim);
   std::vector<double> rho_uBip(nDim);
@@ -115,10 +120,10 @@ ComputeMdotElemOpenAlgorithm::execute()
   std::vector<double> ws_shape_function;
   std::vector<double> ws_face_shape_function;
 
-  // time step
+  // time step; scale projection time scale by pstabFac (no divide by here)
   const double dt = realm_.get_time_step();
   const double gamma1 = realm_.get_gamma1();
-  const double projTimeScale = dt/gamma1;
+  const double projTimeScale = dt/gamma1*pstabFac;
 
   // deal with interpolation procedure
   const double interpTogether = realm_.get_mdot_interp();
@@ -126,6 +131,7 @@ ComputeMdotElemOpenAlgorithm::execute()
 
   // set accumulation variables
   double mdotOpen = 0.0;
+  size_t mdotOpenIpCount = 0;
 
   // deal with state
   ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
@@ -157,7 +163,6 @@ ComputeMdotElemOpenAlgorithm::execute()
     MasterElement *meFC = sierra::nalu::get_surface_master_element(b.topology());
     const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
-
 
     // algorithm related; element
     ws_coordinates.resize(nodesPerElement*nDim);
@@ -192,6 +197,8 @@ ComputeMdotElemOpenAlgorithm::execute()
       meFC->shape_fcn(&p_face_shape_function[0]);
     
     const stk::mesh::Bucket::size_type length   = b.size();
+
+    mdotOpenIpCount += length*numScsBip;
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
@@ -331,14 +338,13 @@ ComputeMdotElemOpenAlgorithm::execute()
         // scatter to mdot and accumulate
         mdot[ip] = tmdot;
         mdotOpen += tmdot;
-        //mdot[ip] = tmdot - projTimeScale*((pBip-pScs)*asq*inv_axdx + noc*includeNOC);
       }
     }
   }
   // scatter back to solution options; not thread safe
   realm_.solutionOptions_->mdotAlgOpen_ += mdotOpen;
+  realm_.solutionOptions_->mdotAlgOpenIpCount_ += mdotOpenIpCount;
 }
-
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/ComputeMdotInflowAlgorithm.C
+++ b/src/ComputeMdotInflowAlgorithm.C
@@ -44,7 +44,8 @@ ComputeMdotInflowAlgorithm::ComputeMdotInflowAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.solutionOptions_->activateOpenMdotCorrection_ 
+                                                     ? "velocity_bc" : "cont_velocity_bc");
   // variable density will need density as a function of user inflow conditions
   densityBC_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -395,10 +395,6 @@ LowMachEquationSystem::register_open_bc(
   VectorFieldType *velocityBC = &(metaData.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc"));
   stk::mesh::put_field(*velocityBC, *part, nDim);
 
-  ScalarFieldType *pressureBC
-    = &(metaData.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
-  stk::mesh::put_field(*pressureBC, *part );
-
   // extract the value for user specified velocity and save off the AuxFunction
   OpenUserData userData = openBCData.userData_;
   Velocity ux = userData.u_;
@@ -419,19 +415,29 @@ LowMachEquationSystem::register_open_bc(
   bcDataAlg_.push_back(auxAlgUbc);
 
   // extract the value for user specified pressure and save off the AuxFunction
-  Pressure pSpec = userData.p_;
-  std::vector<double> userSpecPbc(1);
-  userSpecPbc[0] = pSpec.pressure_;
-
-  // new it
-  ConstantAuxFunction *theAuxFuncPbc = new ConstantAuxFunction(0, 1, userSpecPbc);
-
-  // bc data alg
-  AuxFunctionAlgorithm *auxAlgPbc
-    = new AuxFunctionAlgorithm(realm_, part,
-                               pressureBC, theAuxFuncPbc,
-                               stk::topology::NODE_RANK);
-  bcDataAlg_.push_back(auxAlgPbc);
+  if ( !realm_.solutionOptions_->activateOpenMdotCorrection_ ) {
+    ScalarFieldType *pressureBC
+      = &(metaData.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
+    stk::mesh::put_field(*pressureBC, *part );
+    
+    Pressure pSpec = userData.p_;
+    std::vector<double> userSpecPbc(1);
+    userSpecPbc[0] = pSpec.pressure_;
+    
+    // new it
+    ConstantAuxFunction *theAuxFuncPbc = new ConstantAuxFunction(0, 1, userSpecPbc);
+    
+    // bc data alg
+    AuxFunctionAlgorithm *auxAlgPbc
+      = new AuxFunctionAlgorithm(realm_, part,
+                                 pressureBC, theAuxFuncPbc,
+                                 stk::topology::NODE_RANK);
+    bcDataAlg_.push_back(auxAlgPbc);
+  }
+  else {
+    if ( userData.pSpec_ ) 
+      throw std::runtime_error("LowMachEqs::regsiter_open_bc error: Pressure specified at an open bc while global correction algorithm has been activated");    
+  }
 
   // mdot at open bc; register field
   MasterElement *meFC = sierra::nalu::get_surface_master_element(theTopo);
@@ -634,6 +640,14 @@ LowMachEquationSystem::solve_and_update()
     // compute velocity relative to mesh with new velocity
     realm_.compute_vrtm();
 
+    // activate global correction scheme
+    if ( realm_.solutionOptions_->activateOpenMdotCorrection_ ) {
+      timeA = NaluEnv::self().nalu_time();
+      continuityEqSys_->computeMdotAlgDriver_->execute();
+      timeB = NaluEnv::self().nalu_time();
+      continuityEqSys_->timerMisc_ += (timeB-timeA);
+    }
+
     // continuity assemble, load_complete and solve
     continuityEqSys_->assemble_and_solve(continuityEqSys_->pTmp_);
 
@@ -833,17 +847,9 @@ LowMachEquationSystem::post_converged_work()
   if (NULL != surfaceForceAndMomentAlgDriver_){
     surfaceForceAndMomentAlgDriver_->execute();
   }
-
+  
   // output mass closure
-  const double integratedAccumulation = realm_.solutionOptions_->mdotAlgAccumulation_;
-  const double integratedInflow = realm_.solutionOptions_->mdotAlgInflow_ ;
-  const double integratedOpen = realm_.solutionOptions_->mdotAlgOpen_;
-  const double totalMassClosure = integratedAccumulation + integratedInflow + integratedOpen;
-  NaluEnv::self().naluOutputP0() << "Mass Balance Review:  " << std::endl;  
-  NaluEnv::self().naluOutputP0() << "Density accumulation: " << integratedAccumulation << std::endl;
-  NaluEnv::self().naluOutputP0() << "Integrated inflow:    " << integratedInflow << std::endl;
-  NaluEnv::self().naluOutputP0() << "Integrated open:      " << integratedOpen << std::endl;
-  NaluEnv::self().naluOutputP0() << "Total mass closure:   " << totalMassClosure << std::endl;
+  continuityEqSys_->computeMdotAlgDriver_->provide_output();
 }
 
 //==========================================================================
@@ -2443,72 +2449,73 @@ ContinuityEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
   const unsigned nDim = meta_data.spatial_dimension();
 
-  // register boundary data; velocity_bc
-  VectorFieldType *theBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc"));
-  stk::mesh::put_field(*theBcField, *part, nDim);
-
-  // extract the value for user specified velocity and save off the AuxFunction
-  InflowUserData userData = inflowBCData.userData_;
-  std::string velocityName = "velocity";
-  UserDataType theDataType = get_bc_data_type(userData, velocityName);
-
-  AuxFunction *theAuxFunc = NULL;
-  if ( CONSTANT_UD == theDataType ) {
-    Velocity ux = userData.u_;
-    std::vector<double> userSpec(nDim);
-    userSpec[0] = ux.ux_;
-    userSpec[1] = ux.uy_;
-    if ( nDim > 2)
-      userSpec[2] = ux.uz_;
+  // register boundary data; cont_velocity_bc
+  if ( !realm_.solutionOptions_->activateOpenMdotCorrection_ ) {
+    VectorFieldType *theBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc"));
+    stk::mesh::put_field(*theBcField, *part, nDim);
     
-    // new it
-    theAuxFunc = new ConstantAuxFunction(0, nDim, userSpec);
+    // extract the value for user specified velocity and save off the AuxFunction
+    InflowUserData userData = inflowBCData.userData_;
+    std::string velocityName = "velocity";
+    UserDataType theDataType = get_bc_data_type(userData, velocityName);
     
-  }
-  else if ( FUNCTION_UD == theDataType ) {
-    // extract the name/params
-    std::string fcnName = get_bc_function_name(userData, velocityName);
-    std::vector<double> theParams = get_bc_function_params(userData, velocityName);
-    if ( theParams.size() == 0 )
-      NaluEnv::self().naluOutputP0() << "function parameter size is zero" << std::endl;
-    // switch on the name found...
-    if ( fcnName == "convecting_taylor_vortex" ) {
-      theAuxFunc = new ConvectingTaylorVortexVelocityAuxFunction(0,nDim);
+    AuxFunction *theAuxFunc = NULL;
+    if ( CONSTANT_UD == theDataType ) {
+      Velocity ux = userData.u_;
+      std::vector<double> userSpec(nDim);
+      userSpec[0] = ux.ux_;
+      userSpec[1] = ux.uy_;
+      if ( nDim > 2)
+        userSpec[2] = ux.uz_;
+      
+      // new it
+      theAuxFunc = new ConstantAuxFunction(0, nDim, userSpec);    
     }
-    else if ( fcnName == "SteadyTaylorVortex" ) {
-      theAuxFunc = new SteadyTaylorVortexVelocityAuxFunction(0,nDim);
-    }
-    else if ( fcnName == "VariableDensity" ) {
-      theAuxFunc = new VariableDensityVelocityAuxFunction(0,nDim);
-    }
-    else if ( fcnName == "VariableDensityNonIso" ) {
-      theAuxFunc = new VariableDensityVelocityAuxFunction(0,nDim);
-    }
-    else if ( fcnName == "kovasznay") {
-      theAuxFunc = new KovasznayVelocityAuxFunction(0,nDim);
+    else if ( FUNCTION_UD == theDataType ) {
+      // extract the name/params
+      std::string fcnName = get_bc_function_name(userData, velocityName);
+      std::vector<double> theParams = get_bc_function_params(userData, velocityName);
+      if ( theParams.size() == 0 )
+        NaluEnv::self().naluOutputP0() << "function parameter size is zero" << std::endl;
+      // switch on the name found...
+      if ( fcnName == "convecting_taylor_vortex" ) {
+        theAuxFunc = new ConvectingTaylorVortexVelocityAuxFunction(0,nDim);
+      }
+      else if ( fcnName == "SteadyTaylorVortex" ) {
+        theAuxFunc = new SteadyTaylorVortexVelocityAuxFunction(0,nDim);
+      }
+      else if ( fcnName == "VariableDensity" ) {
+        theAuxFunc = new VariableDensityVelocityAuxFunction(0,nDim);
+      }
+      else if ( fcnName == "VariableDensityNonIso" ) {
+        theAuxFunc = new VariableDensityVelocityAuxFunction(0,nDim);
+      }
+      else if ( fcnName == "kovasznay") {
+        theAuxFunc = new KovasznayVelocityAuxFunction(0,nDim);
+      }
+      else {
+        throw std::runtime_error("ContEquationSystem::register_inflow_bc: limited functions supported");
+      }
     }
     else {
-      throw std::runtime_error("ContEquationSystem::register_inflow_bc: limited functions supported");
+      throw std::runtime_error("ContEquationSystem::register_inflow_bc: only constant and user function supported");
     }
-  }
-  else {
-    throw std::runtime_error("ContEquationSystem::register_inflow_bc: only constant and user function supported");
-  }
-
-  // bc data alg
-  AuxFunctionAlgorithm *auxAlg
-    = new AuxFunctionAlgorithm(realm_, part,
-                               theBcField, theAuxFunc,
-                               stk::topology::NODE_RANK);
-
-  // how to populate the field?
-  if ( userData.externalData_ ) {
-    // xfer will handle population; only need to populate the initial value
-    realm_.initCondAlg_.push_back(auxAlg);
-  }
-  else {
-    // put it on bcData
-    bcDataAlg_.push_back(auxAlg);
+    
+    // bc data alg
+    AuxFunctionAlgorithm *auxAlg
+      = new AuxFunctionAlgorithm(realm_, part,
+                                 theBcField, theAuxFunc,
+                                 stk::topology::NODE_RANK);
+    
+    // how to populate the field?
+    if ( userData.externalData_ ) {
+      // xfer will handle population; only need to populate the initial value
+      realm_.initCondAlg_.push_back(auxAlg);
+    }
+    else {
+      // put it on bcData
+      bcDataAlg_.push_back(auxAlg);
+    }
   }
 
   // non-solver; contribution to Gjp; allow for element-based shifted
@@ -2568,9 +2575,11 @@ ContinuityEquationSystem::register_open_bc(
 
   // register boundary data
   stk::mesh::MetaData &meta_data = realm_.meta_data();
-  ScalarFieldType *pressureBC
-    = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
-  stk::mesh::put_field(*pressureBC, *part );
+  ScalarFieldType *pressureBC = NULL;
+  if ( !realm_.solutionOptions_->activateOpenMdotCorrection_ ) {
+    pressureBC = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
+    stk::mesh::put_field(*pressureBC, *part );
+  }
 
   VectorFieldType &dpdxNone = dpdx_->field_of_state(stk::mesh::StateNone);
 
@@ -2580,7 +2589,8 @@ ContinuityEquationSystem::register_open_bc(
       = assembleNodalGradAlgDriver_->algMap_.find(algType);
     if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
       Algorithm *theAlg 
-        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, pressureBC, &dpdxNone, edgeNodalGradient_);
+        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, pressureBC == NULL ? pressure_ : pressureBC, 
+                                                 &dpdxNone, edgeNodalGradient_);
       assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
     }
     else {
@@ -2930,7 +2940,8 @@ ContinuityEquationSystem::manage_projected_nodal_gradient(
   // fill the map for expected boundary condition names...
   projectedNodalGradEqs_->set_data_map(INFLOW_BC, "pressure");
   projectedNodalGradEqs_->set_data_map(WALL_BC, "pressure");
-  projectedNodalGradEqs_->set_data_map(OPEN_BC, "pressure_bc");
+  projectedNodalGradEqs_->set_data_map(OPEN_BC, 
+   realm_.solutionOptions_->activateOpenMdotCorrection_ ? "pressure" : "pressure_bc");
   projectedNodalGradEqs_->set_data_map(SYMMETRY_BC, "pressure");
 }
 

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -89,7 +89,11 @@ SolutionOptions::SolutionOptions()
     latitude_(0.0),
     mdotAlgAccumulation_(0.0),
     mdotAlgInflow_(0.0),
-    mdotAlgOpen_(0.0)
+    mdotAlgOpen_(0.0),
+    activateOpenMdotCorrection_(false),
+    mdotAlgOpenCorrection_(0.0),
+    mdotAlgOpenIpCount_(0),
+    mdotAlgOpenPost_(0.0)
 {
   // nothing to do
 }
@@ -194,6 +198,10 @@ SolutionOptions::load(const YAML::Node & y_node)
     // allow for periodic sampling in time
     get_if_present(y_solution_options, "input_variables_from_file_periodic_time",
       inputVariablesPeriodicTime_, inputVariablesPeriodicTime_);
+
+    // check for global correction algorithm
+    get_if_present(y_solution_options, "activate_open_mdot_correction",
+      activateOpenMdotCorrection_, activateOpenMdotCorrection_);
 
     // first set of options; hybrid, source, etc.
     const YAML::Node y_options = expect_sequence(y_solution_options, "options", required);


### PR DESCRIPTION
* add global correction to LHS open BC.

* when mdot correction is active:

  1)  no pStab is used. As such, zero out open
      pStab contribution to LHS/RHS in addition to OpenMdot.

  2) make sure pressure_bc is neither registered nor used in the code
     base. This, importantly, includes Gjp contributions as well.

* ensure that at inflow bcs, cont_velocity_bc is neither registered nor used