### PR TITLE
Allow different tolerance settings for final/non-final outer iters

### DIFF
--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -105,7 +105,8 @@ class TpetraLinearSolver : public LinearSolver
     int solve(
       Teuchos::RCP<LinSys::Vector> sln,
       int & iterationCount,
-      double & scaledResidual);
+      double & scaledResidual,
+      bool isFinalOuterIter);
 
     virtual PetraType getType() { return PT_TPETRA; }
     TpetraLinearSolverConfig *getConfig() { return config_; }

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -37,12 +37,18 @@ class TpetraLinearSolverConfig {
     std::string get_method() {return method_;}
     std::string preconditioner_type(){ return preconditionerType_;}
 
+  inline double tolerance() const { return tolerance_; }
+  inline double finalTolerance() const { return finalTolerance_; }
+
   private:
     std::string name_;
     std::string method_;
     std::string precond_;
     Teuchos::RCP<Teuchos::ParameterList> params_;
     Teuchos::RCP<Teuchos::ParameterList> paramsPrecond_;
+
+  double tolerance_;
+  double finalTolerance_;
 
     std::string muelu_xml_file_;
     bool useMueLu_;

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -586,6 +586,8 @@ class Realm {
 
   stk::mesh::PartVector allPeriodicInteractingParts_;
   stk::mesh::PartVector allNonConformalInteractingParts_;
+
+  bool isFinalOuterIter_{false};
 };
 
 } // namespace nalu

--- a/src/LinearSolver.C
+++ b/src/LinearSolver.C
@@ -181,7 +181,8 @@ int
 TpetraLinearSolver::solve(
   Teuchos::RCP<LinSys::Vector> sln,
   int & iters,
-  double & finalResidNrm)
+  double & finalResidNrm,
+  bool isFinalOuterIter)
 {
   ThrowRequire(!sln.is_null());
 
@@ -207,6 +208,16 @@ TpetraLinearSolver::solve(
   // Update preconditioner timer for this timestep; actual summing over
   // timesteps is handled in EquationSystem::assemble_and_solve
   timerPrecond_ = time;
+
+  Teuchos::RCP<Teuchos::ParameterList> params(
+    Teuchos::rcp(new Teuchos::ParameterList));
+  if (isFinalOuterIter) {
+    params->set("Convergence Tolerance", config_->finalTolerance());
+  } else {
+    params->set("Convergence Tolerance", config_->tolerance());
+  }
+
+  solver_->setParameters(params);
 
   problem_->setProblem();
   solver_->solve();

--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -62,10 +62,13 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
   double tol;
   int max_iterations, kspace, output_level;
 
-  get_if_present(node, "tolerance", tol, 1.e-4);
+  get_if_present(node, "tolerance", tolerance_, 1.e-4);
+  get_if_present(node, "final_tolerance", finalTolerance_, tolerance_);
   get_if_present(node, "max_iterations", max_iterations, 50);
   get_if_present(node, "kspace", kspace, 50);
   get_if_present(node, "output_level", output_level, 0);
+
+  tol = tolerance_;
 
   //Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::params();
   params_->set("Convergence Tolerance", tol);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1896,6 +1896,8 @@ Realm::advance_time_step()
       << "/" << numNonLinearIterations
       << std::setw(29) << std::right << "Equation System Iteration" << std::endl;
 
+    isFinalOuterIter_ = ((i+1) == numNonLinearIterations);
+
     const bool isConverged = equationSystems_.solve_and_update();
 
     // evaluate properties based on latest np1 solution

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1380,7 +1380,8 @@ TpetraLinearSystem::solve(
   const int status = linearSolver->solve(
       sln_,
       iters,
-      finalResidNorm);
+      finalResidNorm,
+      realm_.isFinalOuterIter_);
 
   solve_time += NaluEnv::self().nalu_time();
 


### PR DESCRIPTION
Add an option in `linear_solvers` section to allow user to specify
linear solver convergence tolerance settings for the final and
prior outer iterations.

This commit fixes the error seen in certain regression tests after a
previous attempt at implementing this feature in pull request #256. Please
see the discussion in #256 for @spdomin's admonitions on using this feature,
particularly its interactions with the convergence tolerance setting in EQS
inputs.