### PR TITLE
Fix variable lenght array to use std::vector.  #220

### DIFF
--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -462,7 +462,7 @@ void tri_gradient_operator(
   const int nint = deriv.dimension(0);
   const int npe  = deriv.dimension(1);
  
-  DoubleType det_j[nint];
+  std::vector<DoubleType> det_j(nint); 
 
   DoubleType dx_ds1, dx_ds2;
   DoubleType dy_ds1, dy_ds2;


### PR DESCRIPTION
#220 Variable length arrays are non-standard even
though some compilers do not flag them as such.