### PR TITLE
First exposed face bc algorithm (consolidated)

### DIFF
--- a/include/BcAlgTraits.h
+++ b/include/BcAlgTraits.h
@@ -25,6 +25,43 @@ struct BcAlgTraitsHex8Quad4 {
   static constexpr stk::topology::topology_t elemTopo_ = stk::topology::HEX_8;
 };
 
+struct BcAlgTraitsQuad4 {
+  static constexpr int nDim_ = 3;
+  static constexpr int nodesPerFace_ = 4;
+  static constexpr int numFaceIp_ = 4;
+  static constexpr stk::topology::topology_t faceTopo_ = stk::topology::QUAD_4;
+};
+
+struct BcAlgTraitsQuad9 {
+  static constexpr int nDim_ = 3;
+  static constexpr int nodesPerFace_ = 9;
+  static constexpr int numFaceIp_ = 36;
+  static constexpr stk::topology::topology_t faceTopo_ = stk::topology::QUAD_9;
+};
+
+struct BcAlgTraitsTri3 {
+  static constexpr int nDim_ = 3;
+  static constexpr int nodesPerFace_ = 3;
+  static constexpr int numFaceIp_ = 3;
+  static constexpr stk::topology::topology_t faceTopo_ = stk::topology::TRI_3;
+};
+
+struct BcAlgTraitsLine2 {
+  static constexpr int nDim_ = 2;
+  static constexpr int nodesPerFace_ = 2;
+  static constexpr int numFaceIp_ = 2;
+  static constexpr stk::topology::topology_t faceTopo_ = stk::topology::LINE_2;
+};
+
+struct BcAlgTraitsLine3 {
+  static constexpr int nDim_ = 2;
+  static constexpr int nodesPerFace_ = 3;
+  static constexpr int numFaceIp_ = 6;
+  static constexpr int numGp_ = 2;
+  static constexpr stk::topology::topology_t faceTopo_ = stk::topology::LINE_3;
+};
+
+
 } // namespace nalu
 } // namespace Sierra
 

--- a/include/BuildTemplates.h
+++ b/include/BuildTemplates.h
@@ -10,6 +10,7 @@
 #define BuildTemplates_h
 
 #include <AlgTraits.h>
+#include <BcAlgTraits.h>
 
 #ifndef USER_POLY_ORDER
 #define USER_POLY_ORDER 5
@@ -49,6 +50,12 @@ template class ClassName<AlgTraitsQuadGL<USER_POLY_ORDER>>;      \
   INSTANTIATE_KERNEL_3D_HO(ClassName)           \
   INSTANTIATE_KERNEL_2D_HO(ClassName)           \
 
+#define INSTANTIATE_FACE_BC_KERNEL(ClassName)  \
+template class ClassName<BcAlgTraitsQuad4>;    \
+template class ClassName<BcAlgTraitsQuad9>;    \
+template class ClassName<BcAlgTraitsTri3>;     \
+template class ClassName<BcAlgTraitsLine2>;    \
+template class ClassName<BcAlgTraitsLine3>;    \
 
 } // namespace nalu
 } // namespace Sierra

--- a/include/kernel/MomentumAdvDiffElemKernel.h
+++ b/include/kernel/MomentumAdvDiffElemKernel.h
@@ -8,7 +8,7 @@
 #ifndef MOMENTUMADVDIFFELEMKERNEL_H
 #define MOMENTUMADVDIFFELEMKERNEL_H
 
-#include "Kernel.h"
+#include "kernel/Kernel.h"
 #include "FieldTypeDef.h"
 
 #include <stk_mesh/base/BulkData.hpp>

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -8,7 +8,6 @@
 #ifndef MomentumOpenAdvDiffElemKernel_h
 #define MomentumOpenAdvDiffElemKernel_h
 
-#include "kernel/MomentumOpenAdvDiffElemKernel.h"
 #include "BcAlgTraits.h"
 #include "master_element/MasterElement.h"
 

