### PR TITLE
Some cleanup in ScratchViews and AssembleElemSolverAlgorithm.

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -33,16 +33,16 @@ public:
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
-    const stk::topology &theTopo,
+    stk::mesh::EntityRank entityRank,
+    unsigned nodesPerEntity,
     bool interleaveMeViews = true);
   virtual ~AssembleElemSolverAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
 
-  // topo for this instance
-  stk::topology topo_;
-
   ElemDataRequests dataNeededByKernels_;
+  stk::mesh::EntityRank entityRank_;
+  unsigned nodesPerEntity_;
   int rhsSize_;
   const bool interleaveMEViews_;
 };

--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -145,7 +145,7 @@ void interleave_me_views(MasterElementViews<DoubleType>& dest,
 }
 
 inline
-void copy_and_interleave(const std::vector<ScratchViews<double>*>& data,
+void copy_and_interleave(ScratchViews<double>** data,
                          int simdElems,
                          ScratchViews<DoubleType>& simdData,
                          bool copyMEViews = true)

--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -145,7 +145,7 @@ void interleave_me_views(MasterElementViews<DoubleType>& dest,
 }
 
 inline
-void copy_and_interleave(ScratchViews<double>** data,
+void copy_and_interleave(std::unique_ptr<ScratchViews<double>>* data,
                          int simdElems,
                          ScratchViews<DoubleType>& simdData,
                          bool copyMEViews = true)

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -137,9 +137,9 @@ public:
   { return coordsFields_; }
 
   const FieldSet& get_fields() const { return fields; }  
-  MasterElement *get_cvfem_volume_me() {return meSCV_;}
-  MasterElement *get_cvfem_surface_me() {return meSCS_;}
-  MasterElement *get_fem_volume_me() {return meFEM_;}
+  MasterElement *get_cvfem_volume_me() const {return meSCV_;}
+  MasterElement *get_cvfem_surface_me() const {return meSCS_;}
+  MasterElement *get_fem_volume_me() const {return meFEM_;}
 
 private:
   std::array<std::set<ELEM_DATA_NEEDED>, MAX_COORDS_TYPES> dataEnums;

--- a/include/KernelBuilder.h
+++ b/include/KernelBuilder.h
@@ -150,7 +150,7 @@ namespace nalu{
     auto itc = solverAlgs.find(algName);
     bool createNewAlg = itc == solverAlgs.end();
     if (createNewAlg) {
-      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, topo, isNotNGP);
+      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, stk::topology::ELEMENT_RANK, topo.num_nodes(), isNotNGP);
       ThrowRequire(theSolverAlg != nullptr);
 
       NaluEnv::self().naluOutputP0() << "Created the following alg: " << algName << std::endl;

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -89,7 +89,7 @@ public:
 
   ScratchViews(const TeamHandleType& team,
                const stk::mesh::BulkData& bulkData,
-               stk::topology topo,
+               int nodesPerEntity,
                ElemDataRequests& dataNeeded);
 
   virtual ~ScratchViews() {
@@ -412,7 +412,7 @@ void MasterElementViews<T>::fill_master_element_views_new_me(
 template<typename T>
 ScratchViews<T>::ScratchViews(const TeamHandleType& team,
              const stk::mesh::BulkData& bulkData,
-             stk::topology topo,
+             int nodesPerEntity,
              ElemDataRequests& dataNeeded)
 {
   /* master elements are allowed to be null if they are not required */
@@ -421,14 +421,13 @@ ScratchViews<T>::ScratchViews(const TeamHandleType& team,
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
 
   int nDim = bulkData.mesh_meta_data().spatial_dimension();
-  int nodesPerElem = topo.num_nodes();
   int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
   int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
   int numFemIp = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
 
-  create_needed_field_views(team, dataNeeded, bulkData, nodesPerElem);
+  create_needed_field_views(team, dataNeeded, bulkData, nodesPerEntity);
 
-  create_needed_master_element_views(team, dataNeeded, nDim, nodesPerElem, numScsIp, numScvIp, numFemIp);
+  create_needed_master_element_views(team, dataNeeded, nDim, nodesPerEntity, numScsIp, numScvIp, numFemIp);
 }
 
 template<typename T>
@@ -507,15 +506,12 @@ int get_num_scalars_pre_req_data( ElemDataRequests& dataNeededBySuppAlgs, int nD
 
 void fill_pre_req_data(ElemDataRequests& dataNeeded,
                        const stk::mesh::BulkData& bulkData,
-                       stk::topology topo,
                        stk::mesh::Entity elem,
                        ScratchViews<double>& prereqData,
                        bool fillMEViews = true);
 
 void fill_master_element_views(ElemDataRequests& dataNeeded,
                                const stk::mesh::BulkData& bulkData,
-                               stk::topology topo,
-                               stk::mesh::Entity elem,
                                ScratchViews<DoubleType>& prereqData);
 
 template<typename T = double>

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -90,7 +90,7 @@ public:
   ScratchViews(const TeamHandleType& team,
                const stk::mesh::BulkData& bulkData,
                int nodesPerEntity,
-               ElemDataRequests& dataNeeded);
+               const ElemDataRequests& dataNeeded);
 
   virtual ~ScratchViews() {
     for(ViewHolder* vh : fieldViews) {
@@ -413,7 +413,7 @@ template<typename T>
 ScratchViews<T>::ScratchViews(const TeamHandleType& team,
              const stk::mesh::BulkData& bulkData,
              int nodesPerEntity,
-             ElemDataRequests& dataNeeded)
+             const ElemDataRequests& dataNeeded)
 {
   /* master elements are allowed to be null if they are not required */
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -120,7 +120,7 @@ struct SharedMemData {
      : simdPrereqData(team, bulk, nodesPerEntity, dataNeededByKernels)
     {
         for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-          prereqData[simdIndex] = new ScratchViews<double>(team, bulk, nodesPerEntity, dataNeededByKernels);
+          prereqData[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, bulk, nodesPerEntity, dataNeededByKernels));
         }
         simdrhs = get_shmem_view_1D<DoubleType>(team, rhsSize);
         simdlhs = get_shmem_view_2D<DoubleType>(team, rhsSize, rhsSize);
@@ -131,7 +131,7 @@ struct SharedMemData {
         sortPermutation = get_int_shmem_view_1D(team, rhsSize);
     }
 
-    ScratchViews<double>* prereqData[simdLen];
+    std::unique_ptr<ScratchViews<double>> prereqData[simdLen];
     ScratchViews<DoubleType> simdPrereqData;
     SharedMemView<DoubleType*> simdrhs;
     SharedMemView<DoubleType**> simdlhs;
@@ -217,10 +217,6 @@ AssembleElemSolverAlgorithm::execute()
                     smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
       }
     });
-
-    for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-       delete smdata.prereqData[simdIndex];
-    }
   });
 }
 

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -48,11 +48,13 @@ AssembleElemSolverAlgorithm::AssembleElemSolverAlgorithm(
   Realm &realm,
   stk::mesh::Part *part,
   EquationSystem *eqSystem,
-  const stk::topology &theTopo,
+  stk::mesh::EntityRank entityRank,
+  unsigned nodesPerEntity,
   bool interleaveMEViews)
   : SolverAlgorithm(realm, part, eqSystem),
