### PR TITLE
Unit-test to prototype a face-element algorithm.

### DIFF
--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -22,7 +22,9 @@ namespace nalu{
 class MasterElement;
 
 enum ELEM_DATA_NEEDED {
-  SCS_AREAV = 0,
+  FC_AREAV = 0,
+  SCS_AREAV,
+  SCS_FACE_GRAD_OP,
   SCS_GRAD_OP,
   SCS_SHIFTED_GRAD_OP,
   SCS_GIJ,
@@ -70,7 +72,7 @@ public:
   ElemDataRequests()
     : dataEnums(),
       coordsFields_(),
-    fields(), meSCS_(NULL), meSCV_(NULL), meFEM_(NULL)
+    fields(), meFC_(nullptr), meSCS_(nullptr), meSCV_(nullptr), meFEM_(nullptr)
   {
   }
 
@@ -92,14 +94,23 @@ public:
 
   void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
 
+  void add_face_field(const stk::mesh::FieldBase& field, unsigned scalarsPerFace);
+  void add_ip_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement);
   void add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement);
 
+  void add_face_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
+  void add_ip_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
   void add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2);
 
   void add_coordinates_field(
     const stk::mesh::FieldBase& field,
     unsigned scalarsPerNode,
     COORDS_TYPES cType);
+
+  void add_cvfem_face_me(MasterElement *meFC)
+  {
+    meFC_ = meFC;
+  }
 
   void add_cvfem_volume_me(MasterElement *meSCV)
   {
@@ -137,6 +148,7 @@ public:
   { return coordsFields_; }
 
   const FieldSet& get_fields() const { return fields; }  
+  MasterElement *get_cvfem_face_me() const {return meFC_;}
   MasterElement *get_cvfem_volume_me() const {return meSCV_;}
   MasterElement *get_cvfem_surface_me() const {return meSCS_;}
   MasterElement *get_fem_volume_me() const {return meFEM_;}
@@ -145,6 +157,7 @@ private:
   std::array<std::set<ELEM_DATA_NEEDED>, MAX_COORDS_TYPES> dataEnums;
   std::map<COORDS_TYPES, const stk::mesh::FieldBase*> coordsFields_;
   FieldSet fields;
+  MasterElement *meFC_;
   MasterElement *meSCS_;
   MasterElement *meSCV_;
   MasterElement *meFEM_;

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -48,31 +48,39 @@ public:
   int create_master_element_views(
     const TeamHandleType& team,
     const std::set<ELEM_DATA_NEEDED>& dataEnums,
-    int nDim, int nodesPerElem,
-    int numScsIp, int numScvIp, int numFemIp);
+    int nDim, int nodesPerFace, int nodesPerElem,
+    int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
 
   void fill_master_element_views(
     const std::set<ELEM_DATA_NEEDED>& dataEnums,
     SharedMemView<double**>* coordsView,
+    MasterElement* meFC,
     MasterElement* meSCS,
     MasterElement* meSCV,
-    MasterElement* meFEM);
+    MasterElement* meFEM,
+    int faceOrdinal = -1);
 
   void fill_master_element_views_new_me(
     const std::set<ELEM_DATA_NEEDED>& dataEnums,
     SharedMemView<DoubleType**>* coordsView,
+    MasterElement* meFC,
     MasterElement* meSCS,
     MasterElement* meSCV,
-    MasterElement* meFEM);
+    MasterElement* meFEM,
+    int faceOrdinal = -1);
 
+  SharedMemView<T**> fc_areav;
   SharedMemView<T**> scs_areav;
+  SharedMemView<T***> dndx_fc_scs;
   SharedMemView<T***> dndx;
   SharedMemView<T***> dndx_shifted;
   SharedMemView<T***> dndx_scv;
   SharedMemView<T***> dndx_fem;
+  SharedMemView<T***> deriv_fc_scs;
   SharedMemView<T***> deriv;
   SharedMemView<T***> deriv_scv;
   SharedMemView<T***> deriv_fem;
+  SharedMemView<T*> det_j_fc_scs;
   SharedMemView<T*> det_j;
   SharedMemView<T*> det_j_scv;
   SharedMemView<T*> det_j_fem;
@@ -132,8 +140,8 @@ private:
 
   void create_needed_master_element_views(const TeamHandleType& team,
                                           const ElemDataRequests& dataNeeded,
-                                          int nDim, int nodesPerElem,
-                                          int numScsIp, int numScvIp, int numFemIp);
+                                          int nDim, int nodesPerFace, int nodesPerElem,
+                                          int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
 
   std::vector<ViewHolder*> fieldViews;
   MasterElementViews<T> meViews[MAX_COORDS_TYPES];