--- a/include/pmr/RadTransWallElemKernel.h
+++ b/include/pmr/RadTransWallElemKernel.h
@@ -1,0 +1,74 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corp.                                           */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef RadTransWallElemKernel_H
+#define RadTransWallElemKernel_H
+
+#include "BcAlgTraits.h"
+#include "FieldTypeDef.h"
+#include "kernel/Kernel.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class ElemDataRequests;
+class MasterElement;
+class RadiativeTransportEquationSystem;
+class TimeIntegrator;
+
+/** Add Int I sj*njds 
+ */
+template<typename BcAlgTraits>
+class RadTransWallElemKernel: public Kernel
+{
+public:
+  RadTransWallElemKernel(
+      const stk::mesh::BulkData&,
+      RadiativeTransportEquationSystem *radEqSystem,
+      const bool &,
+      ElemDataRequests&);
+
+  virtual ~RadTransWallElemKernel();
+
+  /** Perform pre-timestep work for the computational kernel
+   */
+  virtual void setup(const TimeIntegrator&);
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  RadTransWallElemKernel() = delete;
+
+  ScalarFieldType *intensity_{nullptr};
+  ScalarFieldType *bcIntensity_{nullptr};
+  GenericFieldType *exposedAreaVec_{nullptr};
+
+  const RadiativeTransportEquationSystem *radEqSystem_;
+  
+  // Integration point to node mapping 
+  const int *ipNodeMap_{nullptr};
+
+  // scratch space
+  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
+  Kokkos::View<DoubleType[BcAlgTraits::nDim_]> v_Sk_{"v_Sk"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* RadTransWallElemKernel_H */

--- a/src/kernel/KernelBuilderLog.C
+++ b/src/kernel/KernelBuilderLog.C
@@ -98,7 +98,7 @@ KernelBuilderLog::print_built_kernel_names(std::string kernelTypeName)
   msgList = msgList.substr(0, msgList.size()-2);
 
   NaluEnv::self().naluOutputP0()
-      << "Built Supplemental Algortihms for "
+      << "Built Kernels for "
       << kernelTypeName
       << " are "
       << msgList

--- a/src/pmr/RadTransWallElemKernel.C
+++ b/src/pmr/RadTransWallElemKernel.C
@@ -1,0 +1,124 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "pmr/RadTransWallElemKernel.h"
+#include "pmr/RadiativeTransportEquationSystem.h"
+#include "BcAlgTraits.h"
+#include "master_element/MasterElement.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename BcAlgTraits>
+RadTransWallElemKernel<BcAlgTraits>::RadTransWallElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  RadiativeTransportEquationSystem *radEqSystem,
+  const bool &useShifted,
+  ElemDataRequests &dataPreReqs)
+  : Kernel(),
+    radEqSystem_(radEqSystem),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_)->ipNodeMap())
+ {
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  bcIntensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity_bc");
+  intensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity");
+  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+
+  MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
+ 
+  // compute and save shape function
+  get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFC->shape_fcn(ptr);}, vf_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_face_me(meFC);
+  
+  // required fields
+  dataPreReqs.add_gathered_nodal_field(*intensity_, 1);
+  dataPreReqs.add_gathered_nodal_field(*bcIntensity_, 1);
+  dataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+
+  // vf
+}
+
+template<typename BcAlgTraits>
+RadTransWallElemKernel<BcAlgTraits>::~RadTransWallElemKernel()
+{}
+
+template<typename BcAlgTraits>
+void
+RadTransWallElemKernel<BcAlgTraits>::setup(const TimeIntegrator& /*timeIntegrator*/)
+{
+  // extract ordinate direction and copy to Double type
+  std::vector<double> Sk(BcAlgTraits::nDim_,0.0);
+  radEqSystem_->get_current_ordinate(&Sk[0]);
+  for ( int j = 0; j < BcAlgTraits::nDim_; ++j )
+    v_Sk_(j) = Sk[j];
+}
+
+template<typename BcAlgTraits>
+void
+RadTransWallElemKernel<BcAlgTraits>::execute(
+  SharedMemView<DoubleType **>&lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  SharedMemView<DoubleType*>& v_intensity = scratchViews.get_scratch_view_1D(
+    *intensity_);
+  SharedMemView<DoubleType*>& v_bcIntensity = scratchViews.get_scratch_view_1D(
+    *bcIntensity_); 
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = scratchViews.get_scratch_view_2D(*exposedAreaVec_);
+
+  for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
+
+    // nearest node (to which we will assemble RHS)
+    const int nearestNode = ipNodeMap_[ip];
+
+    // interpolate to bip; both intensity flavors
+    DoubleType iBip = 0.0;
+    DoubleType iBcBip = 0.0;
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const DoubleType r = vf_shape_function_(ip,ic);
+      iBip += r*v_intensity(ic);
+      iBcBip += r*v_bcIntensity(ic);
+    }
+    
+    // determine in or out intensity bc based on sign of ajsj
+    DoubleType ajsj = 0.0;
+    for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+      ajsj += vf_exposedAreaVec(ip,j)*v_Sk_(j);
+    }
+
+    // account for both cases, i.e., Int sj I njdS; flavor of I depends on sign of ajsj
+    const DoubleType ajsjFac = stk::math::if_then_else(ajsj > 0, 1.0, 0.0);
+    const DoubleType om_ajsjFac = 1.0 - ajsjFac;
+   
+    // use dof intensity (ajsjFac  == unity); requires LHS assemble
+    for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
+      lhs(nearestNode,ic) += ajsj*vf_shape_function_(ip,ic)*ajsjFac;
+    }
+    rhs(nearestNode) -= iBip*ajsj*ajsjFac;
+    
+    // use bc intensity (ajsjFac == 0); requires NO LHS assembly
+    rhs(nearestNode) -= iBcBip*ajsj*om_ajsjFac;
+  } 
+}
+
+INSTANTIATE_FACE_BC_KERNEL(RadTransWallElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -37,11 +37,12 @@
 #include "kernel/KernelBuilder.h"
 #include "kernel/KernelBuilderLog.h"
 
-// consolidated
+// implemented kernels
 #include "AssembleElemSolverAlgorithm.h"
 #include "pmr/RadTransAdvectionSUCVElemKernel.h"
 #include "pmr/RadTransAbsorptionBlackBodyElemKernel.h"
 #include "pmr/RadTransIsotropicScatteringElemKernel.h"
+#include "pmr/RadTransWallElemKernel.h"
 
 // stk_util
 #include <stk_util/parallel/Parallel.hpp>
@@ -562,9 +563,8 @@ RadiativeTransportEquationSystem::register_interior_algorithm(
       build_topo_kernel_if_requested<RadTransIsotropicScatteringElemKernel>
         (partTopo, *this, activeKernels, "isotropic_scattering",
          realm_.bulk_data(), true, dataPreReqs);
-      
+
       report_invalid_supp_alg_names();
-      report_built_supp_alg_names();
     }
   }
 }
