### PR TITLE
Refactor simd unit-tests to not use special element-loop.

### DIFF
--- a/unit_tests/UnitTestSimdContAdvElem.C
+++ b/unit_tests/UnitTestSimdContAdvElem.C
@@ -49,9 +49,11 @@ TEST_F(Hex8MeshWithNSOFields, continuityAdvElem)
 
   stk::mesh::Selector all = meta.universal_part();
   const stk::mesh::BucketVector& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK, all);
-  const int numElems = stk::mesh::count_selected_entities(all, elemBuckets);
+  const unsigned numElems = stk::mesh::count_selected_entities(all, elemBuckets);
 
   std::cerr<<"numElems: "<<numElems<<", elapsedTime Hex8MeshWithNSOFields.continuityAdvElem: "<<elapsedTimeSimd<<std::endl;
+
+  EXPECT_EQ(numElems, helperObjs.linsys->numSumIntoCalls_);
 }
 
 TEST_F(Hex8MeshWithNSOFields, continuityAdvElem_new_ME)
@@ -89,8 +91,10 @@ TEST_F(Hex8MeshWithNSOFields, continuityAdvElem_new_ME)
 
   stk::mesh::Selector all = meta.universal_part();
   const stk::mesh::BucketVector& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK, all);
-  const int numElems = stk::mesh::count_selected_entities(all, elemBuckets);
+  const unsigned numElems = stk::mesh::count_selected_entities(all, elemBuckets);
 
   std::cerr<<"numElems: "<<numElems<<", elapsedTime Hex8MeshWithNSOFields.continuityAdvElem: "<<elapsedTimeSimd<<std::endl;
+
+  EXPECT_EQ(numElems, helperObjs.linsys->numSumIntoCalls_);
 }
 

--- a/unit_tests/UnitTestSimdMomentum.C
+++ b/unit_tests/UnitTestSimdMomentum.C
@@ -1,117 +1,19 @@
 #include <gtest/gtest.h>
 
 #include <stk_util/environment/WallTime.hpp>
-#include <stk_simd/Simd.hpp>
-#include <KokkosInterface.h>
-
-#include "UnitTestUtils.h"
+#include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
 #include <SolutionOptions.h>
+#include <TimeIntegrator.h>
+#include <MomentumAdvDiffElemKernel.h>
 #include <nso/MomentumNSOElemKernel.h>
 #include <ElemDataRequests.h>
-#include <ScratchViews.h>
-#include <master_element/MasterElement.h>
 
