### PR TITLE
Added scalar open eleme kernel with unit test

### DIFF
--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -30,7 +30,7 @@ class MasterElement;
 template <typename T> class PecletFunction;
 class SolutionOptions;
 
-/** Symmetry kernel for momentum equation (velocity DOF)
+/** Open adv/diff kernel for momentum equation (velocity DOF)
  */
 template<typename BcAlgTraits>
 class MomentumOpenAdvDiffElemKernel: public Kernel

--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -21,6 +21,7 @@ namespace nalu {
 
 class SolutionOptions;
 class ElemDataRequests;
+class MasterElement;
 
 /** Symmetry kernel for momentum equation (velocity DOF)
  */
@@ -58,8 +59,7 @@ private:
   const double includeDivU_;
   const bool shiftedGradOp_;
 
-  // Integration point to node mapping
-  const int* ipNodeMap_{nullptr};
+  MasterElement *meSCS_{nullptr};
 
   /// Shape functions
   Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};

--- a/include/kernel/ScalarOpenAdvElemKernel.h
+++ b/include/kernel/ScalarOpenAdvElemKernel.h
@@ -5,8 +5,8 @@
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 
-#ifndef MomentumOpenAdvDiffElemKernel_h
-#define MomentumOpenAdvDiffElemKernel_h
+#ifndef ScalarOpenAdvElemKernel_h
+#define ScalarOpenAdvElemKernel_h
 
 #include "master_element/MasterElement.h"
 
@@ -30,23 +30,24 @@ class MasterElement;
 template <typename T> class PecletFunction;
 class SolutionOptions;
 
-/** Symmetry kernel for momentum equation (velocity DOF)
+/** Symmetry kernel for scalar equation
  */
 template<typename BcAlgTraits>
-class MomentumOpenAdvDiffElemKernel: public Kernel
+class ScalarOpenAdvElemKernel: public Kernel
 {
 public:
-  MomentumOpenAdvDiffElemKernel(
+  ScalarOpenAdvElemKernel(
     const stk::mesh::MetaData &metaData,
     const SolutionOptions &solnOpts,
-    EquationSystem* eqSystem,
-    VectorFieldType *velocity,
-    GenericFieldType *Gjui,
-    ScalarFieldType *viscosity,
+    EquationSystem* eqSystem,  
+    ScalarFieldType *scalarQ,
+    ScalarFieldType *bcScalarQ,
+    VectorFieldType *Gjq,
+    ScalarFieldType *diffFluxCoeff,
     ElemDataRequests &faceDataPreReqs,
     ElemDataRequests &elemDataPreReqs);
 
-  virtual ~MomentumOpenAdvDiffElemKernel();
+  virtual ~ScalarOpenAdvElemKernel();
 
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
@@ -58,26 +59,21 @@ public:
     ScratchViews<DoubleType> &elemScratchViews);
 
 private:
-  MomentumOpenAdvDiffElemKernel() = delete;
+  ScalarOpenAdvElemKernel() = delete;
 
-  ScalarFieldType *viscosity_{nullptr};
-  GenericFieldType *Gjui_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
+  ScalarFieldType *scalarQ_{nullptr};
+  ScalarFieldType *bcScalarQ_{nullptr};
+  VectorFieldType *Gjq_{nullptr};
+  ScalarFieldType *diffFluxCoeff_{nullptr};
   VectorFieldType *velocityRTM_{nullptr};
   VectorFieldType *coordinates_{nullptr};
   ScalarFieldType *density_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
   GenericFieldType *openMassFlowRate_{nullptr};
-  VectorFieldType *velocityBc_{nullptr};
   
   // numerical parameters
   const double alphaUpw_;
   const double om_alphaUpw_;
   const double hoUpwind_;
-  const double nfEntrain_;
-  const double om_nfEntrain_;
-  const double includeDivU_;
-  const bool shiftedGradOp_;
   const double small_{1.0e-16};
 
   // Integration point to node mapping and master element for interior
@@ -88,13 +84,10 @@ private:
   PecletFunction<DoubleType> *pecletFunction_{nullptr};
 
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"vf_shape_func"};
-  Kokkos::View<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_shape_function_ {"v_shape_func"};
   Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
-  Kokkos::View<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_adv_shape_function_ {"v_adv_shape_func"};
 };
 
 }  // nalu
 }  // sierra
 
-#endif /* MomentumOpenAdvDiffElemKernel_h */
+#endif /* ScalarOpenAdvElemKernel_h */

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -43,7 +43,6 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::MomentumOpenAdvDiffElemKernel(
     om_nfEntrain_(1.0-nfEntrain_),
     includeDivU_(solnOpts.includeDivU_),
     shiftedGradOp_(solnOpts.get_shifted_grad_op(velocity->name())),
-    ipNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_)->ipNodeMap()),
     faceIpNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_)->ipNodeMap()),
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_)),
     pecletFunction_(eqSystem->create_peclet_function<DoubleType>(velocity->name()))
