### PR TITLE
Bug fix for #183 and #184

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -150,7 +150,7 @@ public:
   virtual void register_interior_algorithm(
     stk::mesh::Part *part) {}
   virtual void provide_output() {}
-  virtual void pre_timestep_work() {}
+  virtual void pre_timestep_work();
   virtual void reinitialize_linear_system() {}
   virtual void post_adapt_work() {}
   virtual void dump_eq_time();
@@ -212,7 +212,7 @@ public:
 
   virtual void load(const YAML::Node & node)
   {
-    get_required(node, "name", name_);
+    get_required(node, "name", userSuppliedName_);
     get_required(node, "max_iterations", maxIterations_);
     get_required(node, "convergence_tolerance", convergenceTolerance_);
   }
@@ -230,6 +230,7 @@ public:
   EquationSystems &equationSystems_;
   Realm &realm_;
   std::string name_;
+  std::string userSuppliedName_;
   const std::string eqnTypeName_;
   int maxIterations_;
   double convergenceTolerance_;
@@ -248,6 +249,7 @@ public:
   double minLinearIterations_;
   int nonLinearIterationCount_;
   bool reportLinearIterations_;
+  bool firstTimeStepSolve_;
   bool edgeNodalGradient_;
 
   void update_iteration_statistics(

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -33,6 +33,7 @@ typedef std::vector< Part * > PartVector ;
 namespace sierra{
 namespace nalu{
 
+class EquationSystem;
 class Realm;
 class LinearSolver;
 
@@ -43,12 +44,12 @@ public:
   LinearSystem(
     Realm &realm,
     const unsigned numDof,
-    const std::string & name,
+    EquationSystem *eqSys,
     LinearSolver *linearSolver);
 
   virtual ~LinearSystem() {}
 
-  static LinearSystem *create(Realm& realm, const unsigned numDof, const std::string & name, LinearSolver *linearSolver);
+  static LinearSystem *create(Realm& realm, const unsigned numDof, EquationSystem *eqSys, LinearSolver *linearSolver);
 
   // Graph/Matrix Construction
   virtual void buildNodeGraph(const stk::mesh::PartVector & parts)=0; // for nodal assembly (e.g., lumped mass and source)
@@ -116,7 +117,7 @@ public:
   const double & nonLinearResidual() {return nonLinearResidual_; }
   const double & scaledNonLinearResidual() {return scaledNonLinearResidual_; }
   void setNonLinearResidual(const double nlr) { nonLinearResidual_ = nlr;}
-  const std::string name() { return name_; }
+  const std::string name() { return eqSysName_; }
   bool & recomputePreconditioner() {return recomputePreconditioner_;}
   bool & reusePreconditioner() {return reusePreconditioner_;}
   double get_timer_precond();
@@ -132,11 +133,12 @@ protected:
   bool debug();
 
   Realm &realm_;
+  EquationSystem *eqSys_;
   bool inConstruction_;
   int writeCounter_;
 
   const unsigned numDof_;
-  const std::string name_;
+  const std::string eqSysName_;
   LinearSolver * linearSolver_;
   int linearSolveIterations_;
   double nonLinearResidual_;

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -51,7 +51,7 @@ public:
   TpetraLinearSystem(
     Realm &realm,
     const unsigned numDof,
-    const std::string & name,
+    EquationSystem *eqSys,
     LinearSolver * linearSolver);
   ~TpetraLinearSystem();
 
@@ -199,7 +199,6 @@ private:
   std::vector<LocalOrdinal> entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxGloballyOwnedRowId_; // = (num_owned_nodes + num_globallyOwned_nodes) * numDof_
-  EquationSystem* eqSys_;
 };
 
 template<typename T1, typename T2>

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -140,7 +140,7 @@ EnthalpyEquationSystem::EnthalpyEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("enthalpy");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_ENTHALPY);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("enthalpy");
@@ -916,7 +916,7 @@ EnthalpyEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("enthalpy");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_ENTHALPY);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();
@@ -983,7 +983,7 @@ EnthalpyEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     // enthalpy assemble, load_complete and solve
     assemble_and_solve(hTmp_);

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -42,6 +42,7 @@ EquationSystem::EquationSystem(
   : equationSystems_(eqSystems),
     realm_(eqSystems.realm_),
     name_(name),
+    userSuppliedName_(name),
     eqnTypeName_(eqnTypeName),
     maxIterations_(1),
     convergenceTolerance_(1.0),
@@ -57,6 +58,7 @@ EquationSystem::EquationSystem(
     minLinearIterations_(1.0e10),
     nonLinearIterationCount_(0),
     reportLinearIterations_(false),
+    firstTimeStepSolve_(true),
     edgeNodalGradient_(realm_.realmUsesEdges_),
     linsys_(NULL),
     num_graph_entries_(0)
@@ -135,6 +137,15 @@ EquationSystem::system_is_converged()
 }
 
 //--------------------------------------------------------------------------
+//-------- pre_timestep_work -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+EquationSystem::pre_timestep_work()
+{
+  firstTimeStepSolve_ = true;
+}
+
+//--------------------------------------------------------------------------
 //-------- provide_scaled_norm ---------------------------------------------
 //--------------------------------------------------------------------------
 double
@@ -181,7 +192,7 @@ EquationSystem::dump_eq_time()
 
   int nprocs = NaluEnv::self().parallel_size();
 
-  NaluEnv::self().naluOutputP0() << "Timing for Eq: " << name_ << std::endl;
+  NaluEnv::self().naluOutputP0() << "Timing for Eq: " << userSuppliedName_ << std::endl;
 
   // get max, min, and sum over processes
   stk::all_reduce_sum(NaluEnv::self().parallel_comm(), &l_timer[0], &g_sum[0], 6);
@@ -295,7 +306,7 @@ EquationSystem::assemble_and_solve(
     linsys_->linearSolveIterations());
   
   if ( error > 0 )
-    NaluEnv::self().naluOutputP0() << "Error in " << name_ << "::solve_and_update()  " << std::endl;
+    NaluEnv::self().naluOutputP0() << "Error in " << userSuppliedName_ << "::solve_and_update()  " << std::endl;
 }
 
 //--------------------------------------------------------------------------

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -125,7 +125,7 @@ HeatCondEquationSystem::HeatCondEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("temperature");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TEMPERATURE);
-  linsys_ = LinearSystem::create(realm_, 1, "HeatCondEQS", solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("temperature");
@@ -908,7 +908,7 @@ HeatCondEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("temperature");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TEMPERATURE);
-  linsys_ = LinearSystem::create(realm_, 1, "HeatCondEQS", solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();
@@ -939,7 +939,7 @@ HeatCondEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
     
     // heat conduction assemble, load_complete and solve
     assemble_and_solve(tTmp_);

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -8,6 +8,7 @@
 
 #include <LinearSystem.h>
 #include <TpetraLinearSystem.h>
+#include <EquationSystem.h>
 #include <Realm.h>
 #include <Simulation.h>
 #include <LinearSolver.h>
@@ -44,13 +45,14 @@ namespace nalu{
 LinearSystem::LinearSystem(
   Realm &realm,
   const unsigned numDof,
-  const std::string & name,
+  EquationSystem *eqSys,
   LinearSolver *linearSolver)
   : realm_(realm),
+    eqSys_(eqSys),
     inConstruction_(false),
     writeCounter_(0),
     numDof_(numDof),
-    name_(name),
+    eqSysName_(eqSys->name_),
     linearSolver_(linearSolver),
     linearSolveIterations_(0),
     nonLinearResidual_(0.0),
@@ -81,13 +83,13 @@ bool LinearSystem::debug()
 }
 
 // static method
-LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, const std::string & name, LinearSolver *solver)
+LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, EquationSystem *eqSys, LinearSolver *solver)
 {
   switch(solver->getType()) {
   case PT_TPETRA:
     return new TpetraLinearSystem(realm,
                                   numDof,
-                                  name,
+                                  eqSys,
                                   solver);
     break;
   case PT_END:

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -615,7 +615,7 @@ LowMachEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     // momentum assemble, load_complete and solve
     momentumEqSys_->assemble_and_solve(momentumEqSys_->uTmp_);
@@ -876,7 +876,7 @@ MomentumEquationSystem::MomentumEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("velocity");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MOMENTUM);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("velocity");
@@ -1971,7 +1971,7 @@ MomentumEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("velocity");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MOMENTUM);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
 
   // initialize new solver
   solverAlgDriver_->initialize_connectivity();
