### PR TITLE
Add specialized fem-based methods for kernel shape functions extraction

### DIFF
--- a/include/Kernel.h
+++ b/include/Kernel.h
@@ -55,6 +55,22 @@ void get_scs_shape_fn_data(LambdaFunction lambdaFunction, ViewType& shape_fn_vie
   }
 }
 
+template<typename AlgTraits, typename LambdaFunction, typename ViewType>
+void get_fem_shape_fn_data(LambdaFunction lambdaFunction, ViewType& shape_fn_view)
+{
+  static_assert(ViewType::Rank == 2u, "2D View");
+  ThrowRequireMsg(shape_fn_view.extent_int(0) == AlgTraits::numGp_, "Inconsistent number of Gauss points");
+  ThrowRequireMsg(shape_fn_view.extent_int(1) == AlgTraits::nodesPerElement_, "Inconsistent number of of nodes");
+
+  double tmp_data[AlgTraits::numGp_*AlgTraits::nodesPerElement_];
+  lambdaFunction(tmp_data);
+
+  DoubleType* data = &shape_fn_view(0,0);
+  for(int i=0; i<AlgTraits::numGp_*AlgTraits::nodesPerElement_; ++i) {
+    data[i] = tmp_data[i];
+  }
+}
+
 /** Base class for computational kernels in Nalu
  *
  * A kernel represents an atomic unit of computation applied over a given set of

--- a/include/ScalarDiffFemKernel.h
+++ b/include/ScalarDiffFemKernel.h
@@ -62,7 +62,7 @@ private:
   const bool shiftedGradOp_;
   
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  Kokkos::View<DoubleType[AlgTraits::numGp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/src/ScalarDiffFemKernel.C
+++ b/src/ScalarDiffFemKernel.C
@@ -47,9 +47,9 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
 
   // master element, shape function is shifted consistently
   if ( shiftedGradOp_ )
-    get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shifted_shape_fcn(ptr);}, v_shape_function_);
+    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shifted_shape_fcn(ptr);}, v_shape_function_);
   else
-    get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shape_fcn(ptr);}, v_shape_function_);
+    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shape_fcn(ptr);}, v_shape_function_);
 
   dataPreReqs.add_fem_volume_me(meFEM_);
 


### PR DESCRIPTION
* Added new get_fem_shape_fcn_data()

Notes:

a) Not sure if this is the best way. I am following the pattern already
coded and wonder if there is a better way to do all of this. Let me know
in the review:)

b) The original call to scs sized by the scsIp and npe; this probably resuted in a memory
overrun.