@@ -146,7 +145,7 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
     const int opposingNode = meSCS_->opposingNodes(face_ordinal,ip); // "Left"
-    const int nearestNode = ipNodeMap_[ip]; // "Right"
+    const int nearestNode = meSCS_->ipNodeMap(face_ordinal)[ip]; // "Right"
     const int opposingScsIp = meSCS_->opposingFace(face_ordinal,ip);
     const int localFaceNode = faceIpNodeMap_[ip];
     

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -137,7 +137,7 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
       }
     }
     
-    // Peclet factor; along the edge is fine  
+    // udotx; extrapolation
     DoubleType udotx = 0.0;
     DoubleType dqR = 0.0;
     for ( int i = 0; i < BcAlgTraits::nDim_; ++i ) {

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -1,0 +1,202 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/ScalarOpenAdvElemKernel.h"
+#include "EquationSystem.h"
+#include "master_element/MasterElement.h"
+#include "PecletFunction.h"
+#include "SolutionOptions.h"
+#include "BuildTemplates.h"
+
+// template and scratch space
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename BcAlgTraits>
+ScalarOpenAdvElemKernel<BcAlgTraits>::ScalarOpenAdvElemKernel(
+  const stk::mesh::MetaData &metaData,
+  const SolutionOptions &solnOpts,
+  EquationSystem *eqSystem,
+  ScalarFieldType *scalarQ,
+  ScalarFieldType *bcScalarQ,
+  VectorFieldType *Gjq,
+  ScalarFieldType *diffFluxCoeff,
+  ElemDataRequests &faceDataPreReqs,
+  ElemDataRequests &elemDataPreReqs)
+  : Kernel(),
+    scalarQ_(scalarQ),
+    bcScalarQ_(bcScalarQ),
+    Gjq_(Gjq),
+    diffFluxCoeff_(diffFluxCoeff),
+    alphaUpw_(solnOpts.get_alpha_upw_factor(scalarQ->name())),
+    om_alphaUpw_(1.0-alphaUpw_),
+    hoUpwind_(solnOpts.get_upw_factor(scalarQ->name())),
+    faceIpNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_)->ipNodeMap()),
+    meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_)),
+    pecletFunction_(eqSystem->create_peclet_function<DoubleType>(scalarQ->name()))
+{
+  // save off fields
+  if ( solnOpts.does_mesh_move() )
+    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+  else
+    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  openMassFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
+  
+  // extract master elements
+  MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
+  
+  // add master elements
+  faceDataPreReqs.add_cvfem_face_me(meFC);
+  elemDataPreReqs.add_cvfem_surface_me(meSCS_);
+
+  // fields and data; face and then element
+  faceDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  faceDataPreReqs.add_gathered_nodal_field(*Gjq_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(*bcScalarQ_, 1);
+  faceDataPreReqs.add_face_field(*openMassFlowRate_, BcAlgTraits::numFaceIp_);
+
+  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(*velocityRTM_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
+  elemDataPreReqs.add_gathered_nodal_field(*density_, 1);
+
+  // never shift properties
+  const bool skewSymmetric = solnOpts.get_skew_symmetric(scalarQ_->name());
+  get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){skewSymmetric ? meFC->shifted_shape_fcn(ptr) : meFC->shape_fcn(ptr);}, 
+                                      vf_adv_shape_function_);
+}
+
+template<typename BcAlgTraits>
+ScalarOpenAdvElemKernel<BcAlgTraits>::~ScalarOpenAdvElemKernel()
+{
+  delete pecletFunction_;
+}
+
+
+template<typename BcAlgTraits>
+void
+ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
+  SharedMemView<DoubleType**> &lhs,
+  SharedMemView<DoubleType *> &rhs,
+  ScratchViews<DoubleType> &faceScratchViews,
+  ScratchViews<DoubleType> &elemScratchViews)
+{
+  DoubleType w_coordBip[BcAlgTraits::nDim_];
+
+  // FIXME #1 and #2 hard-code a face_node_ordinal and ordinal
+  const int face_node_ordinals[BcAlgTraits::nodesPerFace_] = {};
+  const int face_ordinal = 1;
+
+  // face
+  SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(*scalarQ_);
+  SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(*bcScalarQ_);
+  SharedMemView<DoubleType**>& vf_Gjq = faceScratchViews.get_scratch_view_2D(*Gjq_);
+  SharedMemView<DoubleType**>& vf_coordinates = faceScratchViews.get_scratch_view_2D(*coordinates_);
+  SharedMemView<DoubleType*>& vf_openMassFlowRate = faceScratchViews.get_scratch_view_1D(*openMassFlowRate_);
+  
+  // element
+  SharedMemView<DoubleType**>& v_coordinates = elemScratchViews.get_scratch_view_2D(*coordinates_);
+  SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(*velocityRTM_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = elemScratchViews.get_scratch_view_1D(*diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(*density_);
+
+  for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
+    
+    const int opposingNode = meSCS_->opposingNodes(face_ordinal,ip); // "Left"
+    const int nearestNode = meSCS_->ipNodeMap(face_ordinal)[ip]; // "Right"
+    const int localFaceNode = faceIpNodeMap_[ip];
+    
+    // zero out vector quantities
+    for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+      w_coordBip[j] = 0.0;
+    }
+    
+    // interpolate to bip
+    DoubleType qIp = 0.0;
+    DoubleType qIpEntrain = 0.0;
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const DoubleType rAdv = vf_adv_shape_function_(ip,ic);
+      qIp += rAdv*vf_scalarQ(ic);
+      qIpEntrain += rAdv*vf_bcScalarQ(ic);
+      for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+        w_coordBip[j] += rAdv*vf_coordinates(ic,j);
+      }
+    }
+    
+    // Peclet factor; along the edge is fine  
+    DoubleType udotx = 0.0;
+    DoubleType dqR = 0.0;
+    for ( int i = 0; i < BcAlgTraits::nDim_; ++i ) {
+      const DoubleType dxi = v_coordinates(nearestNode,i) - v_coordinates(opposingNode,i);
+      udotx += 0.5*dxi*(v_vrtm(opposingNode,i) + v_vrtm(nearestNode,i));
+      DoubleType dxBip = w_coordBip[i] - v_coordinates(nearestNode,i);
+      dqR += dxBip*vf_Gjq(localFaceNode,i)*hoUpwind_;
+    }
+    const DoubleType qIpUpw = vf_scalarQ(localFaceNode) + dqR;
+    
+    // Peclet factor; along the edge is fine
+    const DoubleType diffIp = 0.5*(v_diffFluxCoeff(opposingNode)/v_density(opposingNode)
+                                   + v_diffFluxCoeff(nearestNode)/v_density(nearestNode));
+    const DoubleType pecFuncArg = stk::math::abs(udotx)/(diffIp+small_);
+    const DoubleType pecfac = pecletFunction_->execute(pecFuncArg);
+    const DoubleType om_pecfac = 1.0-pecfac;
+   
+    const DoubleType tmdot = vf_openMassFlowRate(ip);
+
+    // account for both cases, i.e., leaving or entering to avoid hard loop over SIMD length
+    const DoubleType mdotLeaving = stk::math::if_then_else(tmdot > 0, 1.0, 0.0);
+    const DoubleType om_mdotLeaving = 1.0 - mdotLeaving;
+
+    //================================
+    // flow is leaving
+    //================================
+    
+    // central is simply qIp
+    
+    // upwind
+    const DoubleType qUpwind = alphaUpw_*qIpUpw + om_alphaUpw_*qIp;
+    
+    // total advection
+    const DoubleType afluxLeaving = tmdot*(pecfac*qUpwind+om_pecfac*qIp);
+
+    rhs(nearestNode) -= afluxLeaving*mdotLeaving;
+
+    // upwind lhs
+    lhs(nearestNode,nearestNode) += tmdot*pecfac*alphaUpw_*mdotLeaving;
+
+    // central part
+    const DoubleType fac = tmdot*(pecfac*om_alphaUpw_+om_pecfac)*mdotLeaving;
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const int nn = face_node_ordinals[ic];
+      lhs(nearestNode,nn) += vf_adv_shape_function_(ip,ic)*fac;
+    }
+
+    //================================
+    // flow is entering
+    //================================
+
+    // extrainment; advect in from specified value
+    const DoubleType afluxEntraining = tmdot*qIpEntrain;
+    rhs(nearestNode) -= afluxEntraining*om_mdotLeaving;
+    
+  }
+}
+
+INSTANTIATE_KERNEL_FACE_ELEMENT(ScalarOpenAdvElemKernel);
+
+}  // nalu
+}  // sierra

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -185,7 +185,7 @@ class Hex8ElementWithBCFields : public ::testing::Test
       Gjui(meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx")),
       scalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_q")),
       bcScalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "bc_scalar_q")),