-    topo_(theTopo),
-    rhsSize_(theTopo.num_nodes()*eqSystem->linsys_->numDof()),
+    entityRank_(entityRank),
+    nodesPerEntity_(nodesPerEntity),
+    rhsSize_(nodesPerEntity*eqSystem->linsys_->numDof()),
     interleaveMEViews_(interleaveMEViews)
 {
 }
@@ -64,6 +66,49 @@ void
 AssembleElemSolverAlgorithm::initialize_connectivity()
 {
   eqSystem_->linsys_->buildElemToNodeGraph(partVec_);
+}
+
+static constexpr int simdLen = stk::simd::ndoubles;
+
+int
+calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSize, int nDim,
+                                      ElemDataRequests& dataNeededByKernels)
+{
+    int bytes_per_thread = (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
+                           get_num_bytes_pre_req_data<double>(dataNeededByKernels, nDim);
+    bytes_per_thread *= 2*simdLen;
+    return bytes_per_thread;
+}
+
+template<typename T>
+void set_zero(T* values, unsigned length)
+{
+    for(unsigned i=0; i<length; ++i) {
+        values[i] = 0;
+    }
+}
+
+int get_next_num_elems_simd(int bktIndex, int bktLength)
+{
+  int numElems = simdLen;
+  if (bktLength - bktIndex*simdLen < simdLen) {
+    numElems = bktLength - bktIndex*simdLen;
+  }
+  if (numElems < 0 || numElems > simdLen) {
+    std::cout<<"ERROR, simdElems="<<numElems<<" shouldn't happen!!"<<std::endl;
+    numElems = 0;
+  }
+  return numElems;
+}
+
+size_t get_simd_bucket_length(size_t bktLength)
+{
+    size_t simdBucketLen = bktLength/simdLen;
+    const size_t remainder = bktLength%simdLen;
+    if (remainder > 0) {
+      simdBucketLen += 1;
+    }
+    return simdBucketLen;
 }
 
 //--------------------------------------------------------------------------
@@ -85,35 +130,31 @@ AssembleElemSolverAlgorithm::execute()
 
   // fixed size for this homogeneous algorithm
   const int bytes_per_team = 0;
-  // Bytes per thread =
-  //    scratch views size + LHS + RHS + node IDs + padding for alignment
-  int bytes_per_thread =
-    (rhsSize_ + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
-    get_num_bytes_pre_req_data<double>(dataNeededByKernels_, meta_data.spatial_dimension());
-  constexpr int simdLen = stk::simd::ndoubles;
-  bytes_per_thread *= 2*simdLen;
+  const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize_, scratchIdsSize,
+                                                                   meta_data.spatial_dimension(), dataNeededByKernels_);
 
   // define some common selectors
-  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
-    &stk::mesh::selectUnion(partVec_);
+  stk::mesh::Selector s_locally_owned_union =
+          meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
 
   stk::mesh::BucketVector const& elem_buckets =
-    realm_.get_buckets( stk::topology::ELEMENT_RANK, s_locally_owned_union );
+          realm_.get_buckets(entityRank_, s_locally_owned_union );
 
   auto team_exec = sierra::nalu::get_team_policy(elem_buckets.size(), bytes_per_team, bytes_per_thread);
   Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
   {
     stk::mesh::Bucket & b = *elem_buckets[team.league_rank()];
     
-    ThrowAssertMsg(b.topology() == topo_,"topo_ = "<<topo_<<", b.topology() = "<<b.topology());
+    ThrowAssertMsg(b.topology().num_nodes() == (unsigned)nodesPerEntity_,"AssembleElemSolverAlgorithm expected nodesPerEntity_ = "
+                   <<nodesPerEntity_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
 
     std::vector<sierra::nalu::ScratchViews<double>*> prereqData(simdLen, nullptr);
 
     for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-      prereqData[simdIndex] = new sierra::nalu::ScratchViews<double>(team, bulk_data, topo_, dataNeededByKernels_);
+      prereqData[simdIndex] = new sierra::nalu::ScratchViews<double>(team, bulk_data, nodesPerEntity_, dataNeededByKernels_);
     }
 
-    sierra::nalu::ScratchViews<DoubleType> simdPrereqData(team, bulk_data, topo_, dataNeededByKernels_);
+    sierra::nalu::ScratchViews<DoubleType> simdPrereqData(team, bulk_data, nodesPerEntity_, dataNeededByKernels_);
 
     SharedMemView<DoubleType*> simdrhs = get_shmem_view_1D<DoubleType>(team, rhsSize_);
     SharedMemView<DoubleType**> simdlhs = get_shmem_view_2D<DoubleType>(team, rhsSize_, rhsSize_);
@@ -123,60 +164,38 @@ AssembleElemSolverAlgorithm::execute()
     SharedMemView<int*> scratchIds = get_int_shmem_view_1D(team, scratchIdsSize);
     SharedMemView<int*> sortPermutation = get_int_shmem_view_1D(team, scratchIdsSize);
 
-    const stk::mesh::Entity* elemNodes[simdLen];
-    unsigned num_nodes = b.topology().num_nodes();
-    const stk::mesh::Bucket::size_type length   = b.size();
-    stk::mesh::Bucket::size_type simdBucketLen = length/simdLen;
-    const stk::mesh::Bucket::size_type remainder = length%simdLen;
-    if (remainder > 0) {
-      simdBucketLen += 1;
-    }
-
+    const stk::mesh::Entity* entityNodes[simdLen];
+    const size_t bucketLen   = b.size();
+    const size_t simdBucketLen = get_simd_bucket_length(bucketLen);
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex)
     {
-      int simdElems = simdLen;
-      if (length - bktIndex*simdLen < simdLen) {
-          simdElems = length - bktIndex*simdLen;
-      }
-      if (simdElems < 0 || simdElems > simdLen) {
-         std::cout<<"ERROR, simdElems="<<simdElems<<" shouldn't happen!!"<<std::endl;
-         simdElems = 0;
-      }
+      int numSimdElems = get_next_num_elems_simd(bktIndex, bucketLen);
 
-      stk::mesh::Entity element;
-      for(int simdElemIndex=0; simdElemIndex<simdElems; ++simdElemIndex) {
-        // get element
-        element = b[bktIndex*simdLen + simdElemIndex];
-        elemNodes[simdElemIndex] = bulk_data.begin_nodes(element);
-        fill_pre_req_data(dataNeededByKernels_, bulk_data, topo_, element,
+      for(int simdElemIndex=0; simdElemIndex<numSimdElems; ++simdElemIndex) {
+        stk::mesh::Entity element = b[bktIndex*simdLen + simdElemIndex];
+        entityNodes[simdElemIndex] = bulk_data.begin_nodes(element);
+        fill_pre_req_data(dataNeededByKernels_, bulk_data, element,
                           *prereqData[simdElemIndex], interleaveMEViews_);
       }
 
-      copy_and_interleave(prereqData, simdElems, simdPrereqData, interleaveMEViews_);
+      copy_and_interleave(prereqData, numSimdElems, simdPrereqData, interleaveMEViews_);
 
       if (!interleaveMEViews_) {
-        fill_master_element_views(dataNeededByKernels_, bulk_data, topo_, element, simdPrereqData);
+        fill_master_element_views(dataNeededByKernels_, bulk_data, simdPrereqData);
       }
 
-      for ( int i = 0; i < rhsSize_; ++i ) {
-        simdrhs(i) = 0.0;
-      }
-
-      for ( int i = 0; i < rhsSize_; ++i ) {
-        for ( int j = 0; j < rhsSize_; ++j ) {
-          simdlhs(i,j) = 0.0;
-        }
-      }
+      set_zero(simdrhs.data(), simdrhs.size());
+      set_zero(simdlhs.data(), simdlhs.size());
 
       // call supplemental; gathers happen inside the elem_execute method
       for ( size_t i = 0; i < activeKernelsSize; ++i )
         activeKernels_[i]->execute( simdlhs, simdrhs, simdPrereqData );
 
-      for(int simdElemIndex=0; simdElemIndex<simdElems; ++simdElemIndex) {
+      for(int simdElemIndex=0; simdElemIndex<numSimdElems; ++simdElemIndex) {
         extract_vector_lane(simdrhs, simdElemIndex, rhs);
         extract_vector_lane(simdlhs, simdElemIndex, lhs);
-        apply_coeff(num_nodes, elemNodes[simdElemIndex], scratchIds, sortPermutation, rhs, lhs, __FILE__);
+        apply_coeff(nodesPerEntity_, entityNodes[simdElemIndex], scratchIds, sortPermutation, rhs, lhs, __FILE__);
       }
     });
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -194,12 +194,11 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
 void fill_pre_req_data(
   ElemDataRequests& dataNeeded,
   const stk::mesh::BulkData& bulkData,
-  stk::topology topo,
   stk::mesh::Entity elem,
   ScratchViews<double>& prereqData,
   bool fillMEViews)
 {
-  int nodesPerElem = topo.num_nodes();
+  int nodesPerElem = bulkData.num_nodes(elem);
 
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
@@ -271,8 +270,6 @@ void fill_pre_req_data(
 void fill_master_element_views(
   ElemDataRequests& dataNeeded,
   const stk::mesh::BulkData& bulkData,
-  stk::topology topo,
-  stk::mesh::Entity elem,
   ScratchViews<DoubleType>& prereqData)
 {
     MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -134,12 +134,11 @@ public:
           stk::topology topo = bkt.topology();
           sierra::nalu::MasterElement* meSCS = dataNeededByKernels_.get_cvfem_surface_me();
 
-          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo, dataNeededByKernels_);
+          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo.num_nodes(), dataNeededByKernels_);
 
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
           {
-             fill_pre_req_data(dataNeededByKernels_, bulkData_, topo,
-                               bkt[jj], prereqData);
+             fill_pre_req_data(dataNeededByKernels_, bulkData_, bkt[jj], prereqData);
             
              for(SuppAlg* alg : suppAlgs_) {
                alg->elem_execute(topo, *meSCS, prereqData);

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -26,7 +26,7 @@ struct HelperObjects {
     realm.metaData_ = &bulk.mesh_meta_data();
     realm.bulkData_ = &bulk;
     eqSystem.linsys_ = linsys;
-    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo);
+    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo.rank(), topo.num_nodes());
   }
 
   ~HelperObjects()
@@ -63,7 +63,7 @@ struct HelperObjectsNewME {
     realm.metaData_ = &bulk.mesh_meta_data();
     realm.bulkData_ = &bulk;
     eqSystem.linsys_ = linsys;
-    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo, false);
+    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, stk::topology::ELEMENT_RANK, topo.num_nodes(), false);
   }
 
   ~HelperObjectsNewME()

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -109,11 +109,10 @@ public:
         auto& b = *buckets[team.league_rank()];
         const auto length = b.size();
 
-        std::vector<sierra::nalu::ScratchViews<double>*> prereqData(simdLen, nullptr);
+        std::vector<std::unique_ptr<sierra::nalu::ScratchViews<double> > > prereqData(simdLen);
 
         for (int simdIndex=0; simdIndex < simdLen; ++simdIndex) {
-          prereqData[simdIndex] = new sierra::nalu::ScratchViews<double>(
-            team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_);
+          prereqData[simdIndex] = std::unique_ptr<sierra::nalu::ScratchViews<double> >(new sierra::nalu::ScratchViews<double>(team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_));
         }
         sierra::nalu::ScratchViews<DoubleType> simdPrereqData(
           team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_);
@@ -142,10 +141,6 @@ public:
 
             func(simdPrereqData, meSCS_, meSCV_);
           });
