### PR TITLE
Add mean resolved ke to turbulence averaging; final bug fix

### DIFF
--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -714,7 +714,8 @@ TurbulenceAveragingPostProcessing::execute()
       // need locally owned and active nodes
       stk::mesh::Selector s_locally_owned_nodes
         = metaData.locally_owned_part() & stk::mesh::selectUnion(avInfo->partVec_)
-        & !(realm_.get_inactive_selector());
+        & !(realm_.get_inactive_selector())
+        & !(stk::mesh::selectUnion(realm_.get_slave_part_vector()));
       compute_mean_resolved_ke(avInfo->name_, s_locally_owned_nodes);
     }
     


### PR DESCRIPTION
* The selector needs to include !slave_nodes... Now, volume is matching
the previous approach.