### PR TITLE
Fixing many broken tests

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -4,43 +4,9 @@
 
 # Standard regression test
 function(add_test_r testname np)
-    set(TEST_INPUT_DECK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i)
-    set(TEST_LAUNCH
-        "mpiexec -np ${np} ${CMAKE_BINARY_DIR}/${nalu_ex_name} -i ${TEST_INPUT_DECK_PATH} -o ${testname}.log")
-    set(TEST_CHECK
-        " && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}")
+    add_test(${testname} sh -c "mpiexec -np ${np} ${CMAKE_BINARY_DIR}/${nalu_ex_name} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}")
+    set_tests_properties(${testname} PROPERTIES TIMEOUT 1500 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
-
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i.in)
-      set(CATALYST_FILE_INPUT_DECK_COMMAND "")
-      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i.in
-                     ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}.i @ONLY)
-      set(TEST_INPUT_DECK_PATH ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}.i)
-      set(TEST_LAUNCH
-          "mpiexec -np ${np} ${CMAKE_BINARY_DIR}/${nalu_ex_name} -i ${TEST_INPUT_DECK_PATH} -o ${testname}.log")
-      if(ENABLE_PARAVIEW_CATALYST)
-        set(CATALYST_FILE_INPUT_DECK_COMMAND "catalyst_file_name: catalyst.txt")
-        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i.in
-                       ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}_catalyst.i @ONLY)
-        set(CATALYST_TEST_INPUT_DECK_PATH ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}_catalyst.i)
-        set(CATALYST_TEST_NUM_IMAGES 1)
-        if(${ARGC} GREATER 2)
-          set(CATALYST_TEST_NUM_IMAGES ${ARGV2})
-        endif()
-        set(CATALYST_TEST_LAUNCH
-            " && mpiexec -np ${np} ${CMAKE_BINARY_DIR}/${nalu_ex_catalyst_name} -i ${CATALYST_TEST_INPUT_DECK_PATH} -o ${testname}.log")
-        set(CATALYST_TEST_CHECK
-            " && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail_catalyst.sh ${testname} ${CATALYST_TEST_NUM_IMAGES}")
-        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/catalyst.txt
-             DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
-        set(TEST_RUN "${TEST_LAUNCH} ${TEST_CHECK} ${CATALYST_TEST_LAUNCH} ${CATALYST_TEST_CHECK}")
-      else()
-        set(TEST_RUN "${TEST_LAUNCH} ${TEST_CHECK}")
-      endif()
-    endif()
-
-    add_test(${testname} sh -c "${TEST_RUN}")
-    set_tests_properties(${testname} PROPERTIES TIMEOUT 1000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
 endfunction(add_test_r)
 
 # Standard performance test
@@ -78,11 +44,28 @@ function(add_test_u testname np)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_u)
 
+# Regression test with catalyst capability
+function(add_test_r_cat testname np ncat)
+    if(ENABLE_PARAVIEW_CATALYST)
+      if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i.in)
+        add_test(${testname} sh -c "mpiexec -np ${np} ${CMAKE_BINARY_DIR}/${nalu_ex_catalyst_name} -i ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}_catalyst.i -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail_catalyst.sh ${testname} ${ncat}")
+        set_tests_properties(${testname} PROPERTIES TIMEOUT 1000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
+        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.i.in
+                       ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/${testname}_catalyst.i @ONLY)
+        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/catalyst.txt
+             DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
+      endif()
+    else()
+      add_test_r(${testname} ${np})
+    endif()
+endfunction(add_test_r_cat)
+
 #=============================================================================
 # Regression tests
 #=============================================================================
 
-add_test_r(ablForcingEdge 4 11)
+add_test_r_cat(ablForcingEdge 4 11)
 add_test_r(ablStableElem 4)
 add_test_r(ablUnstableEdge 4)
 add_test_r(actuatorLine 8)
@@ -126,7 +109,7 @@ add_test_r(inputFireElem 4)
 add_test_r(kovasznay_P5 1)
 add_test_r(milestoneRun 4)
 add_test_r(milestoneRunConsolidated 4)
-add_test_r(mixedTetPipe 8 7)
+add_test_r_cat(mixedTetPipe 8 7)
 add_test_r(movingCylinder 4)
 add_test_r(nonConformalWithPeriodic 2)
 add_test_r(nonIsoEdgeOpenJet 4)
