### PR TITLE
Low level optimizations to the copy/interleave code supporting simd.

### DIFF
--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -18,44 +18,19 @@ namespace sierra{
 namespace nalu{
 
 template<typename DTYPE>
-void interleave_3D(SharedMemView<DTYPE***>& dview, const SharedMemView<double***>& sview, int simdIndex, int simdLen)
+void interleave_3D(SharedMemView<DTYPE***>& dview, const SharedMemView<double***>& sview, int simdIndex)
 {
     int dim0 = dview.dimension(0);
     int dim1 = dview.dimension(1);
     int dim2 = dview.dimension(2);
 
-//    int len = dim0*dim1*dim2;
-//    DTYPE& dval = dview(0,0,0);
-//    double* dptr = &dval[simdIndex];
-//    double* sptr = &sview(0,0,0);
-//    for(int i=0; i<len; ++i) {
-//        *dptr = *sptr++;
-//        dptr += simdLen;
-//    }
     for(int i=0; i<dim0; ++i) {
         for(int j=0; j<dim1; ++j) {
             for(int k=0; k<dim2; ++k) {
                 stk::simd::set_data(dview(i,j,k), simdIndex, sview(i,j,k));
-            }   
-        }   
-    }   
-}
-
-template<typename DTYPE>
-void interleave_1D(SharedMemView<DTYPE*>& dview, const SharedMemView<double*>& sview, int simdIndex, int simdLen)
-{
-    int dim = dview.dimension(0);
-//    DTYPE& dval = dview(0);
-//    double* dptr = &dval[simdIndex];
-//    double* sptr = &sview(0);
-
-    for(int i=0; i<dim; ++i) {
-        stk::simd::set_data(dview(i), simdIndex, sview(i));
+            }
+        }
     }
-//    for(int i=0; i<dim; ++i) {
-//       *dptr = *sptr++;
-//       dptr += simdLen;
-//    }   
 }
 
 template<typename DTYPE>
@@ -67,71 +42,134 @@ void interleave_2D(SharedMemView<DTYPE**>& dview, const SharedMemView<double**>&
         for(int j=0; j<dim1; ++j) {
             stk::simd::set_data(dview(i,j), simdIndex, sview(i,j));
         }
-    }   
+    }
+}
+
+template<typename DTYPE>
+void interleave_1D(SharedMemView<DTYPE*>& dview, const SharedMemView<double*>& sview, int simdIndex)
+{
+    int dim = dview.dimension(0);
+
+    for(int i=0; i<dim; ++i) {
+        stk::simd::set_data(dview(i), simdIndex, sview(i));
+    }
+}
+
+template<typename DTYPE>
+void interleave_1D(SharedMemView<DTYPE*>& dview, const double* sviews[], int simdElems)
+{
+    int dim = dview.dimension(0);
+    DoubleType* dptr = dview.data();
+    for(int i=0; i<dim; ++i) {
+        DoubleType& d = dptr[i];
+        for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
+            stk::simd::set_data(d, simdIndex, sviews[simdIndex][i]);
+        }
+    }
+}
+
+template<typename DTYPE>
+void interleave_2D(SharedMemView<DTYPE**>& dview, const double* sviews[], int simdElems)
+{
+    int len = dview.dimension(0)*dview.dimension(1);
+    DoubleType* d = dview.data();
+    for(int idx=0; idx<len; ++idx) {
+        DoubleType& dv = d[idx];
+        for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
+            stk::simd::set_data(dv, simdIndex, sviews[simdIndex][idx]);
+        }
+    }
+}
+
+template<typename DTYPE>
+void interleave_3D(SharedMemView<DTYPE***>& dview, const double* sviews[], int simdElems)
+{
+    int len = dview.dimension(0)*dview.dimension(1)*dview.dimension(2);
+    DoubleType* d = dview.data();
+    for(int idx=0; idx<len; ++idx) {
+        DoubleType& dv = d[idx];
+        for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
+            stk::simd::set_data(dv, simdIndex, sviews[simdIndex][idx]);
+        }
+    }
 }
 
 inline
