### PR TITLE
Upating YAML instructions in documentation

### DIFF
--- a/docs/source/developer/testing.rst
+++ b/docs/source/developer/testing.rst
@@ -77,7 +77,7 @@ TPL versions are officially tested:
   boost@1.60.0
   cmake@3.6.1
   parallel-netcdf@1.6.1
-  yaml-cpp@0.5.3
+  yaml-cpp@master
   hdf5@1.8.16
   netcdf@4.3.3.1
   zlib@1.2.11

--- a/docs/source/user/build_manually.rst
+++ b/docs/source/user/build_manually.rst
@@ -145,10 +145,10 @@ using mpi: /path/to/mpi/openmpi/bin/mpicc
     ./b2 -j 4 2>&1 | tee boost_build_one
     ./b2 -j 4 install 2>&1 | tee boost_build_intall
 
-YAML-CPP v0.5.3
-~~~~~~~~~~~~~~~
+YAML-CPP
+~~~~~~~~
 
-YAML is provided `here <https://github.com/jbeder/yaml-cpp>`__. Versions of Nalu before v1.1.0 used earlier versions of YAML-CPP. For brevity only the latest build instructions are discussed and the history of the Nalu git repo can be used to find older installation instructions if required.
+YAML is provided `here <https://github.com/jbeder/yaml-cpp>`__. Versions of Nalu before v1.1.0 used earlier versions of YAML-CPP. For brevity only the latest build instructions are discussed and the history of the Nalu git repo can be used to find older installation instructions if required. YAML-CPP has introduced several fixes since v0.5.3 in the master branch, so it is recommended to build the master branch, or choose commit ``5d5bb52e`` which is the latest commit that has been tested as of this writing.
 
 Prepare:
 


### PR DESCRIPTION
This updates the YAML instructions in the documentation to recommend using a specific commit or the master branch of YAML-CPP. Addressing #309 .