### PR TITLE
WIP.... Refactor dgInfoVec_ management...

### DIFF
--- a/include/DgInfo.h
+++ b/include/DgInfo.h
@@ -55,7 +55,9 @@ class DgInfo {
     const int nDim);
   
   ~DgInfo();
-  
+
+  void dump_info();
+
   int parallelRank_;
   uint64_t globalFaceId_;
   uint64_t localGaussPointId_;
@@ -70,6 +72,7 @@ class DgInfo {
   
   int nDim_;
 
+  const double bestXRef_;
   double bestX_;
   int opposingFaceIsGhosted_;
 
@@ -99,6 +102,10 @@ class DgInfo {
 
   // iso-parametric coordinates for gauss point on opposing face (-1:1)
   std::vector<double> opposingIsoParCoords_;  
+
+  // possible reuse
+  std::vector<uint64_t> allOpposingFaceIds_;
+  std::vector<uint64_t> allOpposingFaceIdsOld_;
 };
   
 } // end sierra namespace

--- a/include/NonConformalInfo.h
+++ b/include/NonConformalInfo.h
@@ -74,13 +74,18 @@ class NonConformalInfo {
 
   ~NonConformalInfo();
 
-  // general method to delete "new" entries within info vec
-  void delete_info_vec();
+  /* delete dgInfoVec_ */
+  void delete_dgInfo();
 
+  /* perform initialization such as dgInfoVec creation and search point/boxes */
   void initialize();
-  void construct_dgInfo_state();
-  void find_possible_face_elements();
-  void set_best_x();
+  
+  /* perform the 'new' */
+  void construct_dgInfo();
+
+  void reset_dgInfo();
+  void construct_bounding_points();
+  void construct_bounding_boxes();
   void determine_elems_to_ghost();
   void complete_search();
   void provide_diagnosis();
@@ -106,6 +111,9 @@ class NonConformalInfo {
 
   /* does the realm have mesh motion */
   const bool meshMotion_;
+
+  /* can we possibly reuse */
+  bool canReuse_;
 
   /* bounding box data types for stk_search */
   std::vector<boundingPoint>      boundingPointVec_;

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -573,6 +573,9 @@ class Realm {
   std::string physics_part_name(std::string) const;
   std::string get_quad_type() const;
 
+  // check for mesh changing
+  bool mesh_changed() const;
+
   stk::mesh::PartVector allPeriodicInteractingParts_;
   stk::mesh::PartVector allNonConformalInteractingParts_;
 };

--- a/src/DgInfo.C
+++ b/src/DgInfo.C
@@ -8,6 +8,7 @@
 
 #include <DgInfo.h>
 #include <master_element/MasterElement.h>
+#include <NaluEnv.h>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -47,7 +48,8 @@ DgInfo::DgInfo(
     meSCSCurrent_(meSCSCurrent),
     currentElementTopo_(currentElementTopo),
     nDim_(nDim),
-    bestX_(1.0e16),
+    bestXRef_(1.0e16),
+    bestX_(bestXRef_),
     opposingFaceIsGhosted_(0)
 {
   // resize internal vectors
@@ -63,6 +65,44 @@ DgInfo::DgInfo(
 DgInfo::~DgInfo()
 {
   // nothing to delete
+}
+
+//--------------------------------------------------------------------------
+//-------- dump_info -------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+DgInfo::dump_info()
+{
+  NaluEnv::self().naluOutput() << "------------------------------------------------- " << std::endl;
+  NaluEnv::self().naluOutput() << "DGInfo::dump_info() for localGaussPointId_ " 
+                               << localGaussPointId_ << " On Rank " << parallelRank_ << std::endl;  
+  NaluEnv::self().naluOutput() << "parallelRank_ " << parallelRank_ << std::endl;
+  NaluEnv::self().naluOutput() << "globalFaceId_ " << globalFaceId_ << std::endl;
+  NaluEnv::self().naluOutput() << "currentGaussPointId_ " << currentGaussPointId_ << std::endl;
+  NaluEnv::self().naluOutput() << "currentFace_ " << currentFace_ << std::endl;
+  NaluEnv::self().naluOutput() << "currentElement_ " << currentElement_ << std::endl;
+  NaluEnv::self().naluOutput() << "currentElementTopo_ " << currentElementTopo_ << std::endl;
+  NaluEnv::self().naluOutput() << "nDim_ " << nDim_ << std::endl;
+  NaluEnv::self().naluOutput() << "bestXRef_ " << bestXRef_ << std::endl;
+  NaluEnv::self().naluOutput() << "bestX_" << bestX_ << std::endl;
+  NaluEnv::self().naluOutput() << "opposingFaceIsGhosted_ " << opposingFaceIsGhosted_ << std::endl;
+  NaluEnv::self().naluOutput() << "opposingFace_ " << opposingFace_ << std::endl;
+  NaluEnv::self().naluOutput() << "opposingElement_ " << std::endl;
+  NaluEnv::self().naluOutput() << "opposingElementTopo_ " << opposingElementTopo_ << std::endl;
+  NaluEnv::self().naluOutput() << "opposingFaceOrdinal_ " << opposingFaceOrdinal_ << std::endl;
+  NaluEnv::self().naluOutput() << "meFCOpposing_ " << meFCOpposing_ << std::endl;
+  NaluEnv::self().naluOutput() << "meSCSOpposing_ "<< meSCSOpposing_ << std::endl;
+  NaluEnv::self().naluOutput() << "currentGaussPointCoords_ " << std::endl;
+  for ( size_t k = 0; k < currentGaussPointCoords_.size(); ++k )
+    NaluEnv::self().naluOutput() << currentGaussPointCoords_[k] << std::endl;
+  NaluEnv::self().naluOutput() << "currentIsoParCoords_ " << std::endl;
+  for ( size_t k = 0; k < currentIsoParCoords_.size(); ++k )
+    NaluEnv::self().naluOutput() << currentIsoParCoords_[k] << std::endl;
+  NaluEnv::self().naluOutput() << "opposingIsoParCoords_ " << std::endl;
+  for ( size_t k = 0; k < opposingIsoParCoords_.size(); ++k )
+    NaluEnv::self().naluOutput() << opposingIsoParCoords_[k] << std::endl;
+  NaluEnv::self().naluOutput() << "------------------------------------------------- " << std::endl;
+  NaluEnv::self().naluOutput() << std::endl;
 }
 
 } // namespace Acon

--- a/src/NonConformalManager.C
+++ b/src/NonConformalManager.C
@@ -265,7 +265,18 @@ NonConformalManager::initialize()
   for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
     nonConformalInfoVec_[k]->complete_search();
 
-  // provide diagnosis
+  // check for reuse
+  bool canReuse = true;
+  for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
+    canReuse &=nonConformalInfoVec_[k]->canReuse_;
+  
+  // reset all reusage flags if all are not true
+  if ( !canReuse ) {
+    for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
+      nonConformalInfoVec_[k]->canReuse_ = false;
+  }
+  
+  // Provide diagnosis
   if ( ncAlgDetailedOutput_ ) {
     for ( size_t k = 0; k < nonConformalInfoVec_.size(); ++k )
       nonConformalInfoVec_[k]->provide_diagnosis();

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -4845,5 +4845,15 @@ std::string Realm::get_quad_type() const
   return solutionOptions_->quadType_;
 }
 
+//--------------------------------------------------------------------------
+//-------- mesh_changed() --------------------------------------------------
+//--------------------------------------------------------------------------
+bool
+ Realm::mesh_changed() const
+{
+  // for now, adaptivity only; load-balance in the future?
+  return solutionOptions_->activateAdaptivity_;
+}
+
 } // namespace nalu
 } // namespace Sierra


### PR DESCRIPTION
* No longer delete dgInfoVec_ every time step should the mesh move.
Only delete this object when the mesh changes due to adaptivity
or parallel mesh management changes.

* break up construct_dgInfo_state() to:
   a) the creation of the dgInfoVec_ via construct_dgInfo(); bucket loop
   b) the creation of the bounding point coordinates via
      construct_bounding_points(); iteration over created vector

The above change allows for creation of the dgInfoVec_ based on
a bucket loop and modification of bestX, old and new opposing face, etc.,
within an iteration over dgInfoVec_. This protects the modification
should buckets change.

* DgInfo::dump_info() when problems arise. Add more richness to output.

* Add notion of old and new opposing face ids for WIP reuse of
linear system. Basically, the NonConformalInfo has a new data member,
canReuse_. If the best ip opposing face is within the old opposing
face vector, then re-use is possible. Need to hook in custom ghosting now.

* remove debug print outs