### PR TITLE
Changed the behavior of residual norm reporting to accomodate the use

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -224,12 +224,15 @@ public:
   void report_built_supp_alg_names();
   bool supp_alg_is_requested(std::string name);
   bool supp_alg_is_requested(std::vector<std::string>);
-
+  
+  void reset_nonlinear_iteration_count();
   bool nodal_src_is_requested();
 
   EquationSystems &equationSystems_;
   Realm &realm_;
   std::string name_;
+  std::string sysName_;
+  bool reportMyResiduals_;
   const std::string eqnTypeName_;
   int maxIterations_;
   double convergenceTolerance_;
@@ -249,6 +252,9 @@ public:
   int nonLinearIterationCount_;
   bool reportLinearIterations_;
   bool edgeNodalGradient_;
+  int eqSysNonLinearIterationCount_;
+  double firstNonLinearResidual_;
+  double scaledNonLinearResidual_;
 
   void update_iteration_statistics(
     const int & iters);

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -142,6 +142,10 @@ EnthalpyEquationSystem::EnthalpyEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_ENTHALPY);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
 
+  // name_ will be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("enthalpy");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for enthalpy: " << edgeNodalGradient_ <<std::endl;

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -720,6 +720,7 @@ EquationSystems::solve_and_update()
 
   for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
   {
+    (*ii)->reset_nonlinear_iteration_count();
     (*ii)->pre_iter_work();
     (*ii)->solve_and_update();
     (*ii)->post_iter_work();

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -127,6 +127,10 @@ HeatCondEquationSystem::HeatCondEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TEMPERATURE);
   linsys_ = LinearSystem::create(realm_, 1, "HeatCondEQS", solver);
 
+  // name_ will be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("temperature");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for temperature: " << edgeNodalGradient_ <<std::endl;

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -878,6 +878,10 @@ MomentumEquationSystem::MomentumEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MOMENTUM);
   linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
 
+  // name_ may be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("velocity");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for velocity: " << edgeNodalGradient_ <<std::endl;
@@ -2138,6 +2142,10 @@ ContinuityEquationSystem::ContinuityEquationSystem(
   std::string solverName = realm_.equationSystems_.get_solver_block_name("pressure");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_CONTINUITY);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+
+  // name_ may be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
 
   // determine nodal gradient form
   set_nodal_gradient("pressure");

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -105,6 +105,10 @@ MassFractionEquationSystem::MassFractionEquationSystem(
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mass_fraction");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MASS_FRACTION);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+
+  // name_ will be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+
   // turn off standard output
   linsys_->provideOutput_ = false;
 

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -130,6 +130,10 @@ MixtureFractionEquationSystem::MixtureFractionEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MIXTURE_FRACTION);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
 
+  // name_ will be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("mixture_fraction");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for mixture_fraction: " << edgeNodalGradient_ <<std::endl;

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -84,6 +84,10 @@ ProjectedNodalGradientEquationSystem::ProjectedNodalGradientEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, eqType_);
   linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, eqSysName_, solver);
 
+  // Set sysName_ to eqSysName_ for residual reporting
+  sysName_ = eqSysName_;
+  reportMyResiduals_ = true;
+
   // push back EQ to manager
   realm_.push_equation_to_systems(this);
 }
@@ -374,7 +378,7 @@ ProjectedNodalGradientEquationSystem::solve_and_update_external()
 void
 ProjectedNodalGradientEquationSystem::deactivate_output()
 {
-  linsys_->provideOutput_ = false;
+  reportMyResiduals_ = false;
 }
 
 } // namespace nalu

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -106,6 +106,10 @@ SpecificDissipationRateEquationSystem::SpecificDissipationRateEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_SPEC_DISS_RATE);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
 
+  // name_ may be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("specific_dissipation_rate");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for specific_dissipation_rate: " << edgeNodalGradient_ <<std::endl;

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1444,20 +1444,6 @@ TpetraLinearSystem::solve(
   linearSolveIterations_ = iters;
   nonLinearResidual_ = realm_.l2Scaling_*norm2;
   linearResidual_ = finalResidNorm;
-    
-  if ( realm_.currentNonlinearIteration_ == 1 )
-    firstNonLinearResidual_ = nonLinearResidual_;
-  scaledNonLinearResidual_ = nonLinearResidual_/std::max(std::numeric_limits<double>::epsilon(), firstNonLinearResidual_);
-
-  if ( provideOutput_ ) {
-    const int nameOffset = name_.length()+8;
-    NaluEnv::self().naluOutputP0()
-      << std::setw(nameOffset) << std::right << name_
-      << std::setw(32-nameOffset)  << std::right << iters
-      << std::setw(18) << std::right << finalResidNorm
-      << std::setw(15) << std::right << nonLinearResidual_
-      << std::setw(14) << std::right << scaledNonLinearResidual_ << std::endl;
-  }
 
   return status;
 }

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -130,6 +130,10 @@ TurbKineticEnergyEquationSystem::TurbKineticEnergyEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TURBULENT_KE);
   linsys_ = LinearSystem::create(realm_, 1, name_, solver);
 
+  // name_ may be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form
   set_nodal_gradient("turbulent_ke");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for turbulent_ke: " << edgeNodalGradient_ <<std::endl;

--- a/src/mesh_motion/MeshDisplacementEquationSystem.C
+++ b/src/mesh_motion/MeshDisplacementEquationSystem.C
@@ -104,6 +104,10 @@ MeshDisplacementEquationSystem::MeshDisplacementEquationSystem(
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MESH_DISPLACEMENT);
   linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
 
+  // name_ may be overwritten by load of user system name, so set sysName_ to the standard name
+  sysName_ = name_;
+  reportMyResiduals_ = true;
+
   // determine nodal gradient form; use the edgeNodalGradient_ data member since mesh_displacement EQ does not need this
   set_nodal_gradient("mesh_velocity");
   NaluEnv::self().naluOutputP0() << "Edge projected nodal gradient for mesh_velocity: " << edgeNodalGradient_ <<std::endl;


### PR DESCRIPTION
case where the user specifies max_iterations > 1 for individual
equation systems.  This fixes a bug that caused an inappropriate
scaling of the nonlinear residual by the current nonlinear residual
only if the outer real iteration counter was at 1.  A new equation
system iteration counter has been introduced, and now the nonlinear
convergence behavior is tracked and reported in the EquationSystem
class rather than the TpetraLinearSystem class.

Added a sysName_ variable to the EquationSystem class.  This was done
to preserve residual norm output format while transferring control of
the output to the EquationSystem class.

Preserve special-case residual output for PNG, RTE, PMR equation sets, using the
reportMyResiduals_ variable within the EquationSystem class.