-      Gjq(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "Gjq"))
+      Gjq(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "Gjq"))
    {
     const double one = 1.0;
     const double oneVecThree[3] = {one, one, one};
@@ -234,7 +234,7 @@ class Hex8ElementWithBCFields : public ::testing::Test
   GenericFieldType& Gjui;
   ScalarFieldType& scalarQ;
   ScalarFieldType& bcScalarQ;
-  ScalarFieldType& Gjq;
+  VectorFieldType& Gjq;
  };
 
 class ABLWallFunctionHex8ElementWithBCFields : public Hex8ElementWithBCFields

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -182,14 +182,17 @@ class Hex8ElementWithBCFields : public ::testing::Test
       wallNormalDistanceBip(meta.declare_field<GenericFieldType>(meta.side_rank(), "wall_normal_distance_bip")),
       bcVelocityOpen(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc")),
       openMdot(meta.declare_field<GenericFieldType>(meta.side_rank(), "open_mass_flow_rate")),
-      Gjui(meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx"))     
+      Gjui(meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx")),
+      scalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_q")),
+      bcScalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "bc_scalar_q")),
+      Gjq(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "Gjq"))
    {
     const double one = 1.0;
     const double oneVecThree[3] = {one, one, one};
     const double oneVecFour[4] = {one, one, -one, -one};
     const double oneVecNine[9] = {one, one, one, one, one, one, one, one, one};
     const double oneVecTwelve[12] = {one, one, one, one, one, one, one, one, one, one, one, one};
-
+    
     stk::mesh::put_field(velocity, meta.universal_part(), 3, oneVecThree);
     stk::mesh::put_field(bcVelocity, meta.universal_part(), 3, oneVecThree);
     stk::mesh::put_field(density, meta.universal_part(), 1);
@@ -201,11 +204,15 @@ class Hex8ElementWithBCFields : public ::testing::Test
     stk::mesh::put_field(exposedAreaVec, meta.universal_part(), 3*meFC->numIntPoints_, oneVecTwelve);
     stk::mesh::put_field(wallFrictionVelocityBip, meta.universal_part(), meFC->numIntPoints_);
     stk::mesh::put_field(wallNormalDistanceBip, meta.universal_part(), meFC->numIntPoints_);
-
+    
     stk::mesh::put_field(bcVelocityOpen, meta.universal_part(), 3, oneVecThree);
     stk::mesh::put_field(openMdot, meta.universal_part(), 4, oneVecFour);
     stk::mesh::put_field(Gjui, meta.universal_part(), 3*3, oneVecNine);
-
+    
+    stk::mesh::put_field(scalarQ, meta.universal_part(), 1, &one);    
+    stk::mesh::put_field(bcScalarQ, meta.universal_part(), 1, &one);    
+    stk::mesh::put_field(Gjq, meta.universal_part(), 3, oneVecThree);    
+    
     unit_test_utils::create_one_reference_element(bulk, stk::topology::HEXAHEDRON_8);
    }
 
