### PR TITLE
Realm: Add input option to skip parts from Exodus file

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -556,6 +556,8 @@ class Realm {
     const TurbulenceModelConstant turbModelEnum);
   bool process_adaptivity();
 
+  void process_skipped_parts();
+
   // element promotion options
   bool doPromotion_; // conto
   unsigned promotionOrder_;
@@ -565,6 +567,10 @@ class Realm {
 
   // save off the node
   const YAML::Node & node_;
+
+  //! User-specified inactive parts in the mesh
+  std::vector<std::string> skippedPartNames_;
+  stk::mesh::PartVector skippedParts_;
 
   // tools
   std::unique_ptr<ElementDescription> desc_; // holds topo info


### PR DESCRIPTION
Introduces `skip_parts_from_file` option in Realm section of Nalu input file
that accepts a list of Exodus parts that must be added to Realm's
inactive_selector.

Usage:

```
realms:

  - name: fluids_realm
    mesh: abl_40.g
    use_edges: yes
    automatic_decomposition_type: rcb
    skip_parts_from_file:
      - zplane_0090.0
```