### PR TITLE
Bug fix for TurbKinEne Ksgs kernel, was missing coordinates_ definition.

### DIFF
--- a/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
@@ -47,6 +47,7 @@ public:
 private:
   TurbKineticEnergyKsgsSrcElemKernel() = delete;
 
+  VectorFieldType *coordinates_{nullptr};
   ScalarFieldType *tkeNp1_{nullptr};
   ScalarFieldType *densityNp1_{nullptr};
   ScalarFieldType *tvisc_{nullptr};

--- a/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
@@ -36,6 +36,8 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsSrcElemKerne
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   tkeNp1_ = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_ke");
   densityNp1_ = metaData.get_field<ScalarFieldType>(
@@ -52,6 +54,7 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsSrcElemKerne
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // required fields
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);


### PR DESCRIPTION
When I tried to use the source term defined in TurbKineticEnergyKsgsSrcElemKernel (this is not the DesignOrder one), I got an error when trying to add the master element call to SCV_VOLUME.  I believe this was due to the coordinates field not being defined, which this pull request resolves.