@@ -177,16 +185,28 @@ template<typename T>
 int MasterElementViews<T>::create_master_element_views(
   const TeamHandleType& team,
   const std::set<ELEM_DATA_NEEDED>& dataEnums,
-  int nDim, int nodesPerElem,
-  int numScsIp, int numScvIp, int numFemIp)
+  int nDim, int nodesPerFace, int nodesPerElem,
+  int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
 {
   int numScalars = 0;
-  bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false;
-  bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false;
+  bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
+  bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
   bool femGradOp = false; bool femShiftedGradOp = false;
   for(ELEM_DATA_NEEDED data : dataEnums) {
     switch(data)
     {
+      case FC_AREAV:
+          ThrowRequireMsg(numFaceIp > 0, "ERROR, meFC must be non-null if FC_AREAV is requested.");
+          fc_areav = get_shmem_view_2D<T>(team, numFaceIp, nDim);
+          numScalars += numFaceIp * nDim;
+          break;
+      case SCS_FACE_GRAD_OP:
+          ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_FACE_GRAD_OP is requested.");
+          dndx_fc_scs = get_shmem_view_3D<T>(team, numFaceIp, nodesPerElem, nDim);
+          numScalars += nodesPerElem * numFaceIp * nDim;
+          needDerivFC = true;
+          needDetjFC = true;
+          break;
       case SCS_AREAV:
          ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
          scs_areav = get_shmem_view_2D<T>(team, numScsIp, nDim);
@@ -253,6 +273,11 @@ int MasterElementViews<T>::create_master_element_views(
     }
   }
 
+  if (needDerivFC) {
+    deriv_fc_scs = get_shmem_view_3D<T>(team, numFaceIp,nodesPerElem,nDim);
+    numScalars += numFaceIp * nodesPerElem * nDim;
+  }
+
   if (needDeriv) {
     deriv = get_shmem_view_3D<T>(team, numScsIp,nodesPerElem,nDim);
     numScalars += numScsIp * nodesPerElem * nDim;
@@ -266,6 +291,11 @@ int MasterElementViews<T>::create_master_element_views(
   if (needDerivFem) {
     deriv_fem = get_shmem_view_3D<T>(team, numFemIp,nodesPerElem,nDim);
     numScalars += numFemIp * nodesPerElem * nDim;
+  }
+
+  if (needDetjFC) {
+    det_j_fc_scs = get_shmem_view_1D<T>(team, numFaceIp);
+    numScalars += numFaceIp;
   }
 
   if (needDetj) {
@@ -294,9 +324,11 @@ template<typename T>
 void MasterElementViews<T>::fill_master_element_views(
   const std::set<ELEM_DATA_NEEDED>& dataEnums,
   SharedMemView<double**>* coordsView,
+  MasterElement* meFC,
   MasterElement* meSCS,
   MasterElement* meSCV,
-  MasterElement* meFEM)
+  MasterElement* meFEM,
+  int faceOrdinal)
 {
   // Guard against calling MasterElement methods on SIMD data structures
   static_assert(std::is_same<T, double>::value,
@@ -306,48 +338,59 @@ void MasterElementViews<T>::fill_master_element_views(
   for(ELEM_DATA_NEEDED data : dataEnums) {
     switch(data)
     {
+      case FC_AREAV:
+        ThrowRequireMsg(meFC != nullptr, "ERROR, meFC needs to be non-null if FC_AREAV is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FC_AREAV requested.");
+        meFC->determinant(1, &((*coordsView)(0,0)), &fc_areav(0,0), &error);
+        break;
       case SCS_AREAV:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
-         meSCS->determinant(1, &((*coordsView)(0,0)), &scs_areav(0,0), &error);
-         break;
+        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+        meSCS->determinant(1, &((*coordsView)(0, 0)), &scs_areav(0, 0), &error);
+        break;
+      case SCS_FACE_GRAD_OP:
+        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+        meSCS->face_grad_op(1, faceOrdinal, &((*coordsView)(0,0)), &dndx_fc_scs(0,0,0), &deriv_fc_scs(0,0,0), &det_j_fc_scs(0));
+        break;
       case SCS_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
-         meSCS->grad_op(1, &((*coordsView)(0,0)), &dndx(0,0,0), &deriv(0,0,0), &det_j(0), &error);
-         break;
+        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+        meSCS->grad_op(1, &((*coordsView)(0, 0)), &dndx(0, 0, 0), &deriv(0, 0, 0), &det_j(0), &error);
+        break;
       case SCS_SHIFTED_GRAD_OP:
         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
-        meSCS->shifted_grad_op(1, &((*coordsView)(0,0)), &dndx_shifted(0,0,0), &deriv(0,0,0), &det_j(0), &error);
+        meSCS->shifted_grad_op(1, &((*coordsView)(0, 0)), &dndx_shifted(0, 0, 0), &deriv(0, 0, 0), &det_j(0), &error);
         break;
       case SCS_GIJ:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
-         meSCS->gij(&((*coordsView)(0,0)), &gijUpper(0,0,0), &gijLower(0,0,0), &deriv(0,0,0));
-         break;
+        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
+        meSCS->gij(&((*coordsView)(0, 0)), &gijUpper(0, 0, 0), &gijLower(0, 0, 0), &deriv(0, 0, 0));
+        break;
       case SCV_VOLUME:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
-         meSCV->determinant(1, &((*coordsView)(0,0)), &scv_volume(0), &error);
-         break;
+        ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
+        meSCV->determinant(1, &((*coordsView)(0, 0)), &scv_volume(0), &error);
+        break;
       case SCV_GRAD_OP:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_GRAD_OP requested.");
-         meSCV->grad_op(1, &((*coordsView)(0,0)), &dndx_scv(0,0,0), &deriv_scv(0,0,0), &det_j_scv(0), &error);
-         break;
+        ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_GRAD_OP is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_GRAD_OP requested.");
+        meSCV->grad_op(1, &((*coordsView)(0, 0)), &dndx_scv(0, 0, 0), &deriv_scv(0, 0, 0), &det_j_scv(0), &error);
+        break;
       case FEM_GRAD_OP:
         ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
-        meFEM->grad_op(1, &((*coordsView)(0,0)), &dndx_fem(0,0,0), &deriv_fem(0,0,0), &det_j_fem(0), &error);
+        meFEM->grad_op(1, &((*coordsView)(0, 0)), &dndx_fem(0, 0, 0), &deriv_fem(0, 0, 0), &det_j_fem(0), &error);
         break;
       case FEM_SHIFTED_GRAD_OP:
         ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_SHIFTED_GRAD_OP is requested.");
         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
-        meFEM->shifted_grad_op(1, &((*coordsView)(0,0)), &dndx_fem(0,0,0), &deriv_fem(0,0,0), &det_j_fem(0), &error);
+        meFEM->shifted_grad_op(1, &((*coordsView)(0, 0)), &dndx_fem(0, 0, 0), &deriv_fem(0, 0, 0), &det_j_fem(0), &error);
         break;
 
-      default: break;
+      default:
+        break;
     }
   }
 }
@@ -356,18 +399,26 @@ template<typename T>
 void MasterElementViews<T>::fill_master_element_views_new_me(
   const std::set<ELEM_DATA_NEEDED>& dataEnums,
   SharedMemView<DoubleType**>* coordsView,
+  MasterElement* meFC,
   MasterElement* meSCS,
   MasterElement* meSCV,
-  MasterElement* meFEM)
+  MasterElement* meFEM,
+  int faceOrdinal)
 {
   for(ELEM_DATA_NEEDED data : dataEnums) {
     switch(data)
     {
+      case FC_AREAV:
+        ThrowRequireMsg(false, "FC_AREAV not implemented yet.");
+        break;
       case SCS_AREAV:
          ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
          ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
          meSCS->determinant(*coordsView, scs_areav);
          break;
+      case SCS_FACE_GRAD_OP:
+        ThrowRequireMsg(false, "SCS_FACE_GRAD_OP not implemented yet.");
+       break;
       case SCS_GRAD_OP:
          ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
          ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
@@ -416,18 +467,25 @@ ScratchViews<T>::ScratchViews(const TeamHandleType& team,
              const ElemDataRequests& dataNeeded)
 {
   /* master elements are allowed to be null if they are not required */
+  MasterElement *meFC = dataNeeded.get_cvfem_face_me();
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
 
   int nDim = bulkData.mesh_meta_data().spatial_dimension();
+  int nodesPerFace = meFC != nullptr ? meFC->nodesPerElement_ : 0;
+  int nodesPerElem = meSCS != nullptr
+          ? meSCS->nodesPerElement_ : meSCV != nullptr
+          ? meSCV->nodesPerElement_ : meFEM != nullptr
+          ? meFEM->nodesPerElement_ : 0;
+  int numFaceIp= meFC  != nullptr ? meFC->numIntPoints_  : 0;
   int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
   int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
   int numFemIp = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
 
   create_needed_field_views(team, dataNeeded, bulkData, nodesPerEntity);
 
-  create_needed_master_element_views(team, dataNeeded, nDim, nodesPerEntity, numScsIp, numScvIp, numFemIp);
+  create_needed_master_element_views(team, dataNeeded, nDim, nodesPerFace, nodesPerElem, numFaceIp, numScsIp, numScvIp, numFemIp);
 }
 
 template<typename T>
@@ -486,8 +544,8 @@ void ScratchViews<T>::create_needed_field_views(const TeamHandleType& team,
 template<typename T>
 void ScratchViews<T>::create_needed_master_element_views(const TeamHandleType& team,
                                         const ElemDataRequests& dataNeeded,
-                                        int nDim, int nodesPerElem,
-                                        int numScsIp, int numScvIp, int numFemIp)
+                                        int nDim, int nodesPerFace, int nodesPerElem,
+                                        int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
 {
   int numScalars = 0;
 
@@ -496,7 +554,7 @@ void ScratchViews<T>::create_needed_master_element_views(const TeamHandleType& t
     hasCoordField[it->first] = true;
     numScalars += meViews[it->first].create_master_element_views(
       team, dataNeeded.get_data_enums(it->first),
-      nDim, nodesPerElem, numScsIp, numScvIp, numFemIp);
+      nDim, nodesPerFace, nodesPerElem, numFaceIp, numScsIp, numScvIp, numFemIp);
   }
 
   num_bytes_required += numScalars * sizeof(T);
@@ -512,7 +570,8 @@ void fill_pre_req_data(ElemDataRequests& dataNeeded,
 
 void fill_master_element_views(ElemDataRequests& dataNeeded,
                                const stk::mesh::BulkData& bulkData,
-                               ScratchViews<DoubleType>& prereqData);
+                               ScratchViews<DoubleType>& prereqData,
+                               int faceOrdinal = -1);
 
 template<typename T = double>
 int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -58,7 +58,7 @@ public:
     MasterElement* meSCS,
     MasterElement* meSCV,
     MasterElement* meFEM,
-    int faceOrdinal = -1);
+    const int* faceOrdinals = nullptr);
 
   void fill_master_element_views_new_me(
     const std::set<ELEM_DATA_NEEDED>& dataEnums,
@@ -67,7 +67,7 @@ public:
     MasterElement* meSCS,
     MasterElement* meSCV,
     MasterElement* meFEM,
-    int faceOrdinal = -1);
+    const int* faceOrdinals = nullptr);
 
   SharedMemView<T**> fc_areav;
   SharedMemView<T**> scs_areav;
@@ -328,7 +328,7 @@ void MasterElementViews<T>::fill_master_element_views(
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement* meFEM,
-  int faceOrdinal)
+  const int* faceOrdinals)
 {
   // Guard against calling MasterElement methods on SIMD data structures
   static_assert(std::is_same<T, double>::value,
@@ -351,7 +351,8 @@ void MasterElementViews<T>::fill_master_element_views(
       case SCS_FACE_GRAD_OP:
         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
-        meSCS->face_grad_op(1, faceOrdinal, &((*coordsView)(0,0)), &dndx_fc_scs(0,0,0), &deriv_fc_scs(0,0,0), &det_j_fc_scs(0));
+        //faceOrdinals is an array of length stk::simd::ndoubles. For non-kokkos master-elem, just pick off first one:
+        meSCS->face_grad_op(1, faceOrdinals[0], &((*coordsView)(0,0)), &dndx_fc_scs(0,0,0), &deriv_fc_scs(0,0,0), &det_j_fc_scs(0));
         break;
       case SCS_GRAD_OP:
         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
@@ -403,7 +404,7 @@ void MasterElementViews<T>::fill_master_element_views_new_me(
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement* meFEM,
-  int faceOrdinal)
+  const int* faceOrdinals)
 {
   for(ELEM_DATA_NEEDED data : dataEnums) {
     switch(data)
@@ -571,7 +572,7 @@ void fill_pre_req_data(ElemDataRequests& dataNeeded,
 void fill_master_element_views(ElemDataRequests& dataNeeded,
                                const stk::mesh::BulkData& bulkData,
                                ScratchViews<DoubleType>& prereqData,
-                               int faceOrdinal = -1);
+                               const int* faceOrdinals = nullptr);
 
 template<typename T = double>
 int get_num_bytes_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)

--- a/src/ElemDataRequests.C
+++ b/src/ElemDataRequests.C
@@ -38,32 +38,58 @@ void ElemDataRequests::add_gathered_nodal_field(const stk::mesh::FieldBase& fiel
   }
 }
 
-void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
+void ElemDataRequests::add_ip_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
 {
-  ThrowRequireMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
-
   FieldInfo fieldInfo(&field, scalarsPerElement);
   FieldSet::iterator iter = fields.find(fieldInfo);
   if (iter == fields.end()) {
     fields.insert(fieldInfo);
   }
   else {
-    ThrowRequireMsg(iter->scalarsDim1 == scalarsPerElement, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with scalarsPerElement=="<<scalarsPerElement<<", but previously requested with scalarsPerElement=="<<iter->scalarsDim1);
+    ThrowRequireMsg(iter->scalarsDim1 == scalarsPerElement, "ElemDataRequests ERROR, ip-field "<<field.name()<<" requested with scalarsPerElement=="<<scalarsPerElement<<", but previously requested with scalarsPerElement=="<<iter->scalarsDim1);
   }
 }
 
-void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+void ElemDataRequests::add_face_field(const stk::mesh::FieldBase& field, unsigned scalarsPerFace)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::FACE_RANK || field.entity_rank()==stk::topology::EDGE_RANK,
+    "ElemDataRequests ERROR, add_face_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+  add_ip_field(field, scalarsPerFace);
+}
+
+void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned scalarsPerElement)
 {
   ThrowRequireMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
 
+  add_ip_field(field, scalarsPerElement);
+}
+
+void ElemDataRequests::add_ip_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+{
   FieldInfo fieldInfo(&field, tensorDim1, tensorDim2);
   FieldSet::iterator iter = fields.find(fieldInfo);
   if (iter == fields.end()) {
     fields.insert(fieldInfo);
   }
   else {
-    ThrowRequireMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2, "ElemDataRequests ERROR, element-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
+    ThrowRequireMsg(iter->scalarsDim1 == tensorDim1 && iter->scalarsDim2 == tensorDim2,
+      "ElemDataRequests ERROR, ip-field "<<field.name()<<" requested with tensorDim1=="<<tensorDim1<<",tensorDim2=="<<tensorDim2<<", but previously requested with tensorDim1=="<<iter->scalarsDim1<<",tensorDim2=="<<iter->scalarsDim2);
   }
+}
+
+void ElemDataRequests::add_face_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::FACE_RANK || field.entity_rank()==stk::topology::EDGE_RANK,"ElemDataRequests ERROR, add_face_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+  add_ip_field(field, tensorDim1, tensorDim2);
+}
+
+void ElemDataRequests::add_element_field(const stk::mesh::FieldBase& field, unsigned tensorDim1, unsigned tensorDim2)
+{
+  ThrowRequireMsg(field.entity_rank()==stk::topology::ELEM_RANK,"ElemDataRequests ERROR, add_element_field called with field "<<field.name()<<" which has entity-rank=="<<field.entity_rank()<<" but is expected to have rank==ELEM_RANK");
+
+  add_ip_field(field, tensorDim1, tensorDim2);
 }
 
 void ElemDataRequests::add_coordinates_field(

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -290,7 +290,7 @@ void fill_master_element_views(
   ElemDataRequests& dataNeeded,
   const stk::mesh::BulkData& bulkData,
   ScratchViews<DoubleType>& prereqData,
-  int faceOrdinal)
+  const int* faceOrdinals)
 {
     MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
     MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
@@ -306,7 +306,7 @@ void fill_master_element_views(
       SharedMemView<DoubleType**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
       auto& meData = prereqData.get_me_views(cType);
   
-      meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM, faceOrdinal);
+      meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM, faceOrdinals);
     }
 }
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -88,15 +88,18 @@ void gather_elem_node_field(const stk::mesh::FieldBase& field,
 int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDim)
 {
   /* master elements are allowed to be null if they are not required */
+  MasterElement *meFC  = dataNeededBySuppAlgs.get_cvfem_face_me();
   MasterElement *meSCS = dataNeededBySuppAlgs.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeededBySuppAlgs.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeededBySuppAlgs.get_fem_volume_me();
   
   const int nodesPerElem = meSCS != nullptr ? meSCS->nodesPerElement_ 
     : meSCV != nullptr ? meSCV->nodesPerElement_ 
-    : meFEM != nullptr ? meFEM->nodesPerElement_ 
+    : meFEM != nullptr ? meFEM->nodesPerElement_
+    : meFC  != nullptr ? meFC->nodesPerElement_
     : 0;
 
+  const int numFaceIp = meFC != nullptr ? meFC->numIntPoints_ : 0;
   const int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
   const int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
   const int numFemIp = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
@@ -117,66 +120,81 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     }
     numScalars += entitiesPerElem*scalarsPerEntity;
   }
-  
+
   for (auto it = dataNeededBySuppAlgs.get_coordinates_map().begin();
        it != dataNeededBySuppAlgs.get_coordinates_map().end(); ++it)
   {
     const std::set<ELEM_DATA_NEEDED>& dataEnums =
       dataNeededBySuppAlgs.get_data_enums(it->first);
-    int dndxLength = 0, gUpperLength = 0, gLowerLength = 0;
+    int dndxLength = 0, dndxLengthFC = 0, gUpperLength = 0, gLowerLength = 0;
 
     // Updated logic for data sharing of deriv and det_j
-    bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false;
-    bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false;
+    bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
+    bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
 
     for(ELEM_DATA_NEEDED data : dataEnums) {
       switch(data)
       {
-      case SCS_AREAV: 
-        numScalars += nDim * numScsIp;
-        break;
-      case SCS_GRAD_OP:
-      case SCS_SHIFTED_GRAD_OP:
-        dndxLength = nodesPerElem*numScsIp*nDim;
-        needDeriv = true;
-        needDetj = true;
-        numScalars += dndxLength;
-        break;
-      case SCV_VOLUME: 
-        numScalars += numScvIp;
-        break;
-      case SCV_GRAD_OP:
-        dndxLength = nodesPerElem*numScvIp*nDim;
-        needDerivScv = true;
-        needDetjScv = true;
-        numScalars += dndxLength;
-        break;
-      case SCS_GIJ: 
-        gUpperLength = nDim*nDim*numScsIp;
-        gLowerLength = nDim*nDim*numScsIp;
-        needDeriv = true;
-        numScalars += (gUpperLength + gLowerLength );
-        break;
-      case FEM_GRAD_OP:
-      case FEM_SHIFTED_GRAD_OP:
-        dndxLength = nodesPerElem*numFemIp*nDim;
-        needDerivFem = true;
-        needDetjFem = true;
-        numScalars += dndxLength;
-        break;
-      default: break;
+        case FC_AREAV:
+          numScalars += nDim * numFaceIp;
+          break;
+        case SCS_AREAV:
+          numScalars += nDim * numScsIp;
+          break;
+        case SCS_FACE_GRAD_OP:
+          dndxLengthFC = nodesPerElem*numFaceIp*nDim;
+          needDerivFC = true;
+          needDetjFC = true;
+          numScalars += dndxLengthFC;
+          break;
+        case SCS_GRAD_OP:
+        case SCS_SHIFTED_GRAD_OP:
+          dndxLength = nodesPerElem*numScsIp*nDim;
+          needDeriv = true;
+          needDetj = true;
+          numScalars += dndxLength;
+          break;
+        case SCV_VOLUME:
+          numScalars += numScvIp;
+          break;
+        case SCV_GRAD_OP:
+          dndxLength = nodesPerElem*numScvIp*nDim;
+          needDerivScv = true;
+          needDetjScv = true;
+          numScalars += dndxLength;
+          break;
+        case SCS_GIJ:
+          gUpperLength = nDim*nDim*numScsIp;
+          gLowerLength = nDim*nDim*numScsIp;
+          needDeriv = true;
+          numScalars += (gUpperLength + gLowerLength );
+          break;
+        case FEM_GRAD_OP:
+        case FEM_SHIFTED_GRAD_OP:
+          dndxLength = nodesPerElem*numFemIp*nDim;
+          needDerivFem = true;
+          needDetjFem = true;
+          numScalars += dndxLength;
+          break;
+        default: break;
       }
     }
-      
+
+    if (needDerivFC)
+      numScalars += nodesPerElem*numFaceIp*nDim;
+
     if (needDeriv)
       numScalars += nodesPerElem*numScsIp*nDim;
-    
+
     if (needDerivScv)
       numScalars += nodesPerElem*numScvIp*nDim;
     
     if (needDerivFem)
       numScalars += nodesPerElem*numFemIp*nDim;
     
+    if (needDetjFC)
+      numScalars += numFaceIp;
+
     if (needDetj)
       numScalars += numScsIp;
     
@@ -200,6 +218,7 @@ void fill_pre_req_data(
 {
   int nodesPerElem = bulkData.num_nodes(elem);
 
+  MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
@@ -262,7 +281,7 @@ void fill_pre_req_data(
       SharedMemView<double**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
       auto& meData = prereqData.get_me_views(cType);
   
-      meData.fill_master_element_views(dataEnums, coordsView, meSCS, meSCV, meFEM);
+      meData.fill_master_element_views(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM);
     }
   }
 }
@@ -270,8 +289,10 @@ void fill_pre_req_data(
 void fill_master_element_views(
   ElemDataRequests& dataNeeded,
   const stk::mesh::BulkData& bulkData,
-  ScratchViews<DoubleType>& prereqData)
+  ScratchViews<DoubleType>& prereqData,
+  int faceOrdinal)
 {
+    MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
     MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
     MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
     MasterElement *meFEM = dataNeeded.get_fem_volume_me();
@@ -285,7 +306,7 @@ void fill_master_element_views(
       SharedMemView<DoubleType**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
       auto& meData = prereqData.get_me_views(cType);
   
-      meData.fill_master_element_views_new_me(dataEnums, coordsView, meSCS, meSCV, meFEM);
+      meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM, faceOrdinal);
     }
 }
 

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -63,7 +63,7 @@ struct HelperObjectsNewME {
     realm.metaData_ = &bulk.mesh_meta_data();
     realm.bulkData_ = &bulk;
     eqSystem.linsys_ = linsys;
-    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, stk::topology::ELEMENT_RANK, topo.num_nodes(), false);
+    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo.rank(), topo.num_nodes(), false);
   }
 
   ~HelperObjectsNewME()

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -17,6 +17,9 @@
 #include <master_element/Hex8CVFEM.h>
 #include <master_element/MasterElement.h>
 