-
-          for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-              delete prereqData[simdIndex];
-          }
       });
   }
 

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -113,10 +113,10 @@ public:
 
         for (int simdIndex=0; simdIndex < simdLen; ++simdIndex) {
           prereqData[simdIndex] = new sierra::nalu::ScratchViews<double>(
-            team, bulk_, AlgTraits::topo_, dataNeeded_);
+            team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_);
         }
         sierra::nalu::ScratchViews<DoubleType> simdPrereqData(
-          team, bulk_, AlgTraits::topo_, dataNeeded_);
+          team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_);
 
         const stk::mesh::Entity* elemNodes[simdLen];
         stk::mesh::Bucket::size_type simdBucketLen = length / simdLen;
@@ -133,14 +133,12 @@ public:
             for (int simdIndex=0; simdIndex < simdElems; ++simdIndex) {
               element = b[bktIndex*simdLen + simdIndex];
               elemNodes[simdIndex] = bulk_.begin_nodes(element);
-              fill_pre_req_data(dataNeeded_, bulk_, AlgTraits::topo_, element,
-                                *prereqData[simdIndex], alsoProcessMEViews);
+              fill_pre_req_data(dataNeeded_, bulk_, element, *prereqData[simdIndex], alsoProcessMEViews);
             }
 
             copy_and_interleave(prereqData, simdElems, simdPrereqData,
                                 alsoProcessMEViews);
