### PR TITLE
Improve the Belos output in Nalu

### DIFF
--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -72,9 +72,8 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
   params_->set("Maximum Iterations", max_iterations);
   if (output_level > 0)
   {
-    params_->set("Verbosity", Belos::Debug + Belos::Warnings + Belos::IterationDetails
-      + Belos::OrthoDetails + Belos::FinalSummary
-      + Belos::TimingDetails + Belos::StatusTestDetails);
+    params_->set("Verbosity", Belos::Errors + Belos::Warnings + Belos::StatusTestDetails);
+    params_->set("Output Style",Belos::Brief); 
   }
 
   params_->set("Output Frequency", output_level);


### PR DESCRIPTION
This commit causes Belos to print the Krylov residual history in a simpler format, similar to Aztec (for those of you who remember that package).  The default Belos output can be confusing and prints more information than we'd typically want to see.  Here's a before/after example:

**before**

```
Belos::StatusTestGeneralOutput: Failed
  (Num calls,Mod test,State test): (1, 1, Passed Failed Undefined)
   Failed.......OR Combination -> 
     OK...........Number of Iterations = 0 < 50
     Unconverged..(2-Norm Res Vec) / (2-Norm Prec Res0)
                  residual [ 0 ] = 1 > 1e-05


Belos::StatusTestGeneralOutput: Failed
  (Num calls,Mod test,State test): (2, 1, Passed Failed Undefined)
   Failed.......OR Combination -> 
     OK...........Number of Iterations = 1 < 50
     Unconverged..(2-Norm Res Vec) / (2-Norm Prec Res0)
                  residual [ 0 ] = 0.259684 > 1e-05
[snip]
```

**after**

```
*******************************************************
***** Belos Iterative Solver:  Pseudo Block Gmres 
***** Maximum Iterations: 50
***** Block Size: 1
***** Residual Test: 
*****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) / (2-Norm Prec Res0), tol = 1e-05
*******************************************************
Iter  0, [ 1] :    1.000000e+00
Iter  1, [ 1] :    5.627616e-01
Iter  2, [ 1] :    3.117113e-01
Iter  3, [ 1] :    2.249184e-01
Iter  4, [ 1] :    1.924150e-01
Iter  5, [ 1] :    1.622222e-01
Iter  6, [ 1] :    1.352788e-01
Iter  7, [ 1] :    1.093295e-01
Iter  8, [ 1] :    9.014814e-02
Iter  9, [ 1] :    7.128857e-02
Iter 10, [ 1] :    5.710763e-02
[snip]
```