+#include <gtest/gtest.h>
+
+typedef stk::mesh::Field<double> IdFieldType;
 typedef stk::mesh::Field<double> ScalarFieldType;
 typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
 typedef stk::mesh::Field<double,stk::mesh::Cartesian,stk::mesh::Cartesian> TensorFieldType;
@@ -73,6 +76,7 @@ protected:
       discreteLaplacianOfPressure(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "discreteLaplacian")),
       scalarQ(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalarQ")),
       diffFluxCoeff(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "diffFluxCoeff")),
+      idField(&meta.declare_field<IdFieldType>(stk::topology::NODE_RANK, "idField")),
       partVec(),
       coordField(nullptr),
       exactLaplacian(0.0)
@@ -84,6 +88,7 @@ protected:
       stk::mesh::put_field(*discreteLaplacianOfPressure, meta.universal_part(), 1, &zero);
       stk::mesh::put_field(*scalarQ, meta.universal_part(), 1, &zero);
       stk::mesh::put_field(*diffFluxCoeff, meta.universal_part(), 1, &zero);
+      stk::mesh::put_field(*idField, meta.universal_part(), 1);
     }
 
     ~Hex8Mesh() {}
@@ -94,7 +99,7 @@ protected:
     }
 
     void fill_mesh_and_initialize_test_fields(const std::string& meshSpec = "generated:20x20x20")
