### PR TITLE
Optimization in sumInto, saves ~10% of assembly time

### DIFF
--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -42,6 +42,9 @@ typedef std::pair<stk::mesh::Entity, stk::mesh::Entity> Connection;
 typedef Kokkos::UnorderedMap<Connection,void> ConnectionSetKK;
 typedef std::vector< Connection > ConnectionVec;
 
+typedef typename LinSys::Vector::dual_view_type dual_view_type;
+typedef typename dual_view_type::t_host host_view_type;
+
   enum DOFStatus {
     DS_NotSet           = 0,
     DS_SkippedDOF       = 1 << 1,
@@ -187,6 +190,10 @@ private:
 
   Teuchos::RCP<LinSys::Matrix> ownedMatrix_;
   Teuchos::RCP<LinSys::Vector> ownedRhs_;
+  LinSys::Matrix::local_matrix_type ownedLocalMatrix_;
+  LinSys::Matrix::local_matrix_type globallyOwnedLocalMatrix_;
+  host_view_type ownedLocalRhs_;
+  host_view_type globallyOwnedLocalRhs_;
 
   Teuchos::RCP<LinSys::Matrix> globallyOwnedMatrix_;
   Teuchos::RCP<LinSys::Vector> globallyOwnedRhs_;


### PR DESCRIPTION
Store a reference to the local-matrix and local-rhs objects
instead of getting them during every call to sumInto. The
reference is refreshed during each call to finalizeLinearSystem
so that it isn't invalidated by mesh motion etc.