### PR TITLE
Use custom sumInto function instead of Tpetra call

### DIFF
--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -71,8 +71,11 @@ public:
       const SharedMemView<const double*> & rhs,
       const SharedMemView<const double**> & lhs,
       const SharedMemView<int*> & localIds,
+      const SharedMemView<int*> & sortPermutation,
       const char * trace_tag
       )=0;
+
+
 
   virtual void sumInto(
     const std::vector<stk::mesh::Entity> & sym_meshobj,

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -49,6 +49,7 @@ protected:
     unsigned numMeshobjs,
     const stk::mesh::Entity* symMeshobjs,
     const SharedMemView<int*> & scratchIds,
+    const SharedMemView<int*> & sortPermutation,
     const SharedMemView<const double*> & rhs,
     const SharedMemView<const double**> & lhs,
     const char *trace_tag);

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -75,6 +75,7 @@ public:
       const SharedMemView<const double*> & rhs,
       const SharedMemView<const double**> & lhs,
       const SharedMemView<int*> & localIds,
+      const SharedMemView<int*> & sortPermutation,
       const char * trace_tag);
 
   void sumInto(
@@ -199,6 +200,8 @@ private:
   std::vector<LocalOrdinal> entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxGloballyOwnedRowId_; // = (num_owned_nodes + num_globallyOwned_nodes) * numDof_
+
+  std::vector<int> sortPermutation_;
 };
 
 template<typename T1, typename T2>

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -59,11 +59,12 @@ SolverAlgorithm::apply_coeff(
   unsigned numMeshobjs,
   const stk::mesh::Entity* symMeshobjs,
   const SharedMemView<int*> & scratchIds,
+  const SharedMemView<int*> & sortPermutation,
   const SharedMemView<const double*> & rhs,
   const SharedMemView<const double**> & lhs,
   const char *trace_tag)
 {
-  eqSystem_->linsys_->sumInto(numMeshobjs, symMeshobjs, rhs, lhs, scratchIds, trace_tag);
+  eqSystem_->linsys_->sumInto(numMeshobjs, symMeshobjs, rhs, lhs, scratchIds, sortPermutation, trace_tag);
 }
 
 } // namespace nalu

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -43,6 +43,7 @@ public:
       const sierra::nalu::SharedMemView<const double*> & rhs,
       const sierra::nalu::SharedMemView<const double**> & lhs,
       const sierra::nalu::SharedMemView<int*> & localIds,
+      const sierra::nalu::SharedMemView<int*> & sortPermutation,
       const char * trace_tag
       )
   {


### PR DESCRIPTION
* Sorts the local column indices on a per-element basis.  This allows us to search for offsets and modify matrix values in just one pass for a particular element being summed into the linear system.  

* Shows a good speed-up on small tests problems, especially with intel compilers.  I plan to---but have yet to---get performance data on a large scale problem.