### PR TITLE
Initial simple unit-tests of the getDofStatus function.

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -158,10 +158,10 @@ class Realm {
   void init_current_coordinates();
 
   std::string get_coordinates_name();
-  bool has_mesh_motion();
-  bool has_mesh_deformation();
-  bool does_mesh_move();
-  bool has_non_matching_boundary_face_alg();
+  bool has_mesh_motion() const;
+  bool has_mesh_deformation() const;
+  bool does_mesh_move() const;
+  bool has_non_matching_boundary_face_alg() const;
 
   // overset boundary condition requires elemental field registration
   bool query_for_overset();
@@ -349,7 +349,9 @@ class Realm {
   // get aura, bulk and meta data
   bool get_activate_aura();
   stk::mesh::BulkData & bulk_data();
+  const stk::mesh::BulkData & bulk_data() const;
   stk::mesh::MetaData & meta_data();
+  const stk::mesh::MetaData & meta_data() const;
 
   // inactive part
   stk::mesh::Selector get_inactive_selector();

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -42,6 +42,14 @@ typedef std::pair<stk::mesh::Entity, stk::mesh::Entity> Connection;
 typedef Kokkos::UnorderedMap<Connection,void> ConnectionSetKK;
 typedef std::vector< Connection > ConnectionVec;
 
+  enum DOFStatus {
+    DS_NotSet           = 0,
+    DS_SkippedDOF       = 1 << 1,
+    DS_OwnedDOF         = 1 << 2,
+    DS_GloballyOwnedDOF = 1 << 3,
+    DS_GhostedDOF       = 1 << 4
+  };
+
 class TpetraLinearSystem : public LinearSystem
 {
 public:
@@ -120,14 +128,6 @@ public:
     return myLIDs[entityId];
   }
 
-
-  enum DOFStatus {
-    DS_NotSet           = 0,
-    DS_SkippedDOF       = 1 << 1,
-    DS_OwnedDOF         = 1 << 2,
-    DS_GloballyOwnedDOF = 1 << 3,
-    DS_GhostedDOF       = 1 << 4
-  };
 
   int getDofStatus(stk::mesh::Entity node);
 
@@ -222,6 +222,8 @@ void copy_kokkos_unordered_map(const Kokkos::UnorderedMap<T1,T2>& src,
   }
   ThrowRequire(fail_count == 0);
 }
+
+int getDofStatus_impl(stk::mesh::Entity node, const Realm& realm);
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2420,7 +2420,7 @@ Realm::get_coordinates_name()
 //-------- has_mesh_motion -------------------------------------------------
 //--------------------------------------------------------------------------
 bool
-Realm::has_mesh_motion()
+Realm::has_mesh_motion() const
 {
   return solutionOptions_->meshMotion_;
 }
@@ -2429,7 +2429,7 @@ Realm::has_mesh_motion()
 //-------- has_mesh_deformation --------------------------------------------
 //--------------------------------------------------------------------------
 bool
-Realm::has_mesh_deformation()
+Realm::has_mesh_deformation() const
 {
   return solutionOptions_->externalMeshDeformation_ | solutionOptions_->meshDeformation_;
 }
@@ -2438,7 +2438,7 @@ Realm::has_mesh_deformation()
 //-------- does_mesh_move --------------------------------------------------
 //--------------------------------------------------------------------------
 bool
-Realm::does_mesh_move()
+Realm::does_mesh_move() const
 {
   return has_mesh_motion() | has_mesh_deformation();
 }
@@ -2447,7 +2447,7 @@ Realm::does_mesh_move()
 //-------- has_non_matching_boundary_face_alg ------------------------------
 //--------------------------------------------------------------------------
 bool
-Realm::has_non_matching_boundary_face_alg()
+Realm::has_non_matching_boundary_face_alg() const
 {
   return hasNonConformal_ | hasOverset_; 
 }
@@ -4785,11 +4785,23 @@ Realm::bulk_data()
   return *bulkData_;
 }
 
+const stk::mesh::BulkData &
+Realm::bulk_data() const
+{
+  return *bulkData_;
+}
+
 //--------------------------------------------------------------------------
 //-------- meta_data() -----------------------------------------------------
 //--------------------------------------------------------------------------
 stk::mesh::MetaData &
 Realm::meta_data()
+{
+  return *metaData_;
+}
+
+const stk::mesh::MetaData &
+Realm::meta_data() const
 {
   return *metaData_;
 }

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include <UnitTestHelperObjects.h>
+#include <stk_mesh/base/BulkData.hpp>
+
+#include "UnitTestUtils.h"
+
+#include <TpetraLinearSystem.h>
+
+TEST_F(Hex8MeshWithNSOFields, getDofStatus_basic)
+{
+  fill_mesh_and_initialize_test_fields("generated:1x1x2");
+
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+
+  stk::mesh::Entity node1 = bulk.get_entity(stk::topology::NODE_RANK, 1);
+  if (bulk.is_valid(node1)) {
+    if (bulk.bucket(node1).owned()) {
+      EXPECT_EQ(sierra::nalu::DS_OwnedDOF, sierra::nalu::getDofStatus_impl(node1, helperObjs.realm));
+    }
+  }
+}
+
+TEST_F(Hex8MeshWithNSOFields, getDofStatus_shared)
+{
+  fill_mesh_and_initialize_test_fields("generated:10x10x10");
+
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+
+  stk::mesh::Selector shared = bulk.mesh_meta_data().globally_shared_part();
+  const stk::mesh::BucketVector& sharedBuckets = bulk.get_buckets(stk::topology::NODE_RANK, shared);
+  
+  for(const stk::mesh::Bucket* bptr : sharedBuckets) {
+      const stk::mesh::Bucket& bucket = *bptr;
+      for(stk::mesh::Entity node : bucket) {
+          if (bucket.owned()) {
+              EXPECT_EQ(sierra::nalu::DS_OwnedDOF,
+                        sierra::nalu::getDofStatus_impl(node, helperObjs.realm));
+          }
+          else {
+              EXPECT_EQ(sierra::nalu::DS_GloballyOwnedDOF,
+                        sierra::nalu::getDofStatus_impl(node, helperObjs.realm));
+          }
+      }
+  }
+}
+

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -7,7 +7,9 @@
 
 #include <TpetraLinearSystem.h>
 
-TEST_F(Hex8MeshWithNSOFields, getDofStatus_basic)
+class DofStatusHex8Mesh : public Hex8Mesh {};
+
+TEST_F(DofStatusHex8Mesh, getDofStatus_basic)
 {
   fill_mesh_and_initialize_test_fields("generated:1x1x2");
 
@@ -21,7 +23,7 @@ TEST_F(Hex8MeshWithNSOFields, getDofStatus_basic)
   }
 }
 
-TEST_F(Hex8MeshWithNSOFields, getDofStatus_shared)
+TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
 {
   fill_mesh_and_initialize_test_fields("generated:10x10x10");
 


### PR DESCRIPTION
Made the body of getDofStatus into a free-function that is called
by the TpetraLinearSystem class member. That way it can also be
called by unit-tests.

These first unit-tests are very basic, only checking owned and
shared. It will be useful to add slightly more sophisticated tests
to nail down getDofStatus behavior for ghosted, periodic and
other dof flavors.