@@ -143,7 +126,7 @@ add_test_r_np(periodic3dEdge 1)
 add_test_r_np(periodic3dEdge 4)
 add_test_r_np(periodic3dEdge 8)
 add_test_r(quad9HC 2)
-add_test_r(steadyTaylorVortex 4 6)
+add_test_r_cat(steadyTaylorVortex 4 6)
 add_test_r_rst2(steadyTaylorVortex_P4 8)
 add_test_r(variableDensNonIso 2)
 add_test_r(variableDensNonUniform 2)

--- a/reg_tests/test_files/ablForcingEdge/ablForcingEdge.i
+++ b/reg_tests/test_files/ablForcingEdge/ablForcingEdge.i
@@ -1,0 +1,217 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: tpetra
+    method: gmres
+    preconditioner: sgs
+    tolerance: 1e-5
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+
+  - name: solve_cont
+    type: tpetra
+    method: gmres
+    preconditioner: muelu
+    tolerance: 1e-5
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+    muelu_xml_file_name: ../../xml/milestone.xml
+
+realms:
+
+  - name: fluidRealm
+    mesh: ../../mesh/abl_1km_cube_sample.g
+    use_edges: yes
+    automatic_decomposition_type: rcb
+
+    equation_systems:
+      name: theEqSys
+      max_iterations: 4
+
+      solver_system_specification:
+        velocity: solve_scalar
+        pressure: solve_cont
+        enthalpy: solve_scalar
+
+      systems:
+
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            convergence_tolerance: 1e-5
+
+        - Enthalpy:
+            name: myEnth
+            max_iterations: 1
+            convergence_tolerance: 1e-5
+
+    material_properties:
+
+      target_name: Unspecified-2-HEX
+
+      constant_specification:
+       universal_gas_constant: 8314.4621
+       reference_pressure: 101325.0
+
+      reference_quantities:
+        - species_name: Air
+          mw: 29.0
+          mass_fraction: 1.0
+
+      specifications:
+ 
+        - name: density
+          type: ideal_gas_t
+
+        - name: viscosity
+          type: polynomial
+          coefficient_declaration:
+           - species_name: Air
+             coefficients: [1.7894e-5, 273.11, 110.56]
+
+        - name: specific_heat
+          type: polynomial
+          coefficient_declaration:
+           - species_name: Air
+             low_coefficients: [3.298677000E+00, 1.408240400E-03, -3.963222000E-06, 
+                                5.641515000E-09, -2.444854000E-12,-1.020899900E+03]
+             high_coefficients: [3.298677000E+00, 1.408240400E-03, -3.963222000E-06, 
+                                 5.641515000E-09, -2.444854000E-12,-1.020899900E+03]
+
+    initial_conditions:
+      - constant: ic_1
+        target_name: Unspecified-2-HEX
+        value:
+          pressure: 0
+          temperature: 300.0
+          velocity: [10.0, 0.0, 0.0]
+
+    boundary_conditions:
+
+    - periodic_boundary_condition: bc_left_right
+      target_name: [Front, Back]
+      periodic_user_data:
+        search_tolerance: 0.0001
+
+    - periodic_boundary_condition: bc_front_back
+      target_name: [Left, Right]
+      periodic_user_data:
+        search_tolerance: 0.0001 
+
+    - open_boundary_condition: bc_open
+      target_name: Top
+      open_user_data:
+        velocity: [10.0,0,0]
+        pressure: 0.0
+        temperature: 300.0
+
+    - wall_boundary_condition: bc_lower
+      target_name: Ground
+      wall_user_data:
+        velocity: [0,0,0]
+        use_abl_wall_function: yes
+        heat_flux: 0.0
+        reference_temperature: 300.0
+        roughness_height: 0.1
+        gravity_vector_component: 3
+
+    solution_options:
+      name: myOptions
+      turbulence_model: wale
+      interp_rhou_together_for_mdot: yes
+
+      options:
+
+        - laminar_prandtl:
+            enthalpy: 0.7
+
+        - turbulent_prandtl:
+            enthalpy: 1.0
+
+        - source_terms:
+            momentum: buoyancy
+            continuity: density_time_derivative
+
+        - user_constants:
+            gravity: [0.0,0.0,-9.81]
+            reference_density: 1.2
+
+        - hybrid_factor:
+            velocity: 0.0
+            enthalpy: 1.0
+
+        - limiter:
+            pressure: no
+            velocity: no
+            enthalpy: yes 
+
+        - peclet_function_form:
+            velocity: tanh
+            enthalpy: tanh
+
+        - peclet_function_tanh_transition:
+            velocity: 5000.0
+            enthalpy: 2.01
+
+        - peclet_function_tanh_width:
+            velocity: 200.0
+            enthalpy: 4.02
+
+        - source_terms:
+            momentum: abl_forcing
+
+    output:
+      output_data_base_name: abl_1km_cube_sample.e
+      output_frequency: 1
+      output_node_set: no
+      output_variables:
+       - velocity
+       - pressure
+       - enthalpy
+       - temperature
+       - specific_heat
+       - viscosity
+
+    abl_forcing:
+      search_method: stk_kdtree
+      search_tolerance: 0.0001
+      search_expansion_factor: 1.5
+
+      from_target_part: [Unspecified-2-HEX]
+
+      momentum:
+        type: computed
+        relaxation_factor: 1.0
+        heights: [80.0]
+        target_part_format: "zplane_%.0fm"
+        velocity_x:
+          - [0.0, 10.0]
+          - [900000.0, 10.0]
+
+        velocity_y:
+          - [0.0, 0.0]
+          - [90000.0, 0.0]
+
+        velocity_z:
+          - [0.0, 0.0]
+          - [90000.0, 0.0]
+
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      start_time: 0
+      termination_step_count: 10
+      time_step: 0.5
+      time_stepping_type: fixed
+      time_step_count: 0
+      second_order_accuracy: yes
+
+      realms:
+        - fluidRealm