-    {   
+    {
         fill_mesh(meshSpec);
 
         partVec = {meta.get_part("block_1")};
@@ -120,6 +125,7 @@ protected:
     ScalarFieldType* discreteLaplacianOfPressure;
     ScalarFieldType* scalarQ;
     ScalarFieldType* diffFluxCoeff;
+    IdFieldType* idField;
     stk::mesh::PartVector partVec;
     const VectorFieldType* coordField;
     double exactLaplacian; 

--- a/unit_tests/kernels/UnitTestFaceBasic.C
+++ b/unit_tests/kernels/UnitTestFaceBasic.C
@@ -1,0 +1,69 @@
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+#include <stk_util/parallel/Parallel.hpp>
+
+#include "ElemDataRequests.h"
+#include "ScratchViews.h"
+#include "CopyAndInterleave.h"
+#include "Kernel.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+  void verify_faces_exist(const stk::mesh::BulkData& bulk)
+  {
+      EXPECT_TRUE(bulk.buckets(stk::topology::FACE_RANK).size() > 0);
+  }
+}
+
+class TestFaceKernel : public sierra::nalu::Kernel {
+public:
+  TestFaceKernel(stk::topology topo, ScalarFieldType* scalarQ, sierra::nalu::ElemDataRequests& dataNeeded)
+  : numTimesExecuted_(0), topo_(topo), scalarQ_(scalarQ)
+  {
+    dataNeeded.add_gathered_nodal_field(*scalarQ, 1);
+  }
+
+  virtual void execute(
+    sierra::nalu::SharedMemView<DoubleType**>& lhs,
+    sierra::nalu::SharedMemView<DoubleType*>& rhs,
+    sierra::nalu::ScratchViews<DoubleType>& faceViews)
+  {
+    sierra::nalu::SharedMemView<DoubleType*>& scalarQview = faceViews.get_scratch_view_1D(*scalarQ_);
+    EXPECT_EQ(topo_.num_nodes(), scalarQview.size());
+    ++numTimesExecuted_;
+  }
+
+  unsigned numTimesExecuted_;
+private:
+  stk::topology topo_;
+  ScalarFieldType* scalarQ_;
+};
+
+TEST_F(Hex8Mesh, faceBasic)
+{
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
+    return;
+  }
+  fill_mesh("generated:1x1x1|sideset:xXyYzZ");
+  verify_faces_exist(bulk);
+
+  stk::topology faceTopo = stk::topology::QUAD_4;
+  stk::topology elemTopo = stk::topology::HEX_8;
+  sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(faceTopo);
+  sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(elemTopo);
+
+  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  int numDof = 1;
+  unit_test_utils::HelperObjectsNewME helperObjs(bulk, faceTopo, numDof, surface1);
+  helperObjs.assembleElemSolverAlg->dataNeededByKernels_.add_cvfem_face_me(meFC);
+  helperObjs.assembleElemSolverAlg->dataNeededByKernels_.add_cvfem_surface_me(meSCS);
+
+  TestFaceKernel faceKernel(faceTopo, scalarQ, helperObjs.assembleElemSolverAlg->dataNeededByKernels_);
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(&faceKernel);
+
+  helperObjs.assembleElemSolverAlg->execute();
+
+  unsigned expectedNumFaces = 6;
+  EXPECT_EQ(expectedNumFaces, faceKernel.numTimesExecuted_);
+}

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -1,0 +1,229 @@
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+#include <stk_util/parallel/Parallel.hpp>
+
+#include "ElemDataRequests.h"
+#include "ScratchViews.h"
+#include "CopyAndInterleave.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+void fill_with_node_ids(stk::mesh::BulkData& bulk, IdFieldType* idField)
+{
+    const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
+    for(const stk::mesh::Bucket* bptr : nodeBuckets) {
+        for(stk::mesh::Entity node : *bptr) {
+            double* idptr = stk::mesh::field_data(*idField, node);
+            *idptr = bulk.identifier(node);
+        }
+    }
+}
+
+void verify_faces_exist(const stk::mesh::BulkData& bulk)
+{
+    EXPECT_TRUE(bulk.buckets(stk::topology::FACE_RANK).size() > 0);
+}
+
+class TestFaceElemKernel {
+public:
+    TestFaceElemKernel(stk::topology faceTopo, stk::topology elemTopo,
+                       IdFieldType* idField,
+                       sierra::nalu::ElemDataRequests& faceDataNeeded,
+                       sierra::nalu::ElemDataRequests& elemDataNeeded)
+    : numTimesExecuted_(0), faceTopo_(faceTopo), elemTopo_(elemTopo), idField_(idField)
+    {
+        faceDataNeeded.add_gathered_nodal_field(*idField, 1);
+        elemDataNeeded.add_gathered_nodal_field(*idField, 1);
+    }
+
+    void execute(/*perhaps bundle args into something like SharedMemData... */
+                 sierra::nalu::ScratchViews<DoubleType>& faceViews,
+                 sierra::nalu::ScratchViews<DoubleType>& elemViews,
+                 int numSimdFaces,
+                 const stk::mesh::ConnectivityOrdinal* elemFaceOrdinals)
+    {
+        sierra::nalu::SharedMemView<DoubleType*>& faceNodeIds = faceViews.get_scratch_view_1D(*idField_);
+        sierra::nalu::SharedMemView<DoubleType*>& elemNodeIds = elemViews.get_scratch_view_1D(*idField_);
+        EXPECT_EQ(faceTopo_.num_nodes(), faceNodeIds.size());
+        EXPECT_EQ(elemTopo_.num_nodes(), elemNodeIds.size());
+
+        std::vector<int> faceNodeOrdinals(faceTopo_.num_nodes());
+
+        for(int simdIndex=0; simdIndex<numSimdFaces; ++simdIndex) {
+           elemTopo_.face_node_ordinals(elemFaceOrdinals[simdIndex], faceNodeOrdinals.begin());
+           for(unsigned i=0; i<faceTopo_.num_nodes(); ++i) {
+               DoubleType faceNodeId = faceNodeIds(i);
+               DoubleType elemNodeId = elemNodeIds(faceNodeOrdinals[i]);
+               EXPECT_NEAR(stk::simd::get_data(faceNodeId,simdIndex), stk::simd::get_data(elemNodeId,simdIndex), 1.e-9);
+           }
+        }
+
+        ++numTimesExecuted_;
+    }
+
+    unsigned numTimesExecuted_;
+private:
+    stk::topology faceTopo_;
+    stk::topology elemTopo_;
+    IdFieldType* idField_;
+};
+
+constexpr int simdLen = stk::simd::ndoubles;
+
+int
+calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSize, int nDim,
+                                      sierra::nalu::ElemDataRequests& faceDataNeeded,
+                                      sierra::nalu::ElemDataRequests& elemDataNeeded)
+{
+    int bytes_per_thread = (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
+                           sierra::nalu::get_num_bytes_pre_req_data<double>(faceDataNeeded, nDim)
+                           +
+                           (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
+                           sierra::nalu::get_num_bytes_pre_req_data<double>(elemDataNeeded, nDim);
+    bytes_per_thread *= 2*simdLen;
+    return bytes_per_thread;
+}
+size_t get_simd_bucket_length(size_t bktLength)
+{
+    size_t simdBucketLen = bktLength/simdLen;
+    const size_t remainder = bktLength%simdLen;
+    if (remainder > 0) {
+      simdBucketLen += 1;
+    }
+    return simdBucketLen;
+}
+int get_next_num_elems_simd(int bktIndex, int bktLength)
+{
+  int numElems = simdLen;
+  if (bktLength - bktIndex*simdLen < simdLen) {
+    numElems = bktLength - bktIndex*simdLen;
+  }
+  if (numElems < 0 || numElems > simdLen) {
+    std::cout<<"ERROR, simdElems="<<numElems<<" shouldn't happen!!"<<std::endl;
+    numElems = 0;
+  }
+  return numElems;
+}
+
+class TestFaceElemAlgorithm {
+public:
+    TestFaceElemAlgorithm(stk::mesh::Part* part, stk::mesh::EntityRank rank, unsigned nodesPerEntity)
+    : kernels_(), part_(part), entityRank_(rank), nodesPerEntity_(nodesPerEntity)
+    {
+    }
+
+    template<typename LambdaFunction>
+    void run_face_elem_algorithm(stk::mesh::BulkData& bulk, LambdaFunction func)
+    {
+        int nDim = bulk.mesh_meta_data().spatial_dimension();
+        int lhsSize = 0, rhsSize = 0, scratchIdsSize = 0;
+        const int bytes_per_team = 0;
+        const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize, scratchIdsSize,
+                                                                         nDim, faceDataNeeded_, elemDataNeeded_);
+
+        stk::mesh::Selector s_locally_owned_union = bulk.mesh_meta_data().locally_owned_part() & *part_;
+
+        stk::mesh::BucketVector const& buckets = bulk.get_buckets(entityRank_, s_locally_owned_union );
+
+        auto team_exec = sierra::nalu::get_team_policy(buckets.size(), bytes_per_team, bytes_per_thread);
+        Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
+        {
+          stk::mesh::Bucket & b = *buckets[team.league_rank()];
+
+          ThrowAssertMsg(b.topology().num_nodes() == (unsigned)nodesPerEntity_,
+                         "TestFaceElemAlgorithm expected nodesPerEntity_ = "
+                         <<nodesPerEntity_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
+          unsigned nodesPerElem = 8; //hard-coded! needs to be obtained or passed in
+
+          std::unique_ptr<sierra::nalu::ScratchViews<double>> faceViews[simdLen];
+          std::unique_ptr<sierra::nalu::ScratchViews<double>> elemViews[simdLen];
+
+          for(int i=0; i<simdLen; ++i) {
+              faceViews[i] = std::unique_ptr<sierra::nalu::ScratchViews<double>>(
+                      new sierra::nalu::ScratchViews<double>(team, bulk, nodesPerEntity_, faceDataNeeded_));
+              elemViews[i] = std::unique_ptr<sierra::nalu::ScratchViews<double>>(
+                      new sierra::nalu::ScratchViews<double>(team, bulk, nodesPerElem, elemDataNeeded_));
+          }
+
+          sierra::nalu::ScratchViews<DoubleType> simdFaceViews(team, bulk, nodesPerEntity_, faceDataNeeded_);
+          sierra::nalu::ScratchViews<DoubleType> simdElemViews(team, bulk, nodesPerElem, elemDataNeeded_);
+
+          stk::mesh::ConnectivityOrdinal elemFaceOrdinals[simdLen] = {stk::mesh::INVALID_CONNECTIVITY_ORDINAL};
+          const size_t bucketLen   = b.size();
+          const size_t simdBucketLen = get_simd_bucket_length(bucketLen);
+
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex)
+          {
+            int numSimdFaces = get_next_num_elems_simd(bktIndex, bucketLen);
+
+            for(int simdFaceIndex=0; simdFaceIndex<numSimdFaces; ++simdFaceIndex) {
+              stk::mesh::Entity face = b[bktIndex*simdLen + simdFaceIndex];
+              elemFaceOrdinals[simdFaceIndex] = bulk.begin_element_ordinals(face)[0];
+              sierra::nalu::fill_pre_req_data(faceDataNeeded_, bulk, face, *faceViews[simdFaceIndex], false);
+
+              const stk::mesh::Entity* elems = bulk.begin_elements(face);
+              unsigned numElems = bulk.num_elements(face);
+              ThrowAssertMsg(numElems==1, "Expecting just 1 element attaced to face!");
+              sierra::nalu::fill_pre_req_data(elemDataNeeded_, bulk, elems[0], *elemViews[simdFaceIndex], false);
+            }
+
+            copy_and_interleave(faceViews, numSimdFaces, simdFaceViews, false);
+            copy_and_interleave(elemViews, numSimdFaces, simdElemViews, false);
+
+            fill_master_element_views(faceDataNeeded_, bulk, simdFaceViews);
+            fill_master_element_views(elemDataNeeded_, bulk, simdElemViews);
+
+            func(/*other args here?*/ simdFaceViews, simdElemViews, numSimdFaces, elemFaceOrdinals);
+          });
+        });
+    }
+
+    sierra::nalu::ElemDataRequests faceDataNeeded_;
+    sierra::nalu::ElemDataRequests elemDataNeeded_;
+    std::vector<TestFaceElemKernel*> kernels_;
+
+private:
+    stk::mesh::Part* part_;
+    stk::mesh::EntityRank entityRank_;
+    unsigned nodesPerEntity_;
+};
+
+} //anonymous namespace
+
+TEST_F(Hex8Mesh, faceElemBasic)
+{
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
+    return;
+  }
+  fill_mesh("generated:1x1x1|sideset:xXyYzZ");
+  verify_faces_exist(bulk);
+  fill_with_node_ids(bulk, idField);
+
+  stk::topology faceTopo = stk::topology::QUAD_4;
+  stk::topology elemTopo = stk::topology::HEX_8;
+  sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(faceTopo);
+  sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(elemTopo);
+  sierra::nalu::MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
+
+  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  TestFaceElemAlgorithm faceElemAlg(surface1, stk::topology::FACE_RANK, faceTopo.num_nodes());
+  faceElemAlg.faceDataNeeded_.add_cvfem_face_me(meFC);
+  faceElemAlg.elemDataNeeded_.add_cvfem_surface_me(meSCS);
+  faceElemAlg.elemDataNeeded_.add_cvfem_volume_me(meSCV);
+
+  TestFaceElemKernel faceElemKernel(faceTopo, elemTopo, idField,
+                                    faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
+
+  faceElemAlg.run_face_elem_algorithm(bulk,
+          [&](sierra::nalu::ScratchViews<DoubleType>& faceViews,
+              sierra::nalu::ScratchViews<DoubleType>& elemViews,
+              int numSimdFaces,
+              const stk::mesh::ConnectivityOrdinal* elemFaceOrdinals)
+      {
+          faceElemKernel.execute(faceViews, elemViews, numSimdFaces, elemFaceOrdinals);
+      });
+
+  unsigned expectedNumFaces = 6;
+  EXPECT_EQ(expectedNumFaces, faceElemKernel.numTimesExecuted_);
+}

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -41,7 +41,7 @@ public:
                  sierra::nalu::ScratchViews<DoubleType>& faceViews,
                  sierra::nalu::ScratchViews<DoubleType>& elemViews,
                  int numSimdFaces,
