### PR TITLE
Realm: Automate determination of inactive parts.

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -508,6 +508,9 @@ class Realm {
   // beginning wall time
   double wallTimeStart_;
 
+  // mesh parts for all interior domains
+  stk::mesh::PartVector interiorPartVec_;
+
   // mesh parts for all boundary conditions
   stk::mesh::PartVector bcPartVec_;
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2988,6 +2988,9 @@ Realm::register_interior_algorithm(
   else {
     it->second->partVec_.push_back(part);
   }
+
+  // Track parts that are registered to interior algorithms
+  interiorPartVec_.push_back(part);
 }
 
 //--------------------------------------------------------------------------
@@ -4828,17 +4831,24 @@ Realm::get_inactive_selector()
     (hasOverset_) ? oversetManager_->get_inactive_selector()
     : stk::mesh::Selector();
 
-  // provide inactive dataProbe parts
-  stk::mesh::Selector inactiveDataProbeSelector = (NULL != dataProbePostProcessing_) 
-    ? (dataProbePostProcessing_->get_inactive_selector())
-    : stk::mesh::Selector();
+  // // provide inactive dataProbe parts
+  // stk::mesh::Selector inactiveDataProbeSelector = (NULL != dataProbePostProcessing_)
+  //   ? (dataProbePostProcessing_->get_inactive_selector())
+  //   : stk::mesh::Selector();
 
-  stk::mesh::Selector inactiveABLForcing = (
-    ( NULL != ablForcingAlg_)
-    ? (ablForcingAlg_->inactive_selector())
-    : stk::mesh::Selector());
+  // stk::mesh::Selector inactiveABLForcing = (
+  //   ( NULL != ablForcingAlg_)
+  //   ? (ablForcingAlg_->inactive_selector())
+  //   : stk::mesh::Selector());
   
-  return inactiveOverSetSelector | inactiveDataProbeSelector | inactiveABLForcing;
+  // return inactiveOverSetSelector | inactiveDataProbeSelector | inactiveABLForcing;
+
+  stk::mesh::Selector otherInactiveSelector = (
+    metaData_->universal_part()
+    & !(stk::mesh::selectUnion(interiorPartVec_))
+    & !(stk::mesh::selectUnion(bcPartVec_)));
+
+  return inactiveOverSetSelector | otherInactiveSelector;
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Implement logic to determine inactive parts (i.e., parts in the
Exodus-II database) that aren't explicitly listed in interior or BC.
The nodes from these parts will be ignored during the setup of
TpetraLinearSystem. Realm::get_inactive_selector must still handle
overset separately because certain interior regions can be tagged
inactive by overset simulations.