@@ -2137,7 +2137,7 @@ ContinuityEquationSystem::ContinuityEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("pressure");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_CONTINUITY);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("pressure");
@@ -2847,7 +2847,7 @@ ContinuityEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("pressure");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_CONTINUITY);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -104,7 +104,7 @@ MassFractionEquationSystem::MassFractionEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mass_fraction");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MASS_FRACTION);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
   // turn off standard output
   linsys_->provideOutput_ = false;
 
@@ -718,7 +718,7 @@ MassFractionEquationSystem::solve_and_update()
     
   for ( int i = 0; i < maxIterations_; ++i ) {
 
-    NaluEnv::self().naluOutputP0() << " " << i+1 << "/" << maxIterations_ << std::setw(15) << std::right << name_ << std::endl;
+    NaluEnv::self().naluOutputP0() << " " << i+1 << "/" << maxIterations_ << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     double nonLinearResidualSum = 0.0;
     double linearResidualSum = 0.0;

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -128,7 +128,7 @@ MixtureFractionEquationSystem::MixtureFractionEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mixture_fraction");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MIXTURE_FRACTION);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("mixture_fraction");
@@ -840,7 +840,7 @@ MixtureFractionEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mixture_fraction");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MIXTURE_FRACTION);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();
@@ -906,7 +906,7 @@ MixtureFractionEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     // mixture fraction assemble, load_complete and solve
     assemble_and_solve(zTmp_);

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -82,7 +82,7 @@ ProjectedNodalGradientEquationSystem::ProjectedNodalGradientEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name(dofName);
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, eqType_);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, eqSysName_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
 
   // push back EQ to manager
   realm_.push_equation_to_systems(this);
