### PR TITLE
Remove a spurious comment from https://github.com/NaluCFD/Nalu/commit…

### DIFF
--- a/src/overset/AssembleOversetSolverConstaintAlgorithm.C
+++ b/src/overset/AssembleOversetSolverConstaintAlgorithm.C
@@ -179,7 +179,6 @@ AssembleOversetSolverConstraintAlgorithm::execute()
       const int rowOi = i * npePlusOne * sizeOfDof;
       const double residual = qNp1Nodal[i] - qNp1Orphan[i];
       p_rhs[i] = -residual;
-      //p_rhs[i] = 0.0;
 
       // row is zero by design (first connected node is the orphan node); assign it fully
       p_lhs[rowOi+i] += 1.0;


### PR DESCRIPTION
…/0c35ced0713a42a17017d475f644ea55f54549dc#diff-f8c530f7a44bdbb5a5c90c6386726154

* while I was checking on the recent general shape function pull request,
I noticed a spurious comment on the overset residual. The comment confused me,
however, I believe that it may have been a WIP debug line that can be removed
to keep the intent of the constraint algorithm clear.