--- a/reg_tests/test_files/mixedTetPipe/mixedTetPipe.i
+++ b/reg_tests/test_files/mixedTetPipe/mixedTetPipe.i
@@ -1,0 +1,142 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: tpetra
+    method: gmres
+    preconditioner: sgs
+    tolerance: 1e-5
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+
+  - name: solve_cont
+    type: tpetra
+    method: gmres
+    preconditioner: muelu
+    tolerance: 1e-6
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+    muelu_xml_file_name: ../../xml/matches_ml_default.xml
+
+realms:
+
+  - name: realm_1
+    mesh: ../../mesh/pipeTet.g
+    use_edges: yes 
+
+    time_step_control:
+     target_courant: 2.0
+     time_step_change_factor: 1.2
+   
+    equation_systems:
+      name: theEqSys
+      max_iterations: 2
+
+      solver_system_specification:
+        velocity: solve_scalar
+        pressure: solve_cont
+        turbulent_ke: solve_scalar
+
+      systems:
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            element_continuity_eqs: yes 
+            convergence_tolerance: 1e-5
+
+        - TurbKineticEnergy:
+            name: myTke
+            max_iterations: 1
+            convergence_tolerance: 1.e-2
+
+    initial_conditions:
+      - constant: ic_1
+        target_name: block_1
+        value:
+          pressure: 0
+          velocity: [0,0,0]
+          turbulent_ke: 1.0e-6
+
+    material_properties:
+      target_name: block_1
+      specifications:
+        - name: density
+          type: constant
+          value: 1.1814e-3
+        - name: viscosity
+          type: constant
+          value: 1.79e-4
+
+    boundary_conditions:
+
+    - inflow_boundary_condition: bc_inflow
+      target_name: surface_1
+      inflow_user_data:
+        velocity: [0.0,0.0,100.0]
+        turbulent_ke: 3.5
+
+    - open_boundary_condition: bc_open
+      target_name: surface_2
+      open_user_data:
+        velocity: [0,0,0]
+        pressure: 0.0
+        turbulent_ke: 0.0
+
+    - wall_boundary_condition: bc_bottom
+      target_name: surface_3
+      wall_user_data:
+        velocity: [0,0,0]
+        use_wall_function: yes
+
+    solution_options:
+      name: myOptions
+      turbulence_model: ksgs
+
+      options:
+
+        - turbulence_model_constants:
+            kappa: 0.41
+            cEps: 0.844
+            cMuEps: 0.0855
+
+        - hybrid_factor:
+            velocity: 1.0 
+
+        - alpha_upw:
+            velocity: 1.0 
+      
+        - noc_correction:
+            pressure: yes 
+
+        - projected_nodal_gradient:
+            pressure: element
+            velocity: edge
+            turbulent_ke: element
+  
+    output:
+      output_data_base_name: mixedTetPipe.e
+      output_frequency: 2 
+      output_node_set: no 
+      output_variables:
+       - velocity
+       - pressure
+       - turbulent_ke
+       - turbulent_viscosity
+
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      start_time: 0
+      time_step: 0.0005
+      termination_time: 0.01
+      time_stepping_type: adaptive
+      time_step_count: 0
+
+      realms: 
+        - realm_1