@@ -326,7 +326,7 @@ ProjectedNodalGradientEquationSystem::reinitialize_linear_system()
   // create new solver; reset parameters
   std::string solverName = realm_.equationSystems_.get_solver_block_name(dofName_);
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, eqType_);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, eqSysName_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
   linsys_->provideOutput_ = provideOutput;
 
   // initialize

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -104,7 +104,7 @@ SpecificDissipationRateEquationSystem::SpecificDissipationRateEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("specific_dissipation_rate");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_SPEC_DISS_RATE);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("specific_dissipation_rate");
@@ -694,7 +694,7 @@ SpecificDissipationRateEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("specific_dissipation_rate");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_SPEC_DISS_RATE);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -128,7 +128,7 @@ TurbKineticEnergyEquationSystem::TurbKineticEnergyEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("turbulent_ke");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TURBULENT_KE);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // determine nodal gradient form
   set_nodal_gradient("turbulent_ke");
@@ -875,7 +875,7 @@ TurbKineticEnergyEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("turbulent_ke");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_TURBULENT_KE);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
 
   // initialize
   solverAlgDriver_->initialize_connectivity();
@@ -909,7 +909,7 @@ TurbKineticEnergyEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     // tke assemble, load_complete and solve
     assemble_and_solve(kTmp_);

--- a/src/mesh_motion/MeshDisplacementEquationSystem.C
+++ b/src/mesh_motion/MeshDisplacementEquationSystem.C
@@ -102,7 +102,7 @@ MeshDisplacementEquationSystem::MeshDisplacementEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mesh_displacement");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MESH_DISPLACEMENT);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
 
   // determine nodal gradient form; use the edgeNodalGradient_ data member since mesh_displacement EQ does not need this
   set_nodal_gradient("mesh_velocity");
@@ -481,7 +481,7 @@ MeshDisplacementEquationSystem::reinitialize_linear_system()
   // create new solver
   std::string solverName = realm_.equationSystems_.get_solver_block_name("mesh_velocity");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_MESH_DISPLACEMENT);
-  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, name_, solver);
+  linsys_ = LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
 
   // initialize new solver
   solverAlgDriver_->initialize_connectivity();
