### PR TITLE
Add run_algorithm template to AssembleElemSolverAlgorithm

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -9,19 +9,31 @@
 #ifndef AssembleElemSolverAlgorithm_h
 #define AssembleElemSolverAlgorithm_h
 
+#include<Realm.h>
 #include<SolverAlgorithm.h>
 #include<ElemDataRequests.h>
+#include <KokkosInterface.h>
+#include <SimdInterface.h>
+#include<ScratchViews.h>
+#include <SharedMemData.h>
+#include<CopyAndInterleave.h>
+#include<FieldTypeDef.h>
 
 namespace stk {
 namespace mesh {
 class Part;
+class Topology;
 }
 }
 
 namespace sierra{
 namespace nalu{
 
-class Realm;
+class MasterElement;
+
+int
+calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSize, int nDim,
+                                      ElemDataRequests& dataNeededByKernels);
 
 class AssembleElemSolverAlgorithm : public SolverAlgorithm
 {
@@ -37,6 +49,59 @@ public:
   virtual void initialize_connectivity();
   virtual void execute();
 
+  template<typename LambdaFunction>
+  void run_algorithm(stk::mesh::BulkData& bulk_data, LambdaFunction lambdaFunc)
+  {
+    stk::mesh::MetaData& meta_data = bulk_data.mesh_meta_data();
+    const int lhsSize = rhsSize_*rhsSize_;
+    const int scratchIdsSize = rhsSize_;
+
+   const int bytes_per_team = 0;
+   const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize_, scratchIdsSize,
+                                                                    meta_data.spatial_dimension(), dataNeededByKernels_);
+   stk::mesh::Selector s_locally_owned_union =
+           meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
+ 
+   stk::mesh::BucketVector const& elem_buckets =
+           realm_.get_buckets(entityRank_, s_locally_owned_union );
+ 
+   auto team_exec = sierra::nalu::get_team_policy(elem_buckets.size(), bytes_per_team, bytes_per_thread);
+   Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
+   {
+     stk::mesh::Bucket & b = *elem_buckets[team.league_rank()];
+ 
+     ThrowAssertMsg(b.topology().num_nodes() == (unsigned)nodesPerEntity_,
+                    "AssembleElemSolverAlgorithm expected nodesPerEntity_ = "
+                    <<nodesPerEntity_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
+ 
+     SharedMemData smdata(team, bulk_data, dataNeededByKernels_, nodesPerEntity_, rhsSize_);
+
+     const size_t bucketLen   = b.size();
+     const size_t simdBucketLen = get_num_simd_groups(bucketLen);
+ 
+     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex)
+     {
+       int numSimdElems = get_length_of_next_simd_group(bktIndex, bucketLen);
+       smdata.numSimdElems = numSimdElems;
+ 
+       for(int simdElemIndex=0; simdElemIndex<numSimdElems; ++simdElemIndex) {
+         stk::mesh::Entity element = b[bktIndex*simdLen + simdElemIndex];
+         smdata.elemNodes[simdElemIndex] = bulk_data.begin_nodes(element);
+         fill_pre_req_data(dataNeededByKernels_, bulk_data, element,
+                           *smdata.prereqData[simdElemIndex], interleaveMEViews_);
+       }
+ 
+       copy_and_interleave(smdata.prereqData, numSimdElems, smdata.simdPrereqData, interleaveMEViews_);
+ 
+       if (!interleaveMEViews_) {
+         fill_master_element_views(dataNeededByKernels_, bulk_data, smdata.simdPrereqData);
+       }
+
+       lambdaFunc(smdata);
+     });
+   });
+  }
+
   ElemDataRequests dataNeededByKernels_;
   stk::mesh::EntityRank entityRank_;
   unsigned nodesPerEntity_;
@@ -48,3 +113,4 @@ public:
 } // namespace Sierra
 
 #endif
+

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -40,6 +40,8 @@ struct SharedMemData {
         sortPermutation = get_int_shmem_view_1D(team, rhsSize);
     }
 
+    const stk::mesh::Entity* elemNodes[simdLen];
+    int numSimdElems;
     std::unique_ptr<ScratchViews<double>> prereqData[simdLen];
     ScratchViews<DoubleType> simdPrereqData;
     SharedMemView<DoubleType*> simdrhs;

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -31,8 +31,6 @@
 
 #include <KokkosInterface.h>
 #include <ScratchViews.h>
