### PR TITLE
Add SCV grad_op for promoted elements

### DIFF
--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -133,6 +133,7 @@ void interleave_me_views(MasterElementViews<DoubleType>& dest,
 {
   interleave_2D(dest.scs_areav, src.scs_areav, simdIndex);
   interleave_3D(dest.dndx, src.dndx, simdIndex);
+  interleave_3D(dest.dndx_scv, src.dndx_scv, simdIndex);
   interleave_3D(dest.dndx_shifted, src.dndx_shifted, simdIndex);
   interleave_3D(dest.dndx_fem, src.dndx_fem, simdIndex);
   interleave_3D(dest.deriv, src.deriv, simdIndex);

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -51,6 +51,14 @@ public:
     double *volume,
     double * error ) final;
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error) final;
+
   std::vector<double> shape_functions() {
     return shapeFunctionVals_;
   }
@@ -78,11 +86,6 @@ private:
   std::vector<double> shapeFunctionVals_;
   std::vector<double> shapeDerivs_;
   std::vector<double> ipWeights_;
-  std::vector<double> geoShapeDerivs_;
-  int geoNodesPerElement_;
-//
-//  Kokkos::View<double**> interpWeights_;
-//  Kokkos::View<double***> derivWeights_;
 };
 
 // 3D Hex 27 subcontrol surface
@@ -167,19 +170,6 @@ private:
     double *POINTER_RESTRICT shapeDeriv,
     double *POINTER_RESTRICT areaVector) const;
 
-  void gradient(
-    const double* POINTER_RESTRICT elemNodalCoords,
-    const double* POINTER_RESTRICT shapeDeriv,
-    double* POINTER_RESTRICT grad,
-    double* POINTER_RESTRICT det_j ) const;
-
-  void gradient(
-    const double* POINTER_RESTRICT elemNodalCoords,
-    const double* POINTER_RESTRICT geometricShapeDeriv,
-    const double*  POINTER_RESTRICT shapeDeriv,
-    double* POINTER_RESTRICT grad,
-    double* POINTER_RESTRICT det_j ) const;
-
   const ElementDescription elem_;
   LagrangeBasis basis_;
   const TensorProductQuadratureRule quadrature_;
@@ -187,8 +177,6 @@ private:
   std::vector<double> shapeFunctionVals_;
   std::vector<double> shapeDerivs_;
   std::vector<double> expFaceShapeDerivs_;
-  std::vector<double> geometricShapeDerivs_;
-  int geometricNodesPerElement_;
   std::vector<ContourData> ipInfo_;
   int ipsPerFace_;
 };
@@ -265,6 +253,14 @@ public:
     double *volume,
     double * error ) final;
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error) final;
+
   std::vector<double> shape_functions() {
     return shapeFunctionVals_;
   }
@@ -291,8 +287,6 @@ private:
   std::vector<double> shapeFunctionVals_;
   std::vector<double> shapeDerivs_;
   std::vector<double> ipWeights_;
-  std::vector<double> geometricShapeDerivs_;
-  int geometricNodesPerElement_;
 };
 class HigherOrderQuad2DSCS final: public MasterElement
 {
@@ -374,27 +368,12 @@ private:
     double *POINTER_RESTRICT shapeDeriv,
     double *POINTER_RESTRICT normalVec ) const;
 
-  void gradient(
-    const double* POINTER_RESTRICT elemNodalCoords,
-    const double* POINTER_RESTRICT shapeDeriv,
-    double* POINTER_RESTRICT grad,
-    double* POINTER_RESTRICT det_j) const;
-
-  void gradient(
-    const double* POINTER_RESTRICT elemNodalCoords,
-    const double* POINTER_RESTRICT geometricShapeDeriv,
-    const double* POINTER_RESTRICT shapeDeriv,
-    double* POINTER_RESTRICT grad,
-    double* POINTER_RESTRICT det_j ) const;
-
   const ElementDescription elem_;
   LagrangeBasis basis_;
   const TensorProductQuadratureRule quadrature_;
 
   std::vector<double> shapeFunctionVals_;
   std::vector<double> shapeDerivs_;
-  std::vector<double> geometricShapeDerivs_;
-  int geometricNodesPerElement_;
   std::vector<ContourData> ipInfo_;
   int ipsPerFace_;
   std::vector<double> expFaceShapeDerivs_;

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -130,8 +130,12 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
         Pk += w_dudx[i][j]*(w_dudx[i][j] + w_dudx[j][i]);
       }
     }
-    Pk *= tviscIp;
-    
+    Pk *= stk::math::max(tviscIp,0);
+    tkeIp = stk::math::max(tkeIp,0);
+    dualNodalVolIp = stk::math::max(dualNodalVolIp,0);
+    rhoIp = stk::math::max(rhoIp,0);
+
+
     // tke factor
     const DoubleType tkeFac = (AlgTraits::nDim_ == 2) 
       ? cEps_*rhoIp*stk::math::sqrt(tkeIp/dualNodalVolIp)


### PR DESCRIPTION
* Addresses #335
* Gets rid of the unused ability to specify sub/super parametric elements for promoted elements.  
* Adds clipping for ip values in design order ksgs, since the interpolation isn't necessarily monotonic