### PR TITLE
Fix declaration of Tpetra::MultiVector and Tpetra::Vector in Nalu

### DIFF
--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -12,6 +12,8 @@
 #include <KokkosInterface.h>
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Vector.hpp>
+#include <Tpetra_MultiVector.hpp>
 
 // Forward declare templates
 namespace Teuchos {
@@ -33,12 +35,6 @@ class Map;
 
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node >
 class Export;
-
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node, bool classic>
-class MultiVector;
-
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node, bool classic>
-class Vector;
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 class Operator;


### PR DESCRIPTION
Recent updates to Tpetra in Trilinos removed the classic template parameter for
Vector and MultiVector. This caused build errors when compiling Nalu with the
latest Trilinos develop branch. This commit fixes this issue.

Fixes #333.