### PR TITLE
ABL: Add resolved and SFS stress computations for velocity and temperature fields

### DIFF
--- a/docs/source/theory/supportedEquationSet.rst
+++ b/docs/source/theory/supportedEquationSet.rst
@@ -93,7 +93,7 @@ k represents the modeled turbulent kinetic energy as is formally defined as,
 
    \bar \rho k = \frac{1}{2} \bar\rho ( \widetilde{u_k u_k} - \tilde u_k \tilde u_k).
 
-Model closures can use, Yoshikawa's approach when k is not transported:
+Model closures can use, Yoshizawa's approach when k is not transported:
 
 .. math::
 

--- a/docs/source/theory/supportedEquationSet.rst
+++ b/docs/source/theory/supportedEquationSet.rst
@@ -30,6 +30,8 @@ derivative to include the :math:`\frac{\partial \rho}{\partial p}`
 sensitivity, an equation that admits acoustic pressure waves is
 realized.
 
+.. _supp_eqn_set_mom_cons:
+
 Conservation of Momentum
 ++++++++++++++++++++++++
 

--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -944,7 +944,10 @@ Turbulence averaging
    .. code-block:: yaml
 
       turbulence_averaging:
+        forced_reset: no
         time_filter_interval: 100000.0
+
+        averaging_type: nalu_classic/moving_exponential
 
         specifications:
 
@@ -959,6 +962,10 @@ Turbulence averaging
 
             compute_tke: yes
             compute_reynolds_stress: yes
+            compute_resolved_stress: yes
+            compute_temperature_resolved_flux: yes
+            compute_sfs_stress: yes
+            compute_temperature_sfs_flux: yes
             compute_q_criterion: yes
             compute_vorticity: yes
             compute_lambda_ci: yes
@@ -969,13 +976,32 @@ Turbulence averaging
    prefixed with ``turbulence_averaging.name`` but only the variable
    name after the period should appear in the input file.
 
+.. inpfile:: turbulence_averaging.forced_reset
+
+   A boolean flag indicating whether the averaging of all quantities in the
+   turbulence averaging section is reset. If this flag is true, the
+   running average is set to zero.
+
+.. inpfile:: turbulence_averaging.averaging_type
+
+   This parameter sets the choice of the running average type. Possible
+   values are:
+
+   ``nalu_classic``
+     "Sawtooth" average. The running average is set to zero each time the time
+     filter width is reached and a new average is calculated for the next time
+     interval.
+
+   ``moving_exponential``
+     "Moving window" average where the window size is set to to the time
+     filter width. The contribution of any quantity before the moving window
+     towards the average value reduces exponentially with every time step.
+   
 .. inpfile:: turbulence_averaging.time_filter_interval
 
-   Number indicating the time filter size over which calculate the
-   running average. The current implementation of the running average
-   in Nalu uses a "sawtooth" average. The running average is set to
-   zero each time the time filter width is reached and a new average
-   is calculated for the next time interval.
+   Number indicating the time filter size over which to calculate the
+   running average. This quantity is used in different ways for each filter
+   discussed above.
 
 .. inpfile:: turbulence_averaging.specifications
 
@@ -1007,6 +1033,36 @@ Turbulence averaging
    A boolean flag indicating whether the reynolds stress is
    computed. The default value is ``no``.
 
+.. inpfile:: turbulence_averaging.specifications.compute_resolved_stress
+
+   A boolean flag indicating whether the resolved stress is
+   computed. The default value is ``no``. When this option is turned on, the
+   Favre averages of the resolved quantities are computed as well.
+   
+.. inpfile:: turbulence_averaging.specifications.compute_temperature_resolved_flux
+
+   A boolean flag indicating whether the resolved temperature flux is
+   computed. The default value is ``no``. When this option is turned on, the
+   Favre averages of the resolved temperature is computed as well.
+
+.. inpfile:: turbulence_averaging.specifications.compute_sfs_stress
+
+   A boolean flag indicating whether the sub-filter scale stress is
+   computed. The default value is ``no``. The sub-filter scale stress model is
+   assumed to be of an eddy viscosity type and the turbulent viscosity computed
+   by the turbulence model is used. The sub-filter scale kinetic energy is used
+   to determine the isotropic component of the sub-filter stress. As described
+   in the section :ref:`supp_eqn_set_mom_cons`, the Yoshisawa model is used to
+   compute the sub-filter kinetic energy when it is not transported. 
+   
+.. inpfile:: turbulence_averaging.specifications.compute_temperature_sfs_flux
+
+   A boolean flag indicating whether the sub-filter scale flux of temperature is
+   computed. The default value is ``no``. The sub-filter scale stress model is
+   assumed to be of an eddy diffusivity type and the turbulent diffusivity computed
+   by the turbulence model is used along with a constant turbulent Prandtl number
+   obtained from the Realm.
+   
 .. inpfile:: turbulence_averaging.specifications.compute_favre_stress
 
    A boolean flag indicating whether the Favre stress is computed. The

