### PR TITLE
Minor typo fix: Grab SDR at state NP1 not N.

### DIFF
--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -497,7 +497,7 @@ ShearStressTransportEquationSystem::compute_f_one_blending()
   const double CDkwClip = 1.0e-10; // 2003 SST
 
   // required fields with state; min_distance is fine
-  ScalarFieldType &sdrNp1 = sdr_->field_of_state(stk::mesh::StateN);
+  ScalarFieldType &sdrNp1 = sdr_->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType &tkeNp1 = tke_->field_of_state(stk::mesh::StateNP1);
 
   // fields not saved off


### PR DESCRIPTION
Unless there is a good reason for the way it was, I think this is a typo. This minor typo does not affect the unit tests or regressions.