-                 const stk::mesh::ConnectivityOrdinal* elemFaceOrdinals)
+                 const int* elemFaceOrdinals)
     {
         sierra::nalu::SharedMemView<DoubleType*>& faceNodeIds = faceViews.get_scratch_view_1D(*idField_);
         sierra::nalu::SharedMemView<DoubleType*>& elemNodeIds = elemViews.get_scratch_view_1D(*idField_);
@@ -148,7 +148,7 @@ public:
           sierra::nalu::ScratchViews<DoubleType> simdFaceViews(team, bulk, nodesPerEntity_, faceDataNeeded_);
           sierra::nalu::ScratchViews<DoubleType> simdElemViews(team, bulk, nodesPerElem, elemDataNeeded_);
 
-          stk::mesh::ConnectivityOrdinal elemFaceOrdinals[simdLen] = {stk::mesh::INVALID_CONNECTIVITY_ORDINAL};
+          int elemFaceOrdinals[simdLen] = {-1};
           const size_t bucketLen   = b.size();
           const size_t simdBucketLen = get_simd_bucket_length(bucketLen);
 
@@ -170,7 +170,7 @@ public:
             copy_and_interleave(faceViews, numSimdFaces, simdFaceViews, false);
             copy_and_interleave(elemViews, numSimdFaces, simdElemViews, false);
 
-            fill_master_element_views(faceDataNeeded_, bulk, simdFaceViews);
+            fill_master_element_views(faceDataNeeded_, bulk, simdFaceViews, elemFaceOrdinals);
             fill_master_element_views(elemDataNeeded_, bulk, simdElemViews);
 
             func(/*other args here?*/ simdFaceViews, simdElemViews, numSimdFaces, elemFaceOrdinals);
@@ -218,7 +218,7 @@ TEST_F(Hex8Mesh, faceElemBasic)
           [&](sierra::nalu::ScratchViews<DoubleType>& faceViews,
               sierra::nalu::ScratchViews<DoubleType>& elemViews,
               int numSimdFaces,
-              const stk::mesh::ConnectivityOrdinal* elemFaceOrdinals)
+              const int* elemFaceOrdinals)
       {
           faceElemKernel.execute(faceViews, elemViews, numSimdFaces, elemFaceOrdinals);
       });

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -76,14 +76,13 @@ calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSi
                                       sierra::nalu::ElemDataRequests& faceDataNeeded,
                                       sierra::nalu::ElemDataRequests& elemDataNeeded)
 {
-    int bytes_per_thread = (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
-                           sierra::nalu::get_num_bytes_pre_req_data<double>(faceDataNeeded, nDim)
-                           +
-                           (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int) +
-                           sierra::nalu::get_num_bytes_pre_req_data<double>(elemDataNeeded, nDim);
+    int bytes_per_thread = (rhsSize + lhsSize)*sizeof(double) + (2*scratchIdsSize)*sizeof(int)
+                         + sierra::nalu::get_num_bytes_pre_req_data<double>(faceDataNeeded, nDim)
+                         + sierra::nalu::get_num_bytes_pre_req_data<double>(elemDataNeeded, nDim);
     bytes_per_thread *= 2*simdLen;
     return bytes_per_thread;
 }
+
 size_t get_simd_bucket_length(size_t bktLength)
 {
     size_t simdBucketLen = bktLength/simdLen;

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -8,7 +8,6 @@
 #ifndef UNITTESTKERNELUTILS_H
 #define UNITTESTKERNELUTILS_H
 
-#include <gtest/gtest.h>
 #include "UnitTestUtils.h"
 
 #include "SolutionOptions.h"
@@ -22,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <mpi.h>
 #include <vector>
 #include <memory>
 #include <iostream>


### PR DESCRIPTION
In unit_tests/kernels/UnitTestFaceElemBasic.C see the
class TestFaceElemAlgorithm, and its method run_face_elem_algorithm.

The run_face_elem_algorithm method uses a similar looping structure
to that used in AssembleElemSolverAlgorithm, but manages two
instances of the ElemDataRequests and ScratchViews objects, specifically
for face data and element data.

Jointly with Stefan and Robert, plumbed another master-element ('meFC')
into the ElemDataRequest and ScratchViews objects. We debated whether to
add the new master-element into those objects or to split those objects
such that a given instance would only hold the needed master-elements.
For now at least, we just added a new master-element into the existing
classes.

Still some issues to be worked out:

- Would face-elem-algorithm instances be templated on two AlgTraits, or
on AlgTraits that hold pairs of topologies (for quad-hex, tri-tet, etc).

- the loop in face-elem-algorithm needs nodesPerElem, which is currently
hard-coded for the unit-test but needs to be obtained from stk-mesh or
from a master-element.

- We think AssembleElemSolverAlgorithm could be made general enough to
handle either element (interior) or face (surface) algorithms. But we
haven't specifically designed a class hierarchy or determined where
a face-elem-algorithm would fit into that hierarchy.

- Haven't yet determined exactly which arguments should be passed to
kernel.execute for a face-elem kernel. The prototype in this unit-test
takes some arguments that probably wouldn't be needed in general.