@@ -516,7 +516,7 @@ MeshDisplacementEquationSystem::solve_and_update()
   for ( int k = 0; k < maxIterations_; ++k ) {
 
     NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
-                    << std::setw(15) << std::right << name_ << std::endl;
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
 
     // tke assemble, load_complete and solve
     assemble_and_solve(dxTmp_);

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -116,7 +116,7 @@ RadiativeTransportEquationSystem::RadiativeTransportEquationSystem(
   // extract solver name and solver object
   std::string solverName = realm_.equationSystems_.get_solver_block_name("intensity");
   LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_INTENSITY);
-  linsys_ = LinearSystem::create(realm_, 1, name_, solver);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
   // turn off standard output
   linsys_->provideOutput_ = false;
 
@@ -814,7 +814,7 @@ RadiativeTransportEquationSystem::solve_and_update()
     zero_irradiation();
 
     NaluEnv::self().naluOutputP0() << "   "
-                    << name_ << " Iteration: " << i+1 << "/" << maxIterations_ << std::endl;
+                    << userSuppliedName_ << " Iteration: " << i+1 << "/" << maxIterations_ << std::endl;
 
     double nonLinearResidualSum = 0.0;
     double linearIterationsSum = 0.0;
@@ -870,7 +870,7 @@ RadiativeTransportEquationSystem::solve_and_update()
 
     // dump norm and averages
     NaluEnv::self().naluOutputP0()
-      << "EqSystem Name:       " << name_ << std::endl
+      << "EqSystem Name:       " << userSuppliedName_ << std::endl
       << "   aver iters      = " << linearIterationsSum/double(ordinateDirections_) << std::endl
       << "nonlinearResidNrm  = " << nonLinearResidualSum/double(ordinateDirections_) 
       << " scaled: " << nonLinearResidualSum_/firstNonLinearResidualSum_ << std::endl

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -18,9 +18,9 @@ struct HelperObjects {
     realmDefaultNode(unit_test_utils::get_realm_default_node()),
     naluObj(new unit_test_utils::NaluTest(yamlNode)),
     realm(naluObj->create_realm(realmDefaultNode, "multi_physics")),
-    linsys(new unit_test_utils::TestLinearSystem(realm, numDof)),
     eqSystems(realm),
     eqSystem(eqSystems),
+    linsys(new unit_test_utils::TestLinearSystem(realm, numDof, &eqSystem)),
     assembleElemSolverAlg(nullptr)
   {
     realm.metaData_ = &bulk.mesh_meta_data();
@@ -43,9 +43,9 @@ struct HelperObjects {
   YAML::Node realmDefaultNode;
   unit_test_utils::NaluTest* naluObj;
   sierra::nalu::Realm& realm;
-  unit_test_utils::TestLinearSystem* linsys;
   sierra::nalu::EquationSystems eqSystems;
   sierra::nalu::EquationSystem eqSystem;
+  unit_test_utils::TestLinearSystem* linsys;
   sierra::nalu::AssembleElemSolverAlgorithm* assembleElemSolverAlg;
 };
 
@@ -55,9 +55,9 @@ struct HelperObjectsNewME {
     realmDefaultNode(unit_test_utils::get_realm_default_node()),
     naluObj(new unit_test_utils::NaluTest(yamlNode)),
     realm(naluObj->create_realm(realmDefaultNode, "multi_physics")),
-    linsys(new unit_test_utils::TestLinearSystem(realm, numDof)),
     eqSystems(realm),
     eqSystem(eqSystems),
+    linsys(new unit_test_utils::TestLinearSystem(realm, numDof, &eqSystem)),
     assembleElemSolverAlg(nullptr)
   {
     realm.metaData_ = &bulk.mesh_meta_data();
@@ -80,9 +80,9 @@ struct HelperObjectsNewME {
   YAML::Node realmDefaultNode;
   unit_test_utils::NaluTest* naluObj;
   sierra::nalu::Realm& realm;
-  unit_test_utils::TestLinearSystem* linsys;
   sierra::nalu::EquationSystems eqSystems;
   sierra::nalu::EquationSystem eqSystem;
+  unit_test_utils::TestLinearSystem* linsys;
   sierra::nalu::AssembleElemSolverAlgorithm* assembleElemSolverAlg;
 };
 

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -9,6 +9,7 @@
 #define UNITTESTLINEARSYSTEM_H
 
 #include "LinearSystem.h"
+#include "EquationSystem.h"
 
 namespace unit_test_utils {
 
@@ -16,8 +17,8 @@ class TestLinearSystem : public sierra::nalu::LinearSystem
 {
 public:
 
-  TestLinearSystem( sierra::nalu::Realm &realm, const unsigned numDof)
-   : sierra::nalu::LinearSystem(realm, numDof, "test", nullptr)
+ TestLinearSystem( sierra::nalu::Realm &realm, const unsigned numDof, sierra::nalu::EquationSystem *eqSys)
+   : sierra::nalu::LinearSystem(realm, numDof, eqSys, nullptr)
   {}
 
   virtual ~TestLinearSystem() {}


### PR DESCRIPTION
There is a clash over names of equation systems. The EquationSystem
is provided an internal name when created. However, later, the
load() step overides this name with a user suplied value.

Consider the following:

	LowMachEQS
          name: myLowMach
        MixtureFractionEQS
          name: myZ
        TurbKinEnerEQS
          name: myTke

Each of the user supplied names are provided above. LowMach creates momentum
and continuity with name_ set to internally suplied names, e.h. "MomEQS"
and "ContEQS". MixFrac and TKE will use also use an internal name, e.g.,
"MixFracEQS", to create the EQS and provide this name to LinSys. However,
after the load() for the equation system input block, the name_ will
be reset to the user supplied name, e.g., "myZ". Therefore,
the name that LinSys uses to look up the EQS will be "MixFracEQS". The eqSys_
under LinSys will always be null (since the internal name was changed to myZ).

* Add notion of userSuppliedName_ and name_, the former set to the provided
name at construction should a user supplied name not exist (as in the above
lowMach use case). Use this name to extract eqSys_ under linearSys.

Notes:
a) With the above fix, there are no diffs...

100% tests passed, 0 tests failed out of 70

* Why look eqSys_ later when the EQS creates the linear system to begin with?
Simple pass in the EQS to LinSys and never extract it based on name.

* modifed unit testing to pass in EQS within the linSys creation.

Notes:
b) With the above fix, there are no diffs...

100% tests passed, 0 tests failed out of 70

* For #184, add firstTimeSolve that is used to properly define the first
nonlinear norm for a time step. Create a bool, firstTimeStepSolve
that is used to determine the first nonlinear norm used for all subsequent
convergence.

Notes:

a) Works now for all use cases. No diffs.

Notes:

a) use case of multiple EQS iterations: Here enthalpy's first norm is 44658.
This value is used consistently within the subiteration.

1/20    Equation System Iteration
 1/1      myLowMach
 1/5         myEnth
        EnthalpyEQS            2       5.00935e-05        44658.5             1
 2/5         myEnth
        EnthalpyEQS            2       7.43172e-09    9.59221e-05    2.1479e-09
2/20    Equation System Iteration
 1/1      myLowMach
 1/5         myEnth
        EnthalpyEQS            2       5.55722e-06        25.6951   0.000575367
 2/5         myEnth

b) use case is for multiple realm iterations... Here, the first heat cond and
momentum NLR is: 2.98 and 1.97e-9. These values are used consistently within
the subiteration.

   Realm Nonlinear Iteration: 1/5

realm_1::advance_time_step()
NLI    Name           Linear Iter      Linear Res     NLinear Res    Scaled NLR
---    ----           -----------      ----------     -----------    ----------
1/1    Equation System Iteration
 1/1           myHC
        HeatCondEQS            5        0.00125363        2.98753             1

realm_2::advance_time_step()
NLI    Name           Linear Iter      Linear Res     NLinear Res    Scaled NLR
---    ----           -----------      ----------     -----------    ----------
1/1    Equation System Iteration
 1/1      myLowMach
        MomentumEQS            6       1.79197e-12    1.97739e-09             1
        ContinuityEQS         10       4.49489e-11    1.19206e-07             1
 1/1         myEnth
        EnthalpyEQS            6       1.40988e-08    2.30266e-05             1

   Realm Nonlinear Iteration: 2/5

realm_1::advance_time_step()
NLI    Name           Linear Iter      Linear Res     NLinear Res    Scaled NLR
---    ----           -----------      ----------     -----------    ----------
1/1    Equation System Iteration
 1/1           myHC
        HeatCondEQS            6       2.17219e-09    1.38557e-05   4.63784e-06

realm_2::advance_time_step()
NLI    Name           Linear Iter      Linear Res     NLinear Res    Scaled NLR
---    ----           -----------      ----------     -----------    ----------
1/1    Equation System Iteration
 1/1      myLowMach
        MomentumEQS            7       9.58412e-14    2.92785e-10      0.148066
        ContinuityEQS          9       6.75397e-11    9.38425e-08       0.78723
 1/1         myEnth
        EnthalpyEQS            6       4.96154e-10    5.14251e-07     0.0223328

Final note:

There is no convergence test within the current iteration over equation systems...
That is fixed by the user specified value. We may want to change that.