-#include <limits>
-#include <vector>
-
-template<typename T>
-using AlignedVector = std::vector<T, non_std::AlignedAllocator<T,64> >;
-
-
-
-void initialize_coords(Kokkos::View<double**>& coords)
-{
-    coords(0,0) = -0.5; coords(0,1) = -0.5;  coords(0,2) = 0.5;
-    coords(1,0) = -0.5; coords(1,1) = -0.5; coords(1,2) = -0.5;
-    coords(2,0) = -0.5; coords(2,1) = 0.5; coords(2,2) = -0.5;
-    coords(3,0) = -0.5; coords(3,1) = 0.5; coords(3,2) = 0.5;
-    coords(4,0) = 0.5; coords(4,1) = -0.5; coords(4,2) = 0.5;
-    coords(5,0) = 0.5; coords(5,1) = -0.5; coords(5,2) = -0.5;
-    coords(6,0) = 0.5; coords(6,1) = 0.5; coords(6,2) = -0.5;
-    coords(7,0) = 0.5; coords(7,1) = 0.5; coords(7,2) = 0.5;
-}
-
-void zero(Kokkos::View<double**>& lhs, Kokkos::View<double*>& rhs)
-{
-  for(size_t i=0; i<lhs.dimension(0); ++i) {
-    for(size_t j=0; j<lhs.dimension(1); ++j) {
-      lhs(i,j) = 0.0;
-    }
-  }
-  for(size_t i=0; i<rhs.dimension(0); ++i) {
-    rhs(i) = 0.0;
-  }
-}
-
-void zero(sierra::nalu::SharedMemView<DoubleType**>& lhs, sierra::nalu::SharedMemView<DoubleType*>& rhs)
-{
-  for(size_t i=0; i<lhs.dimension(0); ++i) {
-    for(size_t j=0; j<lhs.dimension(1); ++j) {
-      lhs(i,j) = 0.0;
-    }
-  }
-  for(size_t i=0; i<rhs.dimension(0); ++i) {
-    rhs(i) = 0.0;
-  }
-}
-
-void zero(Kokkos::View<stk::simd::Double**>& lhs, Kokkos::View<stk::simd::Double*>& rhs)
-{
-  for(size_t i=0; i<lhs.dimension(0); ++i) {
-    for(size_t j=0; j<lhs.dimension(1); ++j) {
-      lhs(i,j) = 0.0;
-    }
-  }
-  for(size_t i=0; i<rhs.dimension(0); ++i) {
-    rhs(i) = 0.0;
-  }
-}
-
-
-//TEST_F(Hex8MeshWithNSOFields, twoMomentumKernels)
-//{
-//  fill_mesh_and_initialize_test_fields("generated:50x50x50");
-//
-//  const VectorFieldType* velocityNp1 = &velocity->field_of_state(stk::mesh::StateNP1);
-//  const ScalarFieldType* densityNp1 = &density->field_of_state(stk::mesh::StateNP1);
-//  sierra::nalu::HexSCS hex8SCS;
-//  int integPts = hex8SCS.numIntPoints_;
-//  int nodesPerElem = hex8SCS.nodesPerElement_;
-//  int spatialDim = hex8SCS.nDim_;
-//
-//  stk::mesh::Selector all = meta.universal_part();
-//  const stk::mesh::BucketVector& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK, all);
-//  const int numElems = stk::mesh::count_selected_entities(all, elemBuckets);
-//
-//  int simdLen = 1;
-//  Data data; 
-//  data.setup(integPts, nodesPerElem, spatialDim, spatialDim, simdLen, &hex8SCS);
-//  DataSimd<double> dataSimd(data);
-//
-//  double startTime = stk::wall_time();
-//  unsigned calls = 0;
-//  for(const stk::mesh::Bucket* bptr : elemBuckets) {
-//    const stk::mesh::Bucket& bkt = *bptr;
-//    for(size_t i=0; i<bkt.size(); ++i) {
-//      stk::mesh::Entity elem = bkt[i];
-//      data.gather_and_compute(0, elem, coordField, scalarQ, diffFluxCoeff, massFlowRate, viscosity,
-//                           velocityNp1, densityNp1, pressure);
-//      dataSimd.copy_and_interleave(data);
-//      zero(dataSimd.lhs, dataSimd.rhs);
-//
-//      ++calls;
-//      momentumAdvDiffElem(integPts, nodesPerElem, spatialDim, dataSimd);
-//      momentumNSOElem(integPts, nodesPerElem, spatialDim, dataSimd);
-//    }
-//  }
-//
-//  double elapsedTimeNoSimd = stk::wall_time() - startTime;
-//  std::cout<<"numElems: "<<numElems<<", elapsedTime Hex8MeshWithNSOFields.twoMomentumKernels: "<<elapsedTimeNoSimd<<", calls: "<<calls<<std::endl;
-//}
-
-TEST_F(Hex8MeshWithNSOFields, twoMomentumKernelsSimd)
+TEST_F(Hex8MeshWithNSOFields, twoMomentumKernels)
 {
   fill_mesh_and_initialize_test_fields("generated:20x20x20");
 
@@ -121,82 +23,42 @@ TEST_F(Hex8MeshWithNSOFields, twoMomentumKernelsSimd)
   solnOpts.externalMeshDeformation_ = false;
   solnOpts.includeDivU_ = 0.0;
 
-  int spatialDim = bulk.mesh_meta_data().spatial_dimension();
+  const unsigned numDof = 3;
+  unit_test_utils::HelperObjectsNewME helperObjs(bulk, stk::topology::HEX_8, numDof, meta.get_part("block_1"));
 
-  sierra::nalu::HexSCS hex8SCS;
+  std::unique_ptr<sierra::nalu::Kernel> advDiffKernel(
+     new sierra::nalu::MomentumAdvDiffElemKernel<sierra::nalu::AlgTraitsHex8>(
+        bulk, solnOpts, velocity, viscosity,
+        helperObjs.assembleElemSolverAlg->dataNeededBySuppAlgs_));
 
-  sierra::nalu::ElemDataRequests dataNeeded;
-  dataNeeded.add_coordinates_field(*coordField, spatialDim, sierra::nalu::CURRENT_COORDINATES);
-  dataNeeded.add_cvfem_surface_me(&hex8SCS);
+  std::unique_ptr<sierra::nalu::Kernel> nsoKernel(
+     new sierra::nalu::MomentumNSOElemKernel<sierra::nalu::AlgTraitsHex8>(
+        bulk, solnOpts, velocity, Gju, viscosity, 0.0, 0.0,
+        helperObjs.assembleElemSolverAlg->dataNeededBySuppAlgs_));
 
-  sierra::nalu::MomentumNSOElemKernel<sierra::nalu::AlgTraitsHex8> nsoAlg(
-     bulk, solnOpts, velocity, Gju, viscosity, 0.0, 0.0, dataNeeded);
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(advDiffKernel.get());
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(nsoKernel.get());
 
-  int nodesPerElem = hex8SCS.nodesPerElement_;
+  sierra::nalu::TimeIntegrator timeIntegrator;
+  timeIntegrator.timeStepN_ = 0.1;
+  timeIntegrator.timeStepNm1_ = 0.1;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.gamma2_ = -1.0;
+  timeIntegrator.gamma3_ = 0.0;
 
-  const int rhsSize = nodesPerElem*spatialDim;
-  const int lhsSize = rhsSize * rhsSize;
-  const int scratchIdsSize = rhsSize;
-
-  const int simdLen = stk::simd::ndoubles; //only turn this on if you also switch DoubleType
-
-  const int bytes_per_team = 0;
-  int bytes_per_thread = (rhsSize + lhsSize) * sizeof(double) + scratchIdsSize*sizeof(int) +
-     sierra::nalu::get_num_bytes_pre_req_data(dataNeeded, spatialDim);
-  bytes_per_thread *= 2*simdLen;
-  
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
   stk::mesh::Selector all = meta.universal_part();
   const stk::mesh::BucketVector& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK, all);
