### PR TITLE
Add logic to repeat search at non-conformal interfaces.

### DIFF
--- a/include/NonConformalInfo.h
+++ b/include/NonConformalInfo.h
@@ -130,6 +130,11 @@ class NonConformalInfo {
   /* save off product of search */
   std::vector<std::pair<theKey, theKey> > searchKeyPair_;
 
+  private :
+  void delete_range_points_found(std::vector<boundingSphere>                 &boundingSphereVec,
+                                 const std::vector<std::pair<theKey,theKey>> &searchKeyPair) const;
+  void repeat_search_if_needed  (const std::vector<boundingSphere>           &boundingSphereVec,
+                                 std::vector<std::pair<theKey,theKey>>       &searchKeyPair) const;
 };
 
 } // end sierra namespace


### PR DESCRIPTION
If the search fails to find a match for some elements then
increase the search distance and repeat the search with just
the elements that were not matched.  This will keep the dynamic
search tolerance algorithm from failing if the search tolerance
suddenly needs to be increased by a large factor from one time
step to the next. If after doubling the search tolerance ten times
and there are still points with no match the function then throws
an error.