@@ -574,7 +574,7 @@ RadiativeTransportEquationSystem::register_interior_algorithm(
 void
 RadiativeTransportEquationSystem::register_wall_bc(
   stk::mesh::Part *part,
-  const stk::topology &/*theTopo*/,
+  const stk::topology &partTopo,
   const WallBoundaryConditionData &wallBCData)
 {
 
@@ -674,18 +674,40 @@ RadiativeTransportEquationSystem::register_wall_bc(
       bcDataMapAlg_.push_back(theCopyAlg);
     */
 
-    // solver; lhs: weak flux implementation
-    std::map<AlgorithmType, SolverAlgorithm *>::iterator itsi
-      = solverAlgDriver_->solverAlgMap_.find(algType);
-    if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
-      AssembleRadTransWallSolverAlgorithm *theAlg
-        = new AssembleRadTransWallSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_);
-      solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+    // solver; lhs: weak bc flux implementation
+    if ( realm_.realmUsesEdges_ ) {
+      std::map<AlgorithmType, SolverAlgorithm *>::iterator itsi
+        = solverAlgDriver_->solverAlgMap_.find(algType);
+      if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
+        AssembleRadTransWallSolverAlgorithm *theAlg
+          = new AssembleRadTransWallSolverAlgorithm(realm_, part, this, realm_.realmUsesEdges_);
+        solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+      }
+      else {
+        itsi->second->partVec_.push_back(part);
+      }
     }
     else {
-      itsi->second->partVec_.push_back(part);
-    }
 
+      // element-based uses consolidated approach fully
+      auto& solverAlgMap = solverAlgDriver_->solverAlgorithmMap_;
+
+      AssembleElemSolverAlgorithm* solverAlg = nullptr;
+      bool solverAlgWasBuilt = false;
+      
+      std::tie(solverAlg, solverAlgWasBuilt) = build_or_add_part_to_face_bc_solver_alg(*this, *part, solverAlgMap);
+      
+      ElemDataRequests& dataPreReqs = solverAlg->dataNeededByKernels_;
+      auto& activeKernels = solverAlg->activeKernels_;
+      
+      if (solverAlgWasBuilt) {
+        build_face_topo_kernel_automatic<RadTransWallElemKernel>
+          (partTopo, *this, activeKernels, "rad_trans_wall_bc",
+           realm_.bulk_data(), this, false, dataPreReqs);
+
+        report_built_supp_alg_names();
+      } 
+    }
   }
   else {
     throw std::runtime_error("Hmmm... Does it make sense to not specify a temperature?");


### PR DESCRIPTION
* add new element types to BcAlgTraits

* add face only instantiation

* add RadTransWallElemKernel

* add kernel builder for face algs

* remove Built Supplemental Algs in favor of Kernels

* build template for face_bc

Notes:

a) good news, no diffs noted (concentic and inputFire)
b) ready to deploy for all other face-only bc algorithms.
c) sadly, AssembleRadTransWall is still there for edge-based only
d) new design looks nice and clean.