--- a/reg_tests/test_files/steadyTaylorVortex/steadyTaylorVortex.i
+++ b/reg_tests/test_files/steadyTaylorVortex/steadyTaylorVortex.i
@@ -1,0 +1,135 @@
+Simulations:
+  - name: sim1
+    time_integrator: ti_1
+    optimizer: opt1
+    error_estimator: errest_1
+
+linear_solvers:
+
+  - name: solve_scalar
+    type: tpetra
+    method: gmres
+    preconditioner: sgs 
+    tolerance: 1e-5
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+
+  - name: solve_cont
+    type: tpetra
+    method: gmres 
+    preconditioner: muelu
+    tolerance: 1e-5
+    max_iterations: 50
+    kspace: 50
+    output_level: 0
+    recompute_preconditioner: no
+    muelu_xml_file_name: ../../xml/matches_ml_default.xml
+
+realms:
+
+  - name: realm_1
+    mesh: ../../mesh/2dTquad_100_P2.g
+    use_edges: no     
+
+    equation_systems:
+      name: theEqSys
+      max_iterations: 1
+   
+      solver_system_specification:
+        pressure: solve_cont
+        velocity: solve_scalar
+        dpdx: solve_scalar
+
+      systems:
+        - LowMachEOM:
+            name: myLowMach
+            max_iterations: 1
+            convergence_tolerance: 1e-2
+
+    initial_conditions:
+
+      - user_function: icUser
+        target_name: block_1
+        user_function_name:
+         velocity: SteadyTaylorVortex
+         pressure: SteadyTaylorVortex 
+         
+    material_properties:
+      target_name: block_1
+
+      specifications:
+
+        - name: density
+          type: constant
+          value: 1.0
+
+        - name: viscosity
+          type: constant
+          value: 0.001
+
+    boundary_conditions:
+
+    - periodic_boundary_condition: bc_left_right
+      target_name: [surface_1, surface_2]
+      periodic_user_data:
+        search_tolerance: 0.0001 
+
+    - periodic_boundary_condition: bc_top_bot
+      target_name: [surface_3, surface_4]
+      periodic_user_data:
+        search_tolerance: 0.0001 
+
+    solution_options:
+      name: myOptions
+      turbulence_model: laminar
+  
+      options:
+
+        - hybrid_factor:
+            velocity: 0.0
+
+        - limiter:
+            pressure: no
+            velocity: no
+
+        - element_source_terms:
+            momentum: [SteadyTaylorVortex, momentum_time_derivative]
+
+        - consistent_mass_matrix_png:
+            pressure: yes
+            velocity: no
+
+    solution_norm:
+      output_frequency: 20
+      file_name: steadyTaylorVortex_100P2.dat
+      spacing: 12
+      percision: 6
+      target_name: block_1
+      dof_user_function_pair:
+       - [velocity, SteadyTaylorVortexVelocity]
+       - [dpdx, SteadyTaylorVortexGradPressure]
+
+    output:
+      output_data_base_name: naluUniformSteadyTV_100_P2_png.e
+      output_frequency: 5
+      output_node_set: no 
+      output_variables:
+       - dual_nodal_volume
+       - velocity
+       - pressure
+       - velocity_exact
+       - dpdx_exact
+
+Time_Integrators:
+  - StandardTimeIntegrator:
+      name: ti_1
+      start_time: 0
+      termination_step_count: 25
+      time_step: 100.0e-6
+      time_stepping_type: fixed 
+      time_step_count: 0
+      second_order_accuracy: no
+
+      realms:
+        - realm_1


### PR DESCRIPTION
It turns out the catalyst code additions were broken and made many existing tests run blank `sh -c` commands, so they weren't running anything and succeeding by default. This pull request reinstates the old function for adding regression tests and adds a separate function for adding tests with catalyst capability.

I'm going to merge this as soon as I verify it runs the tests correctly.

@tjotaha  Can you check if this still runs your tests like you expect?