@@ -225,6 +232,9 @@ class Hex8ElementWithBCFields : public ::testing::Test
   VectorFieldType& bcVelocityOpen;
   GenericFieldType& openMdot;
   GenericFieldType& Gjui;
+  ScalarFieldType& scalarQ;
+  ScalarFieldType& bcScalarQ;
+  ScalarFieldType& Gjq;
  };
 
 class ABLWallFunctionHex8ElementWithBCFields : public Hex8ElementWithBCFields

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -10,6 +10,7 @@
 #include "AssembleFaceElemSolverAlgorithm.h"
 #include "kernel/MomentumOpenAdvDiffElemKernel.h"
 #include "kernel/MomentumSymmetryElemKernel.h"
+#include "kernel/ScalarOpenAdvElemKernel.h"
 
 #include <gtest/gtest.h>
 
@@ -162,6 +163,33 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumOpen)
                                                                                         faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(momentumOpenAdvDiffElemKernel);
+
+  faceElemAlg.execute();
+}
+
+TEST_F(Hex8ElementWithBCFields, faceElemScalarOpen)
+{
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
+    return;
+  }
+  verify_faces_exist(bulk);
+
+  sierra::nalu::SolutionOptions solnOptions;
+
+  stk::topology faceTopo = stk::topology::QUAD_4;
+  stk::topology elemTopo = stk::topology::HEX_8;
+  stk::mesh::Part* surface1 = meta.get_part("all_surfaces");
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+
+  sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
+                                                          faceTopo.num_nodes(), elemTopo.num_nodes());
+
+  auto  scalarOpenAdvElemKernel =
+    new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(meta, solnOptions, &helperObjs.eqSystem, 
+                                                                                &scalarQ, &bcScalarQ, &Gjq, &viscosity,
+                                                                                faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
+
+  faceElemAlg.activeKernels_.push_back(scalarOpenAdvElemKernel);
 
   faceElemAlg.execute();
 }


### PR DESCRIPTION
* coded advection-based scalar element kernel

* realized nearest node was wrong in all face/elem kernels. Resolved
this first in ScalarOpenAdv and then propogated the change to MomentumOpen
and MomentumSymm.

Notes:

a) open is last, however, I think that I will transition back to
executing the full path for Scalar open. At that point, all scalars can
deprecate.
b) the easiest path forward is probably to fully activate ScalarOpen,
MomentumSymm, and, finally, MomentumOpen.