### PR TITLE
HYPRE: Add 64-bit integer support for Hypre interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,17 @@ SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${Trilinos_Fortran_COMPILER_FLAG
 MESSAGE("-- CMAKE_CXX_FLAGS     = ${CMAKE_CXX_FLAGS}")
 MESSAGE("-- CMAKE_Fortran_FLAGS = ${CMAKE_Fortran_FLAGS}")
 
+if (ENABLE_HYPRE)
+  include(CheckSymbolExists)
+  set(CMAKE_REQUIRED_INCLUDES "${HYPRE_INCLUDE_DIRS}")
+  check_symbol_exists(
+    HYPRE_BIGINT "${HYPRE_INCLUDE_DIRS}/HYPRE_config.h" NALU_HYPRE_BIGINT)
+  if (NOT NALU_HYPRE_BIGINT)
+    message(WARNING
+      "HYPRE does not enable 64-bit integer support; will fail on large problems!")
+  endif()
+endif()
+
 file (GLOB SOURCE src/*.C src/*/*.C src/*/*.F)
 file (GLOB HEADER include/*.h include/*/*.h)
 

--- a/docs/source/user/build_manually.rst
+++ b/docs/source/user/build_manually.rst
@@ -297,11 +297,20 @@ HYPRE library and link to it when building Nalu.
    cd hypre/src
 
    # 2. Configure HYPRE package and pass installation directory
-   ./configure --prefix=$nalu_install_dir --without-superlu --without-openmp
+   ./configure --prefix=$nalu_install_dir --without-superlu --without-openmp --enable-bigint
 
    # 3. Compile and install
    make && make install
 
+.. note::
+
+   #. Make sure that ``--enable-bigint`` option is turned on if you intend to
+      run linear systems with :math:`> 2` billion rows. Otherwise, ``nalu``
+      executable will throw an error at runtime for large problems.
+
+   #. Users must pass ``-DENABLE_HYPRE`` option to CMake during Nalu
+      configuration phase. Optionally, the variable `-DHYPRE_DIR`` can be used
+      to pass the path of HYPRE install location to CMake.
 
 Build
 *****

--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -12,6 +12,10 @@
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 
+#ifdef NALU_USES_HYPRE
+#include "HYPRE_utilities.h"
+#endif
+
 namespace sierra{
 namespace nalu{
 
@@ -29,6 +33,16 @@ typedef stk::mesh::Field<double, stk::mesh::SimpleArrayTag>  GenericFieldType;
 // field type for local ids
 typedef unsigned LocalId;
 typedef stk::mesh::Field<LocalId>  LocalIdFieldType;
+
+
+// Hypre Integer types
+#ifdef NALU_USES_HYPRE
+typedef HYPRE_Int HypreIntType;
+#else
+typedef int HypreIntType;
+#endif
+
+typedef stk::mesh::Field<HypreIntType> HypreIDFieldType;
 
 } // namespace nalu
 } // namespace Sierra

--- a/include/HypreDirectSolver.h
+++ b/include/HypreDirectSolver.h
@@ -91,27 +91,27 @@ private:
 
   mutable HYPRE_Solver precond_;
 
-  int (*solverCreatePtr_)(MPI_Comm, HYPRE_Solver*);
-  int (*solverDestroyPtr_)(HYPRE_Solver);
-  int (*solverSetupPtr_)(
+  HypreIntType (*solverCreatePtr_)(MPI_Comm, HYPRE_Solver*);
+  HypreIntType (*solverDestroyPtr_)(HYPRE_Solver);
+  HypreIntType (*solverSetupPtr_)(
     HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector);
-  int (*solverSolvePtr_)(
+  HypreIntType (*solverSolvePtr_)(
     HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector);
-  int (*solverPrecondPtr_)(
+  HypreIntType (*solverPrecondPtr_)(
     HYPRE_Solver,
     HYPRE_PtrToParSolverFcn,
     HYPRE_PtrToParSolverFcn,
     HYPRE_Solver);
 
-  int (*precondCreatePtr_)(MPI_Comm, HYPRE_Solver*);
-  int (*precondDestroyPtr_)(HYPRE_Solver);
-  int (*precondSetupPtr_)(
+  HypreIntType (*precondCreatePtr_)(MPI_Comm, HYPRE_Solver*);
+  HypreIntType (*precondDestroyPtr_)(HYPRE_Solver);
+  HypreIntType (*precondSetupPtr_)(
     HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector);
-  int (*precondSolvePtr_)(
+  HypreIntType (*precondSolvePtr_)(
     HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector);
 
-  int (*solverNumItersPtr_)(HYPRE_Solver, int*);
-  int (*solverFinalResidualNormPtr_)(HYPRE_Solver, double*);
+  HypreIntType (*solverNumItersPtr_)(HYPRE_Solver, HypreIntType*);
+  HypreIntType (*solverFinalResidualNormPtr_)(HYPRE_Solver, double*);
 
 
   //! Flag indicating whether a preconditioner is used. Certain solvers like

--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -9,6 +9,7 @@
 #define HYPRELINEARSYSTEM_H
 
 #include "LinearSystem.h"
+#include "XSDKHypreInterface.h"
 
 #include "stk_mesh/base/BulkData.hpp"
 
@@ -213,7 +214,7 @@ protected:
    *
    *  @return The HYPRE row ID
    */
-  int get_entity_hypre_id(const stk::mesh::Entity&);
+  HypreIntType get_entity_hypre_id(const stk::mesh::Entity&);
 
   //! Helper method to transfer the solution from a HYPRE_IJVector instance to
   //! the STK field data instance.
@@ -265,25 +266,32 @@ private:
   std::vector<RowStatus> rowStatus_;
 
   //! Track which rows are skipped
-  std::unordered_set<int> skippedRows_;
+  std::unordered_set<HypreIntType> skippedRows_;
+
+  //! Buffer for handling Global Row IDs for use in sumInto methods
+  std::vector<HypreIntType> idBuffer_;
 
   //! The lowest row owned by this MPI rank
-  int iLower_;
+  HypreIntType iLower_;
   //! The highest row owned by this MPI rank
-  int iUpper_;
+  HypreIntType iUpper_;
   //! The lowest column owned by this MPI rank; currently jLower_ == iLower_
-  int jLower_;
+  HypreIntType jLower_;
   //! The highest column owned by this MPI rank; currently jUpper_ == iUpper_
-  int jUpper_;
+  HypreIntType jUpper_;
   //! Total number of rows owned by this particular MPI rank
-  int numRows_;
+  HypreIntType numRows_;
   //! Maximum Row ID in the Hypre linear system
-  int maxRowID_;
+  HypreIntType maxRowID_;
 
   //! Flag indicating whether the linear system has been initialized
   bool systemInitialized_{false};
 
-  bool checkSkippedRows_{true};
+  //! Flag indicating that sumInto should check to see if rows must be skipped
+  bool checkSkippedRows_{false};
+
+  //! Flag indicating that dirichlet and/or overset rows are present for this system
+  bool hasSkippedRows_{false};
 };
 
 }  // nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -604,7 +604,7 @@ class Realm {
    *  must be adjusted accordingly to account for multiple degrees of freedom on
    *  a particular node. This is performed in sierra::nalu::HypreLinearSystem.
    */
-  int hypreILower_;
+  stk::mesh::EntityId hypreILower_;
 
   /** The ending index (global) of the HYPRE linear system in this MPI rank
    *
@@ -612,13 +612,13 @@ class Realm {
    *  must be adjusted accordingly to account for multiple degrees of freedom on
    *  a particular node. This is performed in sierra::nalu::HypreLinearSystem.
    */
-  int hypreIUpper_;
+  stk::mesh::EntityId hypreIUpper_;
 
   /** The total number of HYPRE nodes in the linear system
    *
    *  Note that this is not an MPI rank local quantity
    */
-  int hypreNumNodes_;
+  stk::mesh::EntityId hypreNumNodes_;
 
   /** Global Row IDs for the HYPRE linear system
    *
@@ -627,7 +627,7 @@ class Realm {
    *  IDs be ordered across MPI ranks; i.e., startIdx (MPI_rank + 1) =
    *  endIdx(MPI_rank) + 1.
    */
-  ScalarIntFieldType* hypreGlobalId_;
+  HypreIDFieldType* hypreGlobalId_{nullptr};
 
   /** Flag indicating whether Hypre solver is being used for any of the equation
    * systems.

--- a/include/XSDKHypreInterface.h
+++ b/include/XSDKHypreInterface.h
@@ -50,6 +50,7 @@
 #ifndef XSDKHYPREINTERFACE_H
 #define XSDKHYPREINTERFACE_H
 
+#include "FieldTypeDef.h"
 #include "Ifpack2_ConfigDefs.hpp"
 
 #include "HYPRE_IJ_mv.h"
@@ -96,59 +97,88 @@ enum Hypre_Chooser{
 
 //! This class is used to help with passing parameters in the SetParameter() function. Use this class to call Hypre's internal parameters.
 class FunctionParameter{
+  using HypreIntType = sierra::nalu::HypreIntType;
+
   public:
     //! Single int constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, int), int param1) :
-      chooser_(chooser),
-      option_(0),
-      int_func_(funct_name),
-      int_param1_(param1) {}
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, HypreIntType),
+      HypreIntType param1)
+      : chooser_(chooser),
+        option_(0),
+        int_func_(funct_name),
+        int_param1_(param1)
+    {}
 
     //! Single double constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, double), double param1):
-      chooser_(chooser),
-      option_(1),
-      double_func_(funct_name),
-      double_param1_(param1) {}
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, double),
+      double param1)
+      : chooser_(chooser),
+        option_(1),
+        double_func_(funct_name),
+        double_param1_(param1)
+    {}
 
-    //! Single double, single int constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, double, int), double param1, int param2):
-      chooser_(chooser),
-      option_(2),
-      double_int_func_(funct_name),
-      int_param1_(param2),
-      double_param1_(param1) {}
+    //! Single double, single HypreIntType constructor.
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, double, HypreIntType),
+      double param1,
+      HypreIntType param2)
+      : chooser_(chooser),
+        option_(2),
+        double_int_func_(funct_name),
+        int_param1_(param2),
+        double_param1_(param1)
+    {}
 
-    //! Two ints constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, int, int), int param1, int param2):
-      chooser_(chooser),
-      option_(3),
-      int_int_func_(funct_name),
-      int_param1_(param1),
-      int_param2_(param2) {}
+    //! Two HypreIntTypes constructor.
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, HypreIntType, HypreIntType),
+      HypreIntType param1,
+      HypreIntType param2)
+      : chooser_(chooser),
+        option_(3),
+        int_int_func_(funct_name),
+        int_param1_(param1),
+        int_param2_(param2)
+    {}
 
-    //! Int pointer constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, int*), int *param1):
-      chooser_(chooser),
-      option_(4),
-      int_star_func_(funct_name),
-      int_star_param_(param1) {}
+    //! HypreIntType pointer constructor.
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, HypreIntType*),
+      HypreIntType* param1)
+      : chooser_(chooser),
+        option_(4),
+        int_star_func_(funct_name),
+        int_star_param_(param1)
+    {}
 
     //! Double pointer constructor.
-    FunctionParameter(Hypre::Hypre_Chooser chooser, int (*funct_name)(HYPRE_Solver, double*), double* param1):
-      chooser_(chooser),
-      option_(5),
-      double_star_func_(funct_name),
-      double_star_param_(param1) {}
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, double*),
+      double* param1)
+      : chooser_(chooser),
+        option_(5),
+        double_star_func_(funct_name),
+        double_star_param_(param1)
+    {}
 
     //! char pointer constructor
-    FunctionParameter(Hypre::Hypre_Chooser chooser,
-                      int (*funct_name)(HYPRE_Solver, char*),
-                      char* param1
-    ): chooser_(chooser),
-       option_(6),
-       char_star_func_(funct_name),
-       char_star_param_(param1)
+    FunctionParameter(
+      Hypre::Hypre_Chooser chooser,
+      HypreIntType (*funct_name)(HYPRE_Solver, char*),
+      char* param1)
+      : chooser_(chooser),
+        option_(6),
+        char_star_func_(funct_name),
+        char_star_param_(param1)
     {}
 
     //! Only method of this class. Calls the function pointer with the passed in HYPRE_Solver
@@ -193,17 +223,17 @@ class FunctionParameter{
   private:
     Hypre::Hypre_Chooser chooser_;
     int option_;
-    int (*int_func_)(HYPRE_Solver, int);
-    int (*double_func_)(HYPRE_Solver, double);
-    int (*double_int_func_)(HYPRE_Solver, double, int);
-    int (*int_int_func_)(HYPRE_Solver, int, int);
-    int (*int_star_func_)(HYPRE_Solver, int*);
-    int (*double_star_func_)(HYPRE_Solver, double*);
-    int (*char_star_func_)(HYPRE_Solver, char*);
-    int int_param1_;
-    int int_param2_;
+    HypreIntType (*int_func_)(HYPRE_Solver, HypreIntType);
+    HypreIntType (*double_func_)(HYPRE_Solver, double);
+    HypreIntType (*double_int_func_)(HYPRE_Solver, double, HypreIntType);
+    HypreIntType (*int_int_func_)(HYPRE_Solver, HypreIntType, HypreIntType);
+    HypreIntType (*int_star_func_)(HYPRE_Solver, HypreIntType*);
+    HypreIntType (*double_star_func_)(HYPRE_Solver, double*);
+    HypreIntType (*char_star_func_)(HYPRE_Solver, char*);
+    HypreIntType int_param1_;
+    HypreIntType int_param2_;
     double double_param1_;
-    int *int_star_param_;
+    HypreIntType *int_star_param_;
     double *double_star_param_;
     char* char_star_param_;
 };

--- a/src/HypreDirectSolver.C
+++ b/src/HypreDirectSolver.C
@@ -1,6 +1,7 @@
 #ifdef NALU_USES_HYPRE
 
 #include "HypreDirectSolver.h"
+#include "XSDKHypreInterface.h"
 #include "NaluEnv.h"
 
 namespace sierra {
@@ -16,34 +17,34 @@ namespace {
 // <https://github.com/trilinos/xSDKTrilinos/blob/master/hypre/src/Ifpack2_Hypre.hpp>
 // for more details
 
-int Hypre_BoomerAMGCreate(MPI_Comm, HYPRE_Solver* solver)
+HypreIntType Hypre_BoomerAMGCreate(MPI_Comm, HYPRE_Solver* solver)
 { return HYPRE_BoomerAMGCreate(solver); }
 
-int Hypre_ParaSailsCreate(MPI_Comm comm, HYPRE_Solver* solver)
+HypreIntType Hypre_ParaSailsCreate(MPI_Comm comm, HYPRE_Solver* solver)
 { return HYPRE_ParaSailsCreate(comm, solver); }
 
-int Hypre_EuclidCreate(MPI_Comm comm, HYPRE_Solver* solver)
+HypreIntType Hypre_EuclidCreate(MPI_Comm comm, HYPRE_Solver* solver)
 { return HYPRE_EuclidCreate(comm, solver); }
 
-int Hypre_AMSCreate(MPI_Comm, HYPRE_Solver *solver)
+HypreIntType Hypre_AMSCreate(MPI_Comm, HYPRE_Solver *solver)
 { return HYPRE_AMSCreate(solver);}
 
-int Hypre_ParCSRHybridCreate(MPI_Comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRHybridCreate(MPI_Comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRHybridCreate(solver);}
 
-int Hypre_ParCSRPCGCreate(MPI_Comm comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRPCGCreate(MPI_Comm comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRPCGCreate(comm, solver);}
 
-int Hypre_ParCSRGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRGMRESCreate(comm, solver);}
 
-int Hypre_ParCSRFlexGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRFlexGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRFlexGMRESCreate(comm, solver);}
 
-int Hypre_ParCSRLGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRLGMRESCreate(MPI_Comm comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRLGMRESCreate(comm, solver);}
 
-int Hypre_ParCSRBiCGSTABCreate(MPI_Comm comm, HYPRE_Solver *solver)
+HypreIntType Hypre_ParCSRBiCGSTABCreate(MPI_Comm comm, HYPRE_Solver *solver)
 { return HYPRE_ParCSRBiCGSTABCreate(comm, solver);}
 }
 
@@ -84,8 +85,10 @@ HypreDirectSolver::solve(
   // Extract linear num. iterations and linear residual. Unlike the TPetra
   // interface, Hypre returns the relative residual norm and not the final
   // absolute residual.
-  solverNumItersPtr_(solver_, &numIterations);
+  HypreIntType numIters;
+  solverNumItersPtr_(solver_, &numIters);
   solverFinalResidualNormPtr_(solver_, &finalResidualNorm);
+  numIterations = numIters;
 
   return status;
 }

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -48,20 +48,7 @@ HypreLinearSystem::HypreLinearSystem(
     rowFilled_(0),
     rowStatus_(0),
     idBuffer_(0)
-{
-#ifndef HYPRE_BIGINT
-  // Make sure that HYPRE is compiled with 64-bit integer support when running
-  // O(~1B) linear systems.
-  uint64_t totalRows = (static_cast<uint64_t>(realm_.hypreNumNodes_) *
-                        static_cast<uint64_t>(numDof_));
-  uint64_t maxHypreSize = static_cast<uint64_t>(std::numeric_limits<HypreIntType>::max());
-
-  if (totalRows > maxHypreSize)
-    throw std::runtime_error(
-      "The linear system size is greater than what HYPRE is compiled for. "
-      "Please recompile with bigint support and link to Nalu");
-#endif
-}
+{}
 
 HypreLinearSystem::~HypreLinearSystem()
 {
@@ -78,6 +65,19 @@ HypreLinearSystem::beginLinearSystemConstruction()
 {
   if (inConstruction_) return;
   inConstruction_ = true;
+
+#ifndef HYPRE_BIGINT
+  // Make sure that HYPRE is compiled with 64-bit integer support when running
+  // O(~1B) linear systems.
+  uint64_t totalRows = (static_cast<uint64_t>(realm_.hypreNumNodes_) *
+                        static_cast<uint64_t>(numDof_));
+  uint64_t maxHypreSize = static_cast<uint64_t>(std::numeric_limits<HypreIntType>::max());
+
+  if (totalRows > maxHypreSize)
+    throw std::runtime_error(
+      "The linear system size is greater than what HYPRE is compiled for. "
+      "Please recompile with bigint support and link to Nalu");
+#endif
 
   const int rank = realm_.bulk_data().parallel_rank();
 


### PR DESCRIPTION
- Use HYPRE_Int type throughout to match datatypes used by HYPRE within Nalu's
  HYPRE interface. Add appropriate checks to ensure that the HYPRE library can
  support the size of linear systems required for problem sizes (`> O(~1
  billion)`).

- Update CMakeLists to check and warn users if HYPRE's 64-bit support is not
  enabled.

- Update HYPRE build documentation with additional instructions to build HYPRE
  with 64-bit integer support.