### PR TITLE
Hypre: Use new functions in Hypre API to zero matrix.

### DIFF
--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -333,16 +333,11 @@ HypreLinearSystem::zeroSystem()
   MPI_Comm comm = realm_.bulk_data().parallel();
   HypreDirectSolver* solver = reinterpret_cast<HypreDirectSolver*>(linearSolver_);
 
-  if (systemInitialized_)
-    HYPRE_IJMatrixDestroy(mat_);
-  HYPRE_IJMatrixCreate(comm, iLower_, iUpper_, jLower_, jUpper_, &mat_);
-  HYPRE_IJMatrixSetObjectType(mat_, HYPRE_PARCSR);
   HYPRE_IJMatrixInitialize(mat_);
-  HYPRE_IJMatrixGetObject(mat_, (void**)&(solver->parMat_));
-
   HYPRE_IJVectorInitialize(rhs_);
   HYPRE_IJVectorInitialize(sln_);
 
+  HYPRE_IJMatrixSetConstantValues(mat_, 0.0);
   HYPRE_ParVectorSetConstantValues(solver->parRhs_, 0.0);
   HYPRE_ParVectorSetConstantValues(solver->parSln_, 0.0);
 


### PR DESCRIPTION
Prior to Hypre v2.14.0, there was no quick way to zero out the entries
in an IJMatrix while preserving the connections. Nalu interface to Hypre
had resorted to destroying and recreating the IJMatrix during the call
to HypreLinearSystem::zeroSystem. This meant that the IJMatrix was
recreated during every outer iteration even if there was no mesh motion.
This overhead is removed by using HYPRE_IJMatrixSetConstantValues to
zero out entries but preserve the matrix structure from previous calls.