### PR TITLE
Nalu Docs: Create CMake rule for generating PDF documentation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -24,6 +24,19 @@ if(SPHINX_FOUND)
         )
     add_dependencies(sphinx doxygen)
     add_custom_target(docs DEPENDS sphinx)
+
+    # Add a sphinx-only HTML target to avoid building doxygen while developing
+    # Nalu documentation
+    add_custom_target(sphinx-html
+        COMMAND ${SPHINX_EXECUTABLE} -M html
+        "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+        -c ${CMAKE_CURRENT_BINARY_DIR})
+
+    # PDF documentation generation using sphinx -> latex -> pdflatex
+    add_custom_target(sphinx-pdf
+        COMMAND ${SPHINX_EXECUTABLE} -M latexpdf
+        "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+        -c ${CMAKE_CURRENT_BINARY_DIR})
 else()
     message(WARNING "Skipping Sphinx documentation due to missing dependencies.")
 endif()

--- a/docs/source/theory/lowMachNumberDerivation.rst
+++ b/docs/source/theory/lowMachNumberDerivation.rst
@@ -179,7 +179,9 @@ pressure coefficient
 The resulting unscaled low Mach number equations are:
 
 .. math::
+   :nowrap:
 
+   \begin{align}
    {{\partial \rho} \over {\partial t}} + {{\partial \rho u_j} 
                                   \over {\partial x_j}} & = 0, \label{lmcon} \\
    {{\partial \rho u_i} \over {\partial t}} + {{\partial \rho u_j u_i}
@@ -190,6 +192,7 @@ The resulting unscaled low Mach number equations are:
        \over {\partial x_j}}  & =
        - {{\partial q_j} \over {\partial x_j}}
        + {{\partial P_{th}} \over {\partial t}}, \label{lmenrg}
+   \end{align}
 
 where the ideal gas law becomes
 

--- a/docs/source/theory/supportedEquationSet.rst
+++ b/docs/source/theory/supportedEquationSet.rst
@@ -37,13 +37,16 @@ The integral form of the Favre-filtered momentum equations used for turbulent tr
 
 .. math::
    :label: favmom
+   :nowrap:
 
+   \begin{align}
    \int {{\partial \bar{\rho} \tilde{u}_i} \over {\partial t}} {\rm d}V
    + \int \bar{\rho} \tilde{u}_i \tilde{u}_j n_j {\rm d}S 
-   &=& 
+   &=
    \int \tilde{\sigma}_{ij} n_j {\rm d}S 
    -\int \tau^{sgs}_{ij} n_j {\rm d}S \nonumber \\ 
-   &+& \int \left(\bar{\rho} - \rho_{\circ} \right) g_i {\rm d}V,
+   &+ \int \left(\bar{\rho} - \rho_{\circ} \right) g_i {\rm d}V,
+   \end{align}
 
 where the subgrid scale turbulent stress :math:`\tau^{sgs}_{ij}` is defined as
 
@@ -62,9 +65,12 @@ The Cauchy stress is provided by,
 and the traceless rate-of-strain tensor defined as follows:
 
 .. math::
+   :nowrap:
 
-   \tilde S^*_{ij} &=& \tilde S_{ij} - \frac{1}{3} \delta_{ij} \tilde S_{kk} \nonumber \\
-   &=& \tilde S_{ij} - \frac{1}{3} \frac{\partial \tilde u_k }{\partial x_k}\delta_{ij}.
+   \begin{align}
+   \tilde S^*_{ij} &= \tilde S_{ij} - \frac{1}{3} \delta_{ij} \tilde S_{kk} \nonumber \\
+   &= \tilde S_{ij} - \frac{1}{3} \frac{\partial \tilde u_k }{\partial x_k}\delta_{ij}.
+   \end{align}
 
 In a low Mach flow, as described in the low Mach theory section, the
 above pressure, :math:`\bar P` is the purturbation about the
@@ -593,11 +599,14 @@ the Mentor 2003 model are then
    \int{\partial \bar{\rho} k \over \partial t}\text{d}V + \int \bar{\rho} k\tilde{u}_{j} n_{j} \text{d} S = \int {(\mu + \hat \sigma_k \mu_{t})} {\partial k \over \partial x_{j}} n_{j} + \int \left(P_{k}^{\omega} - \beta^* \bar{\rho} k \omega\right) \text{d} V,
 
 .. math::
+   :nowrap:
 
-   \int {\partial \bar{\rho} \omega \over \partial t}\text{d} V + \int \bar{\rho} \omega \tilde{u}_{j} n_{j} \text{d}S &=& 
+   \begin{align}
+   \int {\partial \bar{\rho} \omega \over \partial t}\text{d} V + \int \bar{\rho} \omega \tilde{u}_{j} n_{j} \text{d}S &=
    \int  {(\mu + \hat\sigma_{\omega} \mu_{t})} {\partial \omega \over \partial x_{j}} n_{j}
    + \int  {2(1-F) \frac{\bar{\rho}\sigma_{\omega2}} {\omega} {\partial k \over \partial x_j} {\partial \omega \over \partial x_j} } \text{d}V \nonumber \\ 
-   &+&  \int \left(\frac{\hat\gamma}{\nu_t} P_{k}^{\omega} - \hat \beta \bar{\rho} \omega^{2}\right) \text{d}V.
+   &+  \int \left(\frac{\hat\gamma}{\nu_t} P_{k}^{\omega} - \hat \beta \bar{\rho} \omega^{2}\right) \text{d}V.
+   \end{align}
 
 The model coefficients, :math:`\hat\sigma_k`, :math:`\hat\sigma_{\omega}`, :math:`\hat\gamma` and :math:`\hat\beta`
 must also be blended, which is represented by


### PR DESCRIPTION
    - New target `sphinx-pdf` that calls the `latexpdf` sphinx generator
      to create a Nalu.pdf file.

    - Fix RST declarations of some equations that weren't converted to
      latex properly. Disabled automated wrapping and manually created
      the equations in latex format to get the desired layout.

    - Also added a `sphinx-html` target to bypass doxygen runs - useful
      looking a HTML docs while working on RST files.