-            fill_master_element_views(dataNeeded_, bulk_, AlgTraits::topo_,
-                                      element, simdPrereqData);
+            fill_master_element_views(dataNeeded_, bulk_, simdPrereqData);
 
             func(simdPrereqData, meSCS_, meSCV_);
           });

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -136,7 +136,7 @@ public:
               fill_pre_req_data(dataNeeded_, bulk_, element, *prereqData[simdIndex], alsoProcessMEViews);
             }
 
-            copy_and_interleave(prereqData, simdElems, simdPrereqData,
+            copy_and_interleave(prereqData.data(), simdElems, simdPrereqData,
                                 alsoProcessMEViews);
             fill_master_element_views(dataNeeded_, bulk_, simdPrereqData);
 

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -142,6 +142,10 @@ public:
 
             func(simdPrereqData, meSCS_, meSCV_);
           });
+
+          for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
+              delete prereqData[simdIndex];
+          }
       });
   }
 

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -124,15 +124,14 @@ public:
           const stk::mesh::Bucket& bkt = *elemBuckets[team.league_rank()];
           stk::topology topo = bkt.topology();
 
-          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo, dataNeededByKernels_);
+          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo.num_nodes(), dataNeededByKernels_);
 
           // See get_num_bytes_pre_req_data for padding
           EXPECT_EQ(static_cast<unsigned>(bytes_per_thread), prereqData.total_bytes() + 8 * sizeof(double));
 
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
           {
-             fill_pre_req_data(dataNeededByKernels_, bulkData_, topo,
-                               bkt[jj], prereqData);
+             fill_pre_req_data(dataNeededByKernels_, bulkData_, bkt[jj], prereqData);
             
              for(SuppAlg* alg : suppAlgs_) {
                alg->elem_execute(topo, prereqData);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -587,13 +587,12 @@ void calc_mass_flow_rate_scs(
       EXPECT_EQ(b.topology(), topo);
 
       sierra::nalu::ScratchViews<double> preReqData(
-        team, bulk, topo, dataNeeded);
+        team, bulk, topo.num_nodes(), dataNeeded);
 
       Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
           stk::mesh::Entity element = b[k];
-          sierra::nalu::fill_pre_req_data(
-            dataNeeded, bulk, topo, element, preReqData);
+          sierra::nalu::fill_pre_req_data(dataNeeded, bulk, element, preReqData);
 
           std::vector<double> rhoU(ndim);
           std::vector<double> v_shape_function(
@@ -668,13 +667,12 @@ void calc_projected_nodal_gradient_interior(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo, dataNeeded);
+      team, bulk, topo.num_nodes(), dataNeeded);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
       stk::mesh::Entity element = b[k];
-      sierra::nalu::fill_pre_req_data(
-        dataNeeded, bulk, topo, element, preReqData);
+      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, element, preReqData);
 
       meSCS->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -746,13 +744,12 @@ void calc_projected_nodal_gradient_interior(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo, dataNeeded);
+      team, bulk, topo.num_nodes(), dataNeeded);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
       stk::mesh::Entity element = b[k];