-  const int numElems = stk::mesh::count_selected_entities(all, elemBuckets);
-
-  auto team_exec = sierra::nalu::get_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);
-
-  std::vector<sierra::nalu::ScratchViews<double>*> prereqData(simdLen, nullptr);
+  const unsigned numElems = stk::mesh::count_selected_entities(all, elemBuckets);
 
   double startTime = stk::wall_time();
-  unsigned calls = 0;
-  Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
-  {
-    const stk::mesh::Bucket &bkt = *elemBuckets[team.league_rank()];
 
-    for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-      delete prereqData[simdIndex];
-      prereqData[simdIndex] = new sierra::nalu::ScratchViews<double>(team, bulk, bkt.topology(), dataNeeded);
-    }
-
-    sierra::nalu::ScratchViews<DoubleType> prereqDataSimd(team, bulk, bkt.topology(), dataNeeded);
-    sierra::nalu::SharedMemView<int*> scratchIds  = sierra::nalu::get_int_shmem_view_1D(team, scratchIdsSize);
-    sierra::nalu::SharedMemView<DoubleType*> rhs  = sierra::nalu::get_shmem_view_1D<DoubleType>(team, rhsSize);
-    sierra::nalu::SharedMemView<DoubleType**> lhs = sierra::nalu::get_shmem_view_2D<DoubleType>(team, rhsSize, rhsSize);
-
-    for(size_t bktIndex=0; bktIndex<bkt.size(); bktIndex += simdLen)
-    {
-      int nelem = simdLen;
-      if (bkt.size() - bktIndex < simdLen) {
-        nelem = bkt.size() - bktIndex;
-      }
-      if (nelem < 0 || nelem > simdLen) {
-        std::cout<<" nelem == "<<nelem<<" shouldn't happen!!!"<<std::endl;
-        break;
-      }
- 
-      for(int simdElemIndex=0; simdElemIndex<nelem; ++simdElemIndex) {
-        stk::mesh::Entity elem = bkt[bktIndex+simdElemIndex];
-        fill_pre_req_data(dataNeeded, bulk, bkt.topology(), elem, *prereqData[simdElemIndex]);
-      }
-      copy_and_interleave(prereqData, nelem, simdLen, prereqDataSimd);
-      zero(lhs, rhs);
-
-      ++calls;
-      nsoAlg.execute(lhs, rhs, prereqDataSimd);
-
-//      momentumAdvDiffElem(integPts, nodesPerElem, spatialDim, prereqDataSimd);
-//      momentumNSOElem(integPts, nodesPerElem, spatialDim, prereqDataSimd);
-    }
-  });
+  helperObjs.assembleElemSolverAlg->execute();
 
   double elapsedTimeSimd = stk::wall_time() - startTime;
-  std::cout<<"numElems: "<<numElems<<", elapsedTime Hex8MeshWithNSOFields.twoMomentumKernels: "<<elapsedTimeSimd<<", calls: "<<calls<<std::endl;
+  std::cout<<"numElems: "<<numElems<<", elapsedTime Hex8MeshWithNSOFields.twoMomentumKernels: "<<elapsedTimeSimd<<std::endl;
+
+  EXPECT_EQ(numElems, helperObjs.linsys->numSumIntoCalls_);
 }
 

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -126,7 +126,7 @@ class Hex8MeshWithNSOFields : public Hex8Mesh
 protected:
     Hex8MeshWithNSOFields()
     : Hex8Mesh(),
-      massFlowRate(&meta.declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "massFlowRate")),   
+      massFlowRate(&meta.declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "mass_flow_rate_scs")),
       Gju(&meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "Gju", 1/*num-states*/)), 
       velocity(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", 3/*num-states*/)), 
       dpdx(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx", 3/*num-states*/)), 
@@ -145,7 +145,7 @@ protected:
       stk::mesh::put_field(*pressure, meta.universal_part(), 1, &one);
     }
 
-    VectorFieldType* massFlowRate;
+    GenericFieldType* massFlowRate;
     GenericFieldType* Gju;
     VectorFieldType* velocity;
     VectorFieldType* dpdx;


### PR DESCRIPTION
They were using an element-loop that was hand-coded directly
in the unit-test, thus not reflecting the "real" code that
drives kernels in nalu.
Now they use the real element loop via the AssembleElemSolverAlgorithm
class. This also makes them more consistent with the kernel
unit-tests that Shreyas wrote.