-void interleave_1D(ViewHolder* dest, const ViewHolder* src, int simdIndex, int simdLen)
+void interleave_1D(ViewHolder* dest, const ViewHolder* sviews[], int simdElems)
 {
-    const SharedMemView<double*>& src_view = static_cast<const ViewT<SharedMemView<double*>>*>(src)->view_;
-    SharedMemView<DoubleType*>& dest_view = static_cast<ViewT<SharedMemView<DoubleType*>>*>(dest)->view_;
-    interleave_1D(dest_view, src_view, simdIndex, simdLen);
+    const double* smemviews[stk::simd::ndoubles];
+    SharedMemView<DoubleType*>& dmemview = static_cast<ViewT<SharedMemView<DoubleType*>>*>(dest)->view_;
+    for(int i=0; i<simdElems; ++i) {
+        smemviews[i] = static_cast<const ViewT<SharedMemView<double*>>*>(sviews[i])->view_.data();
+    }
+
+    interleave_1D(dmemview, smemviews, simdElems);
 }
 
 inline
-void interleave_2D(ViewHolder* dest, const ViewHolder* src, int simdIndex)
+void interleave_2D(ViewHolder* dest, const ViewHolder* sviews[], int simdElems)
 {
-    const SharedMemView<double**>& src_view = static_cast<const ViewT<SharedMemView<double**>>*>(src)->view_;
-    SharedMemView<DoubleType**>& dest_view = static_cast<ViewT<SharedMemView<DoubleType**>>*>(dest)->view_;
-    interleave_2D(dest_view, src_view, simdIndex);
+    const double* smemviews[stk::simd::ndoubles];
+    SharedMemView<DoubleType**>& dmemview = static_cast<ViewT<SharedMemView<DoubleType**>>*>(dest)->view_;
+    for(int i=0; i<simdElems; ++i) {
+        smemviews[i] = static_cast<const ViewT<SharedMemView<double**>>*>(sviews[i])->view_.data();
+    }
+
+    interleave_2D(dmemview, smemviews, simdElems);
 }
 
 inline
