### PR TITLE
Copy fix NSO; simple

### DIFF
--- a/include/nso/MomentumNSOElemKernel.h
+++ b/include/nso/MomentumNSOElemKernel.h
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */

--- a/include/nso/MomentumNSOSijElemKernel.h
+++ b/include/nso/MomentumNSOSijElemKernel.h
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */

--- a/include/nso/ScalarNSOKeElemKernel.h
+++ b/include/nso/ScalarNSOKeElemKernel.h
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */


### PR DESCRIPTION
As per Srini's request, I have taken a shot at cleaning up, as a first step, NSO copyright.

All of these cases below are the "easy" type in which a copyright clause has been copy/pasted in error. Code converted as part of the large re-factor has been left alone as we need to discuss this as a team.

The pedigree of the code is below. In one case, a later file rename caused a copyright change.

Author: Stefan P. Domino <spdomin@sandia.gov>  2017-03-01 16:06:44
Committer: Stefan P. Domino <spdomin@sandia.gov>  2017-03-01 16:06:44
Parent: a89639787541783a735eff17c3acf27396ca089d (Increasing test timeout values, and disabling non-uniform tests for the moment.)
Child:  80043a4a1e79ed416b7639e46a44748c50786bff (Convert MomAdvDiffSuppAlg to the new infrastructure)
Branches: copyFixNSO, master, nsoKe, remotes/fork/nsoKe, remotes/origin/hfm-fy18q1, remotes/origin/master, remotes/origin/revert-256-abl-tol-setting, remotes/origin/srk-041017-nc-per-getDofStatus, remotes/origin/srk-050317-nc-per-1, remotes/origin/srk-050317-nonconf-periodic
Follows: v1.1.0
Precedes: v1.2.0

    Add MomentumNSOElemSuppAlg that will work with new AssembleElemSolverAlg design

Author: Stefan P. Domino <spdomin@sandia.gov>  2017-04-18 17:19:58
Committer: Stefan P. Domino <spdomin@sandia.gov>  2017-04-18 17:19:58
Parent: b78c320908438ad2ae7b1ea1ddc97702bde9b5fd (Enable paraview catalyst (#111))
Child:  1f129a7415295ebc30bf42efe71ff6c5a9bfbf7c (Install type-o for pnetcdf)
Branches: copyFixNSO, master, nsoKe, remotes/fork/nsoKe, remotes/origin/hfm-fy18q1, remotes/origin/master, remotes/origin/revert-256-abl-tol-setting, remotes/origin/srk-050317-nc-per-1, remotes/origin/srk-050317-nonconf-periodic
Follows: v1.1.0
Precedes: v1.2.0

    NSO as a proper turbulence model for production V&V project; Sij

Author: Stefan P. Domino <nalucfd@gmail.com>  2017-11-29 12:38:10
Committer: GitHub <noreply@github.com>  2017-11-29 12:38:10
Parent: 9cd07327dbf7d7beadbde83978f8ed047b4f86d0 (Higher order implementation for actuator line (#236))
Child:  8e187ee4cff7bd15b99010646553cb7cf4b8e1b3 (Add a clipped, scaled scalar variance for table lookups (#255))
Branches: copyFixNSO, master, nsoKe, remotes/origin/master, remotes/origin/revert-256-abl-tol-setting
Follows: v1.2.0
Precedes: 

    Add ke NSO for Z and h (#253)
