### PR TITLE
Re-commit "Use local kokkos matrix API instead of Tpetra::CrsMatrix A…

### DIFF
--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1201,7 +1201,7 @@ TpetraLinearSystem::sumInto(
   )
 {
   const size_t n_obj = entities.size();
-  const int numRows = n_obj * numDof_;
+  const unsigned numRows = n_obj * numDof_;
 
   ThrowAssert(numRows == rhs.size());
   ThrowAssert(numRows*numRows == lhs.size());
@@ -1217,17 +1217,17 @@ TpetraLinearSystem::sumInto(
     }
   }
 
-  for (int i = 0; i < numRows; ++i) {
+  for (unsigned i = 0; i < numRows; ++i) {
     sortPermutation_[i] = i;
   }
-  Tpetra::Details::shellSortKeysAndValues(scratchIds.data(), sortPermutation_.data(), numRows);
+  Tpetra::Details::shellSortKeysAndValues(scratchIds.data(), sortPermutation_.data(), (int)numRows);
 
   const LinSys::Matrix::local_matrix_type& ownedLocalMatrix = ownedMatrix_->getLocalMatrix();
   const LinSys::Matrix::local_matrix_type& globallyOwnedLocalMatrix = globallyOwnedMatrix_->getLocalMatrix();
   const auto& ownedLocalRhs = ownedRhs_->getLocalView<sierra::nalu::HostSpace>();
   const auto& globallyOwnedLocalRhs = globallyOwnedRhs_->getLocalView<sierra::nalu::HostSpace>();
 
-  for (int r = 0; r < numRows; r++) {
+  for (unsigned r = 0; r < numRows; r++) {
     const LocalOrdinal localId = scratchIds[r];
     const LocalOrdinal cur_perm_index = sortPermutation_[r];
     const double* const cur_lhs = &lhs[cur_perm_index*numRows];

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1269,6 +1269,7 @@ TpetraLinearSystem::applyDirichletBCs(
   stk::mesh::BucketVector const& buckets =
     realm_.get_buckets( stk::topology::NODE_RANK, selector );
 
+  const bool internalMatrixIsSorted = true;
   int nbc=0;
   for(const stk::mesh::Bucket* bptr : buckets) {
     const stk::mesh::Bucket & b = *bptr;
@@ -1294,6 +1295,7 @@ TpetraLinearSystem::applyDirichletBCs(
         const bool useOwned = localId < maxOwnedRowId_;
         const LocalOrdinal actualLocalId = useOwned ? localId : localId - maxOwnedRowId_;
         Teuchos::RCP<LinSys::Matrix> matrix = useOwned ? ownedMatrix_ : globallyOwnedMatrix_;
+        const LinSys::Matrix::local_matrix_type& local_matrix = matrix->getLocalMatrix();
 
         if(localId > maxGloballyOwnedRowId_) {
           std::cerr << "localId > maxGloballyOwnedRowId_:: localId= " << localId << " maxGloballyOwnedRowId_= " << maxGloballyOwnedRowId_ << " useOwned = " << (localId < maxOwnedRowId_ ) << std::endl;
@@ -1306,11 +1308,13 @@ TpetraLinearSystem::applyDirichletBCs(
 
         matrix->getLocalRowView(actualLocalId, indices, values);
         const size_t rowLength = values.size();
-        new_values.resize(rowLength);
-        for(size_t i=0; i < rowLength; ++i) {
-            new_values[i] = (indices[i] == localId) ? diagonal_value : 0;
+        if (rowLength > 0) {
+          new_values.resize(rowLength);
+          for(size_t i=0; i < rowLength; ++i) {
+              new_values[i] = (indices[i] == localId) ? diagonal_value : 0;
+          }
+          local_matrix.replaceValues(actualLocalId, &indices[0], rowLength, new_values.data(), internalMatrixIsSorted);
         }
-        matrix->replaceLocalValues(actualLocalId, indices, new_values);
 
         // Replace the RHS residual with (desired - actual)
         Teuchos::RCP<LinSys::Vector> rhs = useOwned ? ownedRhs_: globallyOwnedRhs_;
@@ -1360,11 +1364,13 @@ TpetraLinearSystem::prepareConstraints(
       // Adjust the LHS; full row is perfectly zero
       matrix->getLocalRowView(actualLocalId, indices, values);
       const size_t rowLength = values.size();
-      new_values.resize(rowLength);
-      for(size_t i=0; i < rowLength; ++i) {
-        new_values[i] = 0.0;
+      if (rowLength > 0) {
+        new_values.resize(rowLength);
+        for(size_t i=0; i < rowLength; ++i) {
+          new_values[i] = 0.0;
+        }
+        local_matrix.replaceValues(actualLocalId, &indices[0], rowLength, new_values.data(), internalMatrixIsSorted);
       }
-      local_matrix.replaceValues(actualLocalId, &indices[0], rowLength, new_values.data(), internalMatrixIsSorted);
       
       // Replace the RHS residual with zero
       Teuchos::RCP<LinSys::Vector> rhs = useOwned ? ownedRhs_: globallyOwnedRhs_;
@@ -1407,11 +1413,13 @@ TpetraLinearSystem::resetRows(
       // Adjust the LHS; zero out all entries (including diagonal)
       matrix->getLocalRowView(actualLocalId, indices, values);
       const size_t rowLength = values.size();
-      new_values.resize(rowLength);
-      for (size_t i=0; i < rowLength; i++) {
-        new_values[i] = 0.0;
+      if (rowLength > 0) {
+        new_values.resize(rowLength);
+        for (size_t i=0; i < rowLength; i++) {
+          new_values[i] = 0.0;
+        }
+        local_matrix.replaceValues(actualLocalId, &indices[0], rowLength, new_values.data(), internalMatrixIsSorted);
       }
-      local_matrix.replaceValues(actualLocalId, &indices[0], rowLength, new_values.data(), internalMatrixIsSorted);
 
       // Replace RHS residual entry = 0.0
       Teuchos::RCP<LinSys::Vector> rhs =


### PR DESCRIPTION
…PI for..."

commit 9437e0c988dd7ec7a3ea3d0ab603e79a06fa9fa5 was previously reverted.

This puts it back in, but also fixes the issue that was seg-faulting
when a zero rowLength was encountered. (Which manifested as indices->getRawPtr()==0)