--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1035,33 +1035,37 @@ Turbulence averaging
 
 .. inpfile:: turbulence_averaging.specifications.compute_resolved_stress
 
-   A boolean flag indicating whether the resolved stress is
-   computed. The default value is ``no``. When this option is turned on, the
-   Favre averages of the resolved quantities are computed as well.
+   A boolean flag indicating whether the average resolved stress is 
+   computed as :math:`< \bar\rho \widetilde{u_i} \widetilde{u_j} >`.
+   The default value is ``no``. When this option is turned on, the Favre
+   average of the resolved velocity, :math:`< \bar{\rho} \widetilde{u_j} >`, is
+   computed as well.
    
 .. inpfile:: turbulence_averaging.specifications.compute_temperature_resolved_flux
 
-   A boolean flag indicating whether the resolved temperature flux is
-   computed. The default value is ``no``. When this option is turned on, the
-   Favre averages of the resolved temperature is computed as well.
+   A boolean flag indicating whether the average resolved temperature flux is
+   computed as :math:`< \bar\rho \widetilde{u_i} \widetilde{\theta} >`. The
+   default value is ``no``. When this option is turned on, the Favre average
+   of the resolved temperature, :math:`< \bar{\rho} \widetilde{\theta} >`, is
+   computed as well.
 
 .. inpfile:: turbulence_averaging.specifications.compute_sfs_stress
 
-   A boolean flag indicating whether the sub-filter scale stress is
+   A boolean flag indicating whether the average sub-filter scale stress is
    computed. The default value is ``no``. The sub-filter scale stress model is
    assumed to be of an eddy viscosity type and the turbulent viscosity computed
    by the turbulence model is used. The sub-filter scale kinetic energy is used
    to determine the isotropic component of the sub-filter stress. As described
-   in the section :ref:`supp_eqn_set_mom_cons`, the Yoshisawa model is used to
+   in the section :ref:`supp_eqn_set_mom_cons`, the Yoshizawa model is used to
    compute the sub-filter kinetic energy when it is not transported. 
    
 .. inpfile:: turbulence_averaging.specifications.compute_temperature_sfs_flux
 
-   A boolean flag indicating whether the sub-filter scale flux of temperature is
-   computed. The default value is ``no``. The sub-filter scale stress model is
-   assumed to be of an eddy diffusivity type and the turbulent diffusivity computed
-   by the turbulence model is used along with a constant turbulent Prandtl number
-   obtained from the Realm.
+   A boolean flag indicating whether the average sub-filter scale flux of
+   temperature is computed. The default value is ``no``. The sub-filter scale
+   stress model is assumed to be of an eddy diffusivity type and the turbulent
+   diffusivity computed by the turbulence model is used along with a constant
+   turbulent Prandtl number obtained from the Realm.
    
 .. inpfile:: turbulence_averaging.specifications.compute_favre_stress
 

--- a/include/AveragingInfo.h
+++ b/include/AveragingInfo.h
@@ -46,6 +46,10 @@ public:
   bool computeQcriterion_;
   bool computeLambdaCI_;
 
+  // Temperature stresses
+  bool computeTemperatureSFS_{false};
+  bool computeTemperatureResolved_{false};
+
   // vector of part names, e.g., block_1, surface_2
   std::vector<std::string> targetNames_;
 

