### PR TITLE
Change target names for postprocessing with promoted meshes

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -575,6 +575,7 @@ class Realm {
   bool high_order_active() const { return doPromotion_; };
 
   std::string physics_part_name(std::string) const;
+  std::vector<std::string> physics_part_names(std::vector<std::string>) const;
   std::string get_quad_type() const;
 
   // check for mesh changing

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -871,7 +871,10 @@ Realm::setup_post_processing_algorithms()
     NaluEnv::self().naluOutputP0() << "the post processing physics name: " << thePhysics << std::endl;
 
     // target
-    std::vector<std::string> targetNames = theData.targetNames_;
+    // map target names to physics parts
+    theData.targetNames_ = physics_part_names(theData.targetNames_);
+
+    const std::vector<std::string>& targetNames = theData.targetNames_;
     for ( size_t in = 0; in < targetNames.size(); ++in)
       NaluEnv::self().naluOutputP0() << "Target name(s): " << targetNames[in] << std::endl;
 
@@ -4568,6 +4571,17 @@ Realm::physics_part_name(std::string name) const
     return super_element_part_name(name);
   }
   return name;
+}
+
+std::vector<std::string>
+Realm::physics_part_names(std::vector<std::string> names) const
+{
+  if (doPromotion_) {
+    std::transform(names.begin(), names.end(), names.begin(), [&](const std::string& name) {
+      return super_element_part_name(name);
+    });
+  }
+  return names;
 }
 
 //--------------------------------------------------------------------------

--- a/src/element_promotion/PromotedElementIO.C
+++ b/src/element_promotion/PromotedElementIO.C
@@ -181,7 +181,7 @@ PromotedElementIO::put_data_on_node_block(
     stk::mesh::Entity node = bulkData_.get_entity(stk::topology::NODE_RANK, ids[k]);
     const T* field_data = static_cast<T*>(stk::mesh::field_data(field, node));
     for (int j = 0; j < fieldLength; ++j) {
-      flatArray[index] = field_data[j];
+      flatArray[index] = (field_data != nullptr) ? field_data[j] : 0.0;
       ++index;
     }
   }


### PR DESCRIPTION
* Changes the postprocessor target names to the corrected super element part name for promoted meshes.

* For outputting surface fields like tau_wall, I'll need to implement a sideset writer for the sub-divided high order elements. 