-      sierra::nalu::fill_pre_req_data(
-        dataNeeded, bulk, topo, element, preReqData);
+      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, element, preReqData);
 
       meSCS->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -826,13 +823,12 @@ void calc_projected_nodal_gradient_boundary(
 
     EXPECT_EQ(b.topology(), topo);
 
-    sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo, dataNeeded);
+    sierra::nalu::ScratchViews<double> preReqData(team, bulk, topo.num_nodes(), dataNeeded);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
       stk::mesh::Entity face = b[k];
-      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, topo, face, preReqData);
+      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, face, preReqData);
 
       meBC->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -900,12 +896,12 @@ void calc_projected_nodal_gradient_boundary(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo, dataNeeded);
+      team, bulk, topo.num_nodes(), dataNeeded);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
       stk::mesh::Entity face = b[k];
-      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, topo, face, preReqData);
+      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, face, preReqData);
 
       meBC->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -969,12 +965,12 @@ void calc_dual_nodal_volume(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo, dataNeeded);
+      team, bulk, topo.num_nodes(), dataNeeded);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
       stk::mesh::Entity element = b[k];
-      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, topo, element, preReqData);
+      sierra::nalu::fill_pre_req_data(dataNeeded, bulk, element, preReqData);
 
       auto v_scv_vol = preReqData.get_me_views(sierra::nalu::CURRENT_COORDINATES).scv_volume;
       const stk::mesh::Entity* node_rels = preReqData.elemNodes;


### PR DESCRIPTION
Removed topo argument from ScratchViews and related functions,
and from AssembleElemSolverAlgorithm. Also generalized
entity-rank and nodes-per-entity in AssembleElemSolverAlgorithm.

There's still more to do, but this is a good start.