--- a/include/AveragingInfo.h
+++ b/include/AveragingInfo.h
@@ -28,7 +28,7 @@ namespace nalu{
 class AveragingInfo
 {
 public:
-  
+
   AveragingInfo();
   ~AveragingInfo();
 
@@ -40,6 +40,8 @@ public:
   bool computeTke_;
   bool computeFavreStress_;
   bool computeFavreTke_;
+  bool computeResolvedStress_{false};
+  bool computeSFSStress_{false};
   bool computeVorticity_;
   bool computeQcriterion_;
   bool computeLambdaCI_;
@@ -53,14 +55,17 @@ public:
   // vector of favre/reynolds fields
   std::vector<std::string> favreFieldNameVec_;
   std::vector<std::string> reynoldsFieldNameVec_;
+  std::vector<std::string> resolvedFieldNameVec_;
 
   // vector of pairs of fields
   std::vector<std::pair<stk::mesh::FieldBase *, stk::mesh::FieldBase *> > favreFieldVecPair_;
   std::vector<std::pair<stk::mesh::FieldBase *, stk::mesh::FieldBase *> > reynoldsFieldVecPair_;
-  
+  std::vector<std::pair<stk::mesh::FieldBase *, stk::mesh::FieldBase *> > resolvedFieldVecPair_;
+
   // sizes for each
   std::vector<unsigned> favreFieldSizeVec_;
   std::vector<unsigned> reynoldsFieldSizeVec_;
+  std::vector<unsigned> resolvedFieldSizeVec_;
 };
 
 } // namespace nalu

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -184,7 +184,8 @@ enum TurbulenceModelConstant {
   TM_CbTwo = 19,
   TM_SDRWallFactor = 20,
   TM_zCV = 21,
-  TM_END = 22
+  TM_ci = 22,
+  TM_END = 23
 };
 
 static const std::string TurbulenceModelConstantNames[] = {
@@ -210,6 +211,7 @@ static const std::string TurbulenceModelConstantNames[] = {
   "Cb2",
   "SDRWallFactor",
   "Z_CV",
+  "ci",
   "END"};
 
 enum ActuatorType {

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -124,14 +124,14 @@ public:
       const double &dt,
       stk::mesh::Selector s_all_nodes);
 
-  void compute_temperature_resolved_stress(
+  void compute_temperature_resolved_flux(
     const std::string &averageBlockName,
     const double &oldTimeFilter,
     const double &zeroCurrent,
     const double &dt,
     stk::mesh::Selector s_all_nodes);
 
-  void compute_temperature_sfs_stress(
+  void compute_temperature_sfs_flux(
     const std::string &averageBlockName,
     const double &oldTimeFilter,
     const double &zeroCurrent,

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -124,6 +124,20 @@ public:
       const double &dt,
       stk::mesh::Selector s_all_nodes);
 
+  void compute_temperature_resolved_stress(
+    const std::string &averageBlockName,
+    const double &oldTimeFilter,
+    const double &zeroCurrent,
+    const double &dt,
+    stk::mesh::Selector s_all_nodes);
+
+  void compute_temperature_sfs_stress(
+    const std::string &averageBlockName,
+    const double &oldTimeFilter,
+    const double &zeroCurrent,
+    const double &dt,
+    stk::mesh::Selector s_all_nodes);
+
   void compute_vorticity(
     const std::string &averageBlockName,
 	stk::mesh::Selector s_all_nodes);

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -110,6 +110,20 @@ public:
     const double &dt,
     stk::mesh::Selector s_all_nodes);
 
+  void compute_resolved_stress(
+      const std::string &averageBlockName,
+      const double &oldTimeFilter,
+      const double &zeroCurrent,
+      const double &dt,
+      stk::mesh::Selector s_all_nodes);
+
+  void compute_sfs_stress(
+      const std::string &averageBlockName,
+      const double &oldTimeFilter,
+      const double &zeroCurrent,
+      const double &dt,
+      stk::mesh::Selector s_all_nodes);
+
   void compute_vorticity(
     const std::string &averageBlockName,
 	stk::mesh::Selector s_all_nodes);

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -33,9 +33,25 @@ namespace nalu{
 class Realm;
 class AveragingInfo;
 
+/** Post-processing to collect various types of statistics on flow fields
+ *
+ *  This class implements Reynolds and Favre averaging as well as other useful
+ *  quantities relevant to analyzing turbulent flows.
+ *
+ *  Currently supported:
+ *    - Reynolds and Favre averaging of flow variables
+ *    - TKE and stress computation
+ *    - Vorticity, Q-criterion, lambda-ci calculation
+ */
 class TurbulenceAveragingPostProcessing
 {
 public:
+  /** Type of time filter averaging applied
+   */
+  enum AveragingType {
+    NALU_CLASSIC = 0,           //!< Classic Nalu implementation (saw-tooth reset)
+    MOVING_EXPONENTIAL,         //!< Moving exponential window averaging
+  };
   
   TurbulenceAveragingPostProcessing(
     Realm &realm,
@@ -111,7 +127,10 @@ public:
 
   double currentTimeFilter_; /* provided by restart */
   double timeFilterInterval_; /* user supplied */
+
   bool forcedReset_; /* allows forhard reset */
+
+  AveragingType averagingType_{NALU_CLASSIC};
 
   // vector of averaging information
   std::vector<AveragingInfo *> averageInfoVec_;

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -658,6 +658,7 @@ SolutionOptions::initialize_turbulence_constants()
   turbModelConstantMap_[TM_CbTwo] = 0.35;
   turbModelConstantMap_[TM_SDRWallFactor] = 1.0;
   turbModelConstantMap_[TM_zCV] = 0.5;
+  turbModelConstantMap_[TM_ci] = 0.9;
 }
 
 


### PR DESCRIPTION
This pull request adds ability to compute time-averaged resolved and SFS stress fields for both temperature and velocity fields for use with ABL precursor simulations. This will be used with boundary layer statistics post-processing to extract various quantities of interest during wind energy simulations. 