### PR TITLE
Account for overset BC parts with check_for_missing_bcs

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -517,7 +517,14 @@ class Realm {
   // mesh parts for all interior domains
   stk::mesh::PartVector interiorPartVec_;
 
-  // mesh parts for all boundary conditions
+  /** Vector holding side sets that have been registered with the boundary
+   * conditions in the input file.
+   *
+   * The member is intended to for use in Realm::enforce_bc_on_exposed_faces to
+   * check for "exposed surfaces" that might have not been assigned BCs in the
+   * input file.
+   *
+   */
   stk::mesh::PartVector bcPartVec_;
 
   // empty part vector should it be required

--- a/include/overset/OversetManagerSTK.h
+++ b/include/overset/OversetManagerSTK.h
@@ -81,6 +81,8 @@ public:
 
   virtual ~OversetManagerSTK();
 
+  virtual void setup();
+
   // main method called for initialization
   virtual void initialize();
   

--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -48,7 +48,7 @@ public:
 
   /** Setup block structure information (steps before mesh creation)
    */
-  void setup();
+  void setup(stk::mesh::PartVector&);
 
   /** Initialize mesh data structure (steps after mesh creation)
    */

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -46,7 +46,7 @@ public:
 
   /** Setup block structure information (steps before mesh creation)
    */
-  void setup();
+  void setup(stk::mesh::PartVector&);
 
   /** Initialize mesh data structure (steps after mesh creation)
    */

--- a/reg_tests/test_files/overset/overset.i
+++ b/reg_tests/test_files/overset/overset.i
@@ -20,6 +20,7 @@ realms:
     mesh: ../../mesh/oversetMeshAligned.g
     use_edges: no
     automatic_decomposition_type: rcb
+    check_for_missing_bcs: yes
 
     equation_systems:
       name: theEqSys

--- a/reg_tests/test_files/oversetSphereTIOGA/oversetSphereTIOGA.i
+++ b/reg_tests/test_files/oversetSphereTIOGA/oversetSphereTIOGA.i
@@ -33,6 +33,7 @@ realms:
     mesh: ../../mesh/oversetSphereTioga.g
     use_edges: no
     automatic_decomposition_type: rcb
+    check_for_missing_bcs: yes
 
     time_step_control:
       target_courant: 2.0

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -996,8 +996,6 @@ Realm::enforce_bc_on_exposed_faces()
 
   NaluEnv::self().naluOutputP0() << "Realm::skin_mesh(): Begin" << std::endl;
 
-  NaluEnv::self().naluOutputP0() << "Realm::skin_mesh(): Begin" << std::endl;
-
   // first, skin mesh and, therefore, populate
   stk::mesh::Selector activePart = metaData_->locally_owned_part() | metaData_->globally_shared_part();
   stk::mesh::PartVector partVec;

--- a/src/overset/OversetManagerSTK.C
+++ b/src/overset/OversetManagerSTK.C
@@ -66,6 +66,18 @@ OversetManagerSTK::OversetManagerSTK(
 OversetManagerSTK::~OversetManagerSTK()
 {}
 
+void
+OversetManagerSTK::setup()
+{
+  // Add all overset BC parts to the BC vector so that check missing BCs can
+  // ignore these parts
+  std::string targetName(oversetUserData_.oversetSurface_);
+  stk::mesh::Part* part = metaData_->get_part(targetName);
+  if (nullptr == part)
+    throw std::runtime_error("OversetManagerSTK:: Invalid overset surface provided");
+  realm_.bcPartVec_.push_back(part);
+}
+
 //--------------------------------------------------------------------------
 //-------- initialize ------------------------------------------------------
 //--------------------------------------------------------------------------

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -47,7 +47,7 @@ OversetManagerTIOGA::~OversetManagerTIOGA()
 void
 OversetManagerTIOGA::setup()
 {
-  tiogaIface_.setup();
+  tiogaIface_.setup(realm_.bcPartVec_);
 }
 
 void

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -66,7 +66,7 @@ void TiogaBlock::load(const YAML::Node& node)
   }
 }
 
-void TiogaBlock::setup()
+void TiogaBlock::setup(stk::mesh::PartVector& bcPartVec)
 {
   names_to_parts(blkNames_, blkParts_);
 
@@ -86,6 +86,12 @@ void TiogaBlock::setup()
     stk::mesh::put_field(ibf, *p);
     stk::mesh::put_field(ibcell, *p);
   }
+
+  // Push overset BC parts to the realm_.bcPartVec_ so that they are ignored
+  // when checking for missing BCs
+  if (ovsetNames_.size() > 0)
+    for (auto bcPart: ovsetParts_)
+      bcPartVec.push_back(bcPart);
 }
 
 void TiogaBlock::initialize()

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -62,10 +62,10 @@ TiogaSTKIface::load(const YAML::Node& node)
       << "TIOGA: Using coordinates field: " << coords_name << std::endl;
 }
 
-void TiogaSTKIface::setup()
+void TiogaSTKIface::setup(stk::mesh::PartVector& bcPartVec)
 {
   for (auto& tb: blocks_) {
-    tb->setup();
+    tb->setup(bcPartVec);
   }
 
   // Initialize the inactive part


### PR DESCRIPTION
Fixes error when the user enables "check_for_missing_bcs" in the input
file and overset BC is active. The fix adds overset side_set targets to
the realm.bcPartVec_ so that enforce_bc_on_exposed_faces will skip these
parts during the BC check step.

Updated two regression tests to provide coverage for this ability.