-#include <SharedMemData.h>
-#include <SimdInterface.h>
 #include <CopyAndInterleave.h>
 
 namespace sierra{
@@ -76,7 +74,6 @@ AssembleElemSolverAlgorithm::initialize_connectivity()
 void
 AssembleElemSolverAlgorithm::execute()
 {
-  stk::mesh::MetaData & meta_data = realm_.meta_data();
   stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
   // set any data
@@ -84,53 +81,8 @@ AssembleElemSolverAlgorithm::execute()
   for ( size_t i = 0; i < activeKernelsSize; ++i )
     activeKernels_[i]->setup(*realm_.timeIntegrator_);
 
-  const int lhsSize = rhsSize_*rhsSize_;
-  const int scratchIdsSize = rhsSize_;
-
-  // fixed size for this homogeneous algorithm
-  const int bytes_per_team = 0;
-  const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize_, scratchIdsSize,
-                                                                   meta_data.spatial_dimension(), dataNeededByKernels_);
-
-  // define some common selectors
-  stk::mesh::Selector s_locally_owned_union =
-          meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
-
-  stk::mesh::BucketVector const& elem_buckets =
-          realm_.get_buckets(entityRank_, s_locally_owned_union );
-
-  auto team_exec = sierra::nalu::get_team_policy(elem_buckets.size(), bytes_per_team, bytes_per_thread);
-  Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
+  run_algorithm(bulk_data, [&](SharedMemData& smdata)
   {
-    stk::mesh::Bucket & b = *elem_buckets[team.league_rank()];
-    
-    ThrowAssertMsg(b.topology().num_nodes() == (unsigned)nodesPerEntity_,
-                   "AssembleElemSolverAlgorithm expected nodesPerEntity_ = "
-                   <<nodesPerEntity_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
-
-    SharedMemData smdata(team, bulk_data, dataNeededByKernels_, nodesPerEntity_, rhsSize_);
-
-    const stk::mesh::Entity* entityNodes[simdLen];
-    const size_t bucketLen   = b.size();
-    const size_t simdBucketLen = get_num_simd_groups(bucketLen);
-
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex)
-    {
-      int numSimdElems = get_length_of_next_simd_group(bktIndex, bucketLen);
-
-      for(int simdElemIndex=0; simdElemIndex<numSimdElems; ++simdElemIndex) {
-        stk::mesh::Entity element = b[bktIndex*simdLen + simdElemIndex];
-        entityNodes[simdElemIndex] = bulk_data.begin_nodes(element);
-        fill_pre_req_data(dataNeededByKernels_, bulk_data, element,
-                          *smdata.prereqData[simdElemIndex], interleaveMEViews_);
-      }
-
-      copy_and_interleave(smdata.prereqData, numSimdElems, smdata.simdPrereqData, interleaveMEViews_);
-
-      if (!interleaveMEViews_) {
-        fill_master_element_views(dataNeededByKernels_, bulk_data, smdata.simdPrereqData);
-      }
-
       set_zero(smdata.simdrhs.data(), smdata.simdrhs.size());
       set_zero(smdata.simdlhs.data(), smdata.simdlhs.size());
 
@@ -138,13 +90,12 @@ AssembleElemSolverAlgorithm::execute()
       for ( size_t i = 0; i < activeKernelsSize; ++i )
         activeKernels_[i]->execute( smdata.simdlhs, smdata.simdrhs, smdata.simdPrereqData );
 
-      for(int simdElemIndex=0; simdElemIndex<numSimdElems; ++simdElemIndex) {
+      for(int simdElemIndex=0; simdElemIndex<smdata.numSimdElems; ++simdElemIndex) {
         extract_vector_lane(smdata.simdrhs, simdElemIndex, smdata.rhs);
         extract_vector_lane(smdata.simdlhs, simdElemIndex, smdata.lhs);
-        apply_coeff(nodesPerEntity_, entityNodes[simdElemIndex],
+        apply_coeff(nodesPerEntity_, smdata.elemNodes[simdElemIndex],
                     smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
       }
-    });
   });
 }
 

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -150,14 +150,15 @@ void test_ME_views(const std::vector<sierra::nalu::ELEM_DATA_NEEDED>& requests)
     driver.dataNeeded_.add_master_element_call(request, sierra::nalu::CURRENT_COORDINATES);
   }
 
+  sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
+  sierra::nalu::MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
   // Execute the loop and perform all tests
-  driver.execute([&](sierra::nalu::ScratchViews<DoubleType>& scratchViews,
-                     sierra::nalu::MasterElement* meSCS,
-                     sierra::nalu::MasterElement* meSCV) {
+  driver.execute([&](sierra::nalu::SharedMemData& smdata) {
       // Extract data from scratchViews
-      sierra::nalu::SharedMemView<DoubleType**>& v_coords = scratchViews.get_scratch_view_2D(
+      sierra::nalu::SharedMemView<DoubleType**>& v_coords = smdata.simdPrereqData.get_scratch_view_2D(
         *driver.coordinates_);
-      auto& meViews = scratchViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
+      auto& meViews = smdata.simdPrereqData.get_me_views(sierra::nalu::CURRENT_COORDINATES);
 
       if (meSCS != nullptr) {
         for(sierra::nalu::ELEM_DATA_NEEDED request : requests) {

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -18,6 +18,8 @@
 #include "KokkosInterface.h"
 #include "SimdInterface.h"
 
+#include "UnitTestHelperObjects.h"
+
 namespace unit_test_utils {
 
 template<typename AlgTraits>
@@ -88,60 +90,13 @@ public:
   template<typename LambdaFunction>
   void execute(LambdaFunction func)
   {
-    constexpr int simdLen = stk::simd::ndoubles;
-    // Do not copy and interleave ME views
-    const bool alsoProcessMEViews = false;
+    int numDof = 1;
+    ThrowAssertMsg(partVec_.size()==1, "KokkosMEViews unit-test assumes partVec_.size==1");
 
-    stk::mesh::Selector sel = (
-      meta_.locally_owned_part() & stk::mesh::selectUnion(partVec_));
+    HelperObjects helperObjs(bulk_, AlgTraits::topo_, numDof, partVec_[0]);
+    helperObjs.assembleElemSolverAlg->dataNeededByKernels_ = dataNeeded_;
 
-    const int bytes_per_team = 0;
-    int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(
-      dataNeeded_, AlgTraits::nDim_);
-    bytes_per_thread *= 3 * stk::simd::ndoubles;
-
-    const auto& buckets = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
-
-    auto team_exec = sierra::nalu::get_team_policy(
-      buckets.size(), bytes_per_team, bytes_per_thread);
-
-    Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team) {
-        auto& b = *buckets[team.league_rank()];
-        const auto length = b.size();
-
-        std::vector<std::unique_ptr<sierra::nalu::ScratchViews<double> > > prereqData(simdLen);
-
-        for (int simdIndex=0; simdIndex < simdLen; ++simdIndex) {
-          prereqData[simdIndex] = std::unique_ptr<sierra::nalu::ScratchViews<double> >(new sierra::nalu::ScratchViews<double>(team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_));
-        }
-        sierra::nalu::ScratchViews<DoubleType> simdPrereqData(
-          team, bulk_, AlgTraits::nodesPerElement_, dataNeeded_);
-
-        const stk::mesh::Entity* elemNodes[simdLen];
-        stk::mesh::Bucket::size_type simdBucketLen = length / simdLen;
-        const stk::mesh::Bucket::size_type remainder = length % simdLen;
-        if (remainder > 0) simdBucketLen++;
-
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex){
-            int simdElems = simdLen;
-            if (length - bktIndex*simdLen < simdLen) {
-              simdElems = length - bktIndex*simdLen;
-            }
-
-            stk::mesh::Entity element;
-            for (int simdIndex=0; simdIndex < simdElems; ++simdIndex) {
-              element = b[bktIndex*simdLen + simdIndex];
-              elemNodes[simdIndex] = bulk_.begin_nodes(element);
-              fill_pre_req_data(dataNeeded_, bulk_, element, *prereqData[simdIndex], alsoProcessMEViews);
-            }
-
-            copy_and_interleave(prereqData.data(), simdElems, simdPrereqData,
-                                alsoProcessMEViews);
-            fill_master_element_views(dataNeeded_, bulk_, simdPrereqData);
-
-            func(simdPrereqData, meSCS_, meSCV_);
-          });
-      });
+    helperObjs.assembleElemSolverAlg->run_algorithm(bulk_, func);
   }
 
   stk::ParallelMachine comm_;


### PR DESCRIPTION
In order to be consistent with AssembleFaceElemSolverAlgorithm
and to facilitate unit-testing of kernels and master-elements
without duplicating the mesh loop and scratch-view management.