-void interleave_3D(ViewHolder* dest, const ViewHolder* src, int simdIndex, int simdLen)
+void interleave_3D(ViewHolder* dest, const ViewHolder* sviews[], int simdElems)
 {
-    const SharedMemView<double***>& src_view = static_cast<const ViewT<SharedMemView<double***>>*>(src)->view_;
-    SharedMemView<DoubleType***>& dest_view = static_cast<ViewT<SharedMemView<DoubleType***>>*>(dest)->view_;
-    interleave_3D(dest_view, src_view, simdIndex, simdLen);
+    const double* smemviews[stk::simd::ndoubles];
+    SharedMemView<DoubleType***>& dmemview = static_cast<ViewT<SharedMemView<DoubleType***>>*>(dest)->view_;
+    for(int i=0; i<simdElems; ++i) {
+        smemviews[i] = static_cast<const ViewT<SharedMemView<double***>>*>(sviews[i])->view_.data();
+    }
+
+    interleave_3D(dmemview, smemviews, simdElems);
 }
 
 inline
 void interleave_me_views(MasterElementViews<DoubleType>& dest,
                          const MasterElementViews<double>& src,
-                         int simdIndex, int simdLen)
+                         int simdIndex)
 {
   interleave_2D(dest.scs_areav, src.scs_areav, simdIndex);
-  interleave_3D(dest.dndx, src.dndx, simdIndex, simdLen);
-  interleave_3D(dest.dndx_shifted, src.dndx_shifted, simdIndex, simdLen);
-  interleave_3D(dest.dndx_fem, src.dndx_fem, simdIndex, simdLen);
-  interleave_3D(dest.deriv, src.deriv, simdIndex, simdLen);
-  interleave_3D(dest.deriv_fem, src.deriv_fem, simdIndex, simdLen);
-  interleave_1D(dest.det_j, src.det_j, simdIndex, simdLen);
-  interleave_1D(dest.det_j_fem, src.det_j_fem, simdIndex, simdLen);
-  interleave_1D(dest.scv_volume, src.scv_volume, simdIndex, simdLen);
-  interleave_3D(dest.gijUpper, src.gijUpper, simdIndex, simdLen);
-  interleave_3D(dest.gijLower, src.gijLower, simdIndex, simdLen);
+  interleave_3D(dest.dndx, src.dndx, simdIndex);
+  interleave_3D(dest.dndx_shifted, src.dndx_shifted, simdIndex);
+  interleave_3D(dest.dndx_fem, src.dndx_fem, simdIndex);
+  interleave_3D(dest.deriv, src.deriv, simdIndex);
+  interleave_3D(dest.deriv_fem, src.deriv_fem, simdIndex);
+  interleave_1D(dest.det_j, src.det_j, simdIndex);
+  interleave_1D(dest.det_j_fem, src.det_j_fem, simdIndex);
+  interleave_1D(dest.scv_volume, src.scv_volume, simdIndex);
+  interleave_3D(dest.gijUpper, src.gijUpper, simdIndex);
+  interleave_3D(dest.gijLower, src.gijLower, simdIndex);
 }
 
 inline
 void copy_and_interleave(const std::vector<ScratchViews<double>*>& data,
                          int simdElems,
-                         int simdLen,
                          ScratchViews<DoubleType>& simdData,
                          bool copyMEViews = true)
 {
     const std::vector<ViewHolder*>& simdFieldViews = simdData.get_field_views();
+    const ViewHolder* fViews[stk::simd::ndoubles];
 
-    for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
-      const std::vector<ViewHolder*>& fieldViews = data[simdIndex]->get_field_views();
-      for(size_t i=0; i<fieldViews.size(); ++i) {
-        if (fieldViews[i] != nullptr) {
-          switch(fieldViews[i]->dim_) {
-          case 1: interleave_1D(simdFieldViews[i], fieldViews[i], simdIndex, simdLen); break;
-          case 2: interleave_2D(simdFieldViews[i], fieldViews[i], simdIndex); break;
-          case 3: interleave_3D(simdFieldViews[i], fieldViews[i], simdIndex, simdLen); break;
-          default: ThrowRequireMsg(fieldViews[i]->dim_ > 0 && fieldViews[i]->dim_ < 4, "ERROR, view dim out of range: "<<fieldViews[i]->dim_);
-             break;
-          }
+    for(size_t fieldViewsIndex=0; fieldViewsIndex<simdFieldViews.size(); ++fieldViewsIndex) {
+      if (simdFieldViews[fieldViewsIndex] != nullptr) {
+        for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
+          fViews[simdIndex] = data[simdIndex]->get_field_views()[fieldViewsIndex];
+        }
+        switch(simdFieldViews[fieldViewsIndex]->dim_) {
+        case 1: interleave_1D(simdFieldViews[fieldViewsIndex], fViews, simdElems); break;
+        case 2: interleave_2D(simdFieldViews[fieldViewsIndex], fViews, simdElems); break;
+        case 3: interleave_3D(simdFieldViews[fieldViewsIndex], fViews, simdElems); break;
+        default: ThrowRequireMsg(simdFieldViews[fieldViewsIndex]->dim_ > 0 &&
+                                 simdFieldViews[fieldViewsIndex]->dim_ < 4,
+                                 "ERROR, view dim out of range: "<<simdFieldViews[fieldViewsIndex]->dim_);
+                 break;
         }
       }
     }
@@ -140,10 +178,10 @@ void copy_and_interleave(const std::vector<ScratchViews<double>*>& data,
     {
       for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
         if (simdData.has_coord_field(CURRENT_COORDINATES)) {
-          interleave_me_views(simdData.get_me_views(CURRENT_COORDINATES), data[simdIndex]->get_me_views(CURRENT_COORDINATES), simdIndex, simdLen);
+          interleave_me_views(simdData.get_me_views(CURRENT_COORDINATES), data[simdIndex]->get_me_views(CURRENT_COORDINATES), simdIndex);
         }
         if (simdData.has_coord_field(MODEL_COORDINATES)) {
-          interleave_me_views(simdData.get_me_views(MODEL_COORDINATES), data[simdIndex]->get_me_views(MODEL_COORDINATES), simdIndex, simdLen);
+          interleave_me_views(simdData.get_me_views(MODEL_COORDINATES), data[simdIndex]->get_me_views(MODEL_COORDINATES), simdIndex);
         }
       }
     }
@@ -152,18 +190,22 @@ void copy_and_interleave(const std::vector<ScratchViews<double>*>& data,
 inline
 void extract_vector_lane(const SharedMemView<DoubleType*>& simdrhs, int simdIndex, SharedMemView<double*>& rhs)
 {
-  for(size_t i=0; i<simdrhs.dimension(0); ++i) {
-    rhs(i) = stk::simd::get_data(simdrhs(i), simdIndex);
+  int dim = simdrhs.dimension(0);
+  const DoubleType* sr = simdrhs.data();
+  double* r = rhs.data();
+  for(int i=0; i<dim; ++i) {
+    r[i] = stk::simd::get_data(sr[i], simdIndex);
   }
 }
 
 inline
 void extract_vector_lane(const SharedMemView<DoubleType**>& simdlhs, int simdIndex, SharedMemView<double**>& lhs)
 {
-  for(size_t i=0; i<simdlhs.dimension(0); ++i) {
-    for(size_t j=0; j<simdlhs.dimension(1); ++j) {
-      lhs(i,j) = stk::simd::get_data(simdlhs(i,j), simdIndex);
-    }
+  int len = simdlhs.dimension(0)*simdlhs.dimension(1);
+  const DoubleType* sl = simdlhs.data();
+  double* l = lhs.data();
+  for(int i=0; i<len; ++i) {
+    l[i] = stk::simd::get_data(sl[i], simdIndex);
   }
 }
 

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -119,7 +119,7 @@ public:
 
   const stk::mesh::Entity* elemNodes;
 
-  inline const std::vector<ViewHolder*> get_field_views() const { return fieldViews; }
+  inline const std::vector<ViewHolder*>& get_field_views() const { return fieldViews; }
 
 private:
   void create_needed_field_views(const TeamHandleType& team,
@@ -495,7 +495,5 @@ int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)
 
 } // namespace nalu
 } // namespace Sierra
-
-#include <CopyAndInterleave.h>
 
 #endif

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -31,6 +31,7 @@
 
 #include <KokkosInterface.h>
 #include <ScratchViews.h>
+#include <CopyAndInterleave.h>
 
 namespace sierra{
 namespace nalu{
@@ -152,7 +153,7 @@ AssembleElemSolverAlgorithm::execute()
                           *prereqData[simdElemIndex], interleaveMEViews_);
       }
 
-      copy_and_interleave(prereqData, simdElems, simdLen, simdPrereqData, interleaveMEViews_);
+      copy_and_interleave(prereqData, simdElems, simdPrereqData, interleaveMEViews_);
 
       if (!interleaveMEViews_) {
         fill_master_element_views(dataNeededBySuppAlgs_, bulk_data, topo_, element, simdPrereqData);

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -12,6 +12,7 @@
 #include "UnitTestUtils.h"
 
 #include "ScratchViews.h"
+#include "CopyAndInterleave.h"
 #include "ElemDataRequests.h"
 #include "AlgTraits.h"
 #include "KokkosInterface.h"
@@ -136,7 +137,7 @@ public:
                                 *prereqData[simdIndex], alsoProcessMEViews);
             }
 
-            copy_and_interleave(prereqData, simdElems, simdLen, simdPrereqData,
+            copy_and_interleave(prereqData, simdElems, simdPrereqData,
                                 alsoProcessMEViews);
             fill_master_element_views(dataNeeded_, bulk_, AlgTraits::topo_,
                                       element, simdPrereqData);

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -15,6 +15,7 @@
 #include "Kernel.h"
 #include "ElemDataRequests.h"
 #include "ScratchViews.h"
+#include "CopyAndInterleave.h"
 #include "AlgTraits.h"
 #include "KokkosInterface.h"
 #include "TimeIntegrator.h"
@@ -292,7 +293,7 @@ public:
             sierra::nalu::fill_pre_req_data(
               dataNeededByKernels_, bulk_, topo_, element, *preReqData[0]);
 
-            sierra::nalu::copy_and_interleave(preReqData, simdLen, simdLen, simdPreReqData);
+            sierra::nalu::copy_and_interleave(preReqData, simdLen, simdPreReqData);
 
             for (int i=0; i < rhsSize; i++) {
               simdRhs(i) = 0.0;


### PR DESCRIPTION
vtune showed that copy/interleave, together with extract_vector_lane,
was occupying about 17% of AssembleElemSolverAlgorithm::execute on
KNL, for the momentum-kernels unit test. The changes in this commit
bring that down to about 6%.