### PR TITLE
Move Teuchos timer summary to end of simulation

### DIFF
--- a/nalu.C
+++ b/nalu.C
@@ -32,6 +32,11 @@
 #include <iomanip>
 #include <stdexcept>
 
+// For Teuchos timer summary
+#include <Teuchos_Ptr.hpp>
+#include <Teuchos_DefaultMpiComm.hpp>
+#include <Teuchos_TimeMonitor.hpp>
+
 static std::string human_bytes_double(double bytes)
 {
   const double K = 1024;
@@ -179,6 +184,20 @@ int main( int argc, char ** argv )
   naluEnv.naluOutputP0() << "Timing for Simulation: nprocs= " << nprocs << std::endl;
   naluEnv.naluOutputP0() << "           main() --  " << " \tavg: " << g_sum/double(nprocs)
 			 << " \tmin: " << g_min << " \tmax: " << g_max << std::endl;
+
+  // Summarize any active Teuchos timers.
+  // TODO There should be an input deck option to allow toggling of summarizeLinearSolverTimers, and the default valueshould be "off"
+  bool summarizeLinearSolverTimers = true;
+  if (summarizeLinearSolverTimers) {
+    const bool alwaysWriteLocal    = false;
+    const bool writeGlobalStats    = true;
+    const bool displayUnusedTimers = false;
+    const std::string filter;
+    const bool ignoreZeroTimers    = true;
+
+    Teuchos::MpiComm<int> mpiComm(naluEnv.parallel_comm());
+    Teuchos::TimeMonitor::summarize(Teuchos::Ptr<Teuchos::MpiComm<int>>(&mpiComm), naluEnv.naluOutputP0(), alwaysWriteLocal, writeGlobalStats, displayUnusedTimers, Teuchos::Union, filter, ignoreZeroTimers);
+  }
 
   // output memory usage
   {

--- a/src/LinearSolver.C
+++ b/src/LinearSolver.C
@@ -138,8 +138,6 @@ void TpetraLinearSolver::setMueLu()
     else if (reusePreconditioner_) {
       MueLu::ReuseTpetraPreconditioner(matrix_, *mueluPreconditioner_);
     }
-    if (config->getSummarizeMueluTimer())
-      Teuchos::TimeMonitor::summarize(std::cout, false, true, false, Teuchos::Union);
   }
 
   problem_->setRightPrec(mueluPreconditioner_);


### PR DESCRIPTION
This commit moves Teuchos::TimeMonitor::summarize() from the
TpetraLinearSolver class to main(), i.e., the end of the Nalu simulation.

Previously, summarize was only available if MueLu was being used;
moreover, summarize was invoked at each call to TpetraLinearSolver::solve.
This resulted in a large amount of intermediate timer output.

Advantages:
  the summary prints only once
  timing information is available for any object that uses Teuchos timers,
    even when MueLu isn't being used.