### PR TITLE
Added SST source kernels and unit tests.

### DIFF
--- a/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
+++ b/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
@@ -54,6 +54,7 @@ private:
   VectorFieldType* coordinates_{nullptr};
 
   const bool lumpedMass_;
+  const bool shiftedGradOp_;
   const double betaStar_;
   const double sigmaWTwo_;
   const double betaOne_;

--- a/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
+++ b/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
@@ -1,0 +1,75 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef SPECIFICDISSIPATIONRATESSTSRCELEMKERNEL_H
+#define SPECIFICDISSIPATIONRATESSTSRCELEMKERNEL_H
+
+#include "Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+template <typename AlgTraits>
+class SpecificDissipationRateSSTSrcElemKernel : public Kernel
+{
+public:
+  SpecificDissipationRateSSTSrcElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~SpecificDissipationRateSSTSrcElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  SpecificDissipationRateSSTSrcElemKernel() = delete;
+
+  ScalarFieldType* tkeNp1_{nullptr};
+  ScalarFieldType* sdrNp1_{nullptr};
+  ScalarFieldType* densityNp1_{nullptr};
+  VectorFieldType* velocityNp1_{nullptr};
+  ScalarFieldType* tvisc_{nullptr};
+  ScalarFieldType* fOneBlend_{nullptr};
+  VectorFieldType* coordinates_{nullptr};
+
+  const bool lumpedMass_;
+  const double betaStar_;
+  const double sigmaWTwo_;
+  const double betaOne_;
+  const double betaTwo_;
+  const double gammaOne_;
+  const double gammaTwo_;
+  double tkeProdLimitRatio_{0.0};
+
+  const int* ipNodeMap_;
+
+  // scratch space
+  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+    v_shape_function_{"v_shape_function"};
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif /* SPECIFICDISSIPATIONRATESSTSRCELEMKERNEL_H */

--- a/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
@@ -1,0 +1,73 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef TURBKINETICENERGYSSTDESSRCELEMKERNEL_H
+#define TURBKINETICENERGYSSTDESSRCELEMKERNEL_H
+
+#include "Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+template <typename AlgTraits>
+class TurbKineticEnergySSTDESSrcElemKernel : public Kernel
+{
+public:
+  TurbKineticEnergySSTDESSrcElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~TurbKineticEnergySSTDESSrcElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  TurbKineticEnergySSTDESSrcElemKernel() = delete;
+
+  ScalarFieldType* tkeNp1_{nullptr};
+  ScalarFieldType* sdrNp1_{nullptr};
+  ScalarFieldType* densityNp1_{nullptr};
+  VectorFieldType* velocityNp1_{nullptr};
+  ScalarFieldType* tvisc_{nullptr};
+  ScalarFieldType* maxLengthScale_{nullptr};
+  ScalarFieldType* fOneBlend_{nullptr};
+  VectorFieldType* coordinates_{nullptr};
+
+  const bool lumpedMass_;
+  const double betaStar_;
+  double tkeProdLimitRatio_{0.0};
+  double cDESke_{0.0};
+  double cDESkw_{0.0};
+
+  const int* ipNodeMap_;
+
+  // scratch space
+  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+    v_shape_function_{"v_shape_function"};
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif /* TURBKINETICENERGYSSTDESSRCELEMKERNEL_H */

--- a/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
@@ -55,6 +55,7 @@ private:
   VectorFieldType* coordinates_{nullptr};
 
   const bool lumpedMass_;
+  const bool shiftedGradOp_;
   const double betaStar_;
   double tkeProdLimitRatio_{0.0};
   double cDESke_{0.0};

--- a/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
@@ -1,0 +1,69 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef TURBKINETICENERGYSSTSRCELEMKERNEL_H
+#define TURBKINETICENERGYSSTSRCELEMKERNEL_H
+
+#include "Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+template <typename AlgTraits>
+class TurbKineticEnergySSTSrcElemKernel : public Kernel
+{
+public:
+  TurbKineticEnergySSTSrcElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~TurbKineticEnergySSTSrcElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  TurbKineticEnergySSTSrcElemKernel() = delete;
+
+  ScalarFieldType* tkeNp1_{nullptr};
+  ScalarFieldType* sdrNp1_{nullptr};
+  ScalarFieldType* densityNp1_{nullptr};
+  VectorFieldType* velocityNp1_{nullptr};
+  ScalarFieldType* tvisc_{nullptr};
+  VectorFieldType* coordinates_{nullptr};
+
+  const bool lumpedMass_;
+  const double betaStar_;
+  double tkeProdLimitRatio_{0.0};
+
+  const int* ipNodeMap_;
+
+  // scratch space
+  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+    v_shape_function_{"v_shape_function"};
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif /* TURBKINETICENERGYSSTSRCELEMKERNEL_H */

--- a/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
@@ -53,6 +53,7 @@ private:
   VectorFieldType* coordinates_{nullptr};
 
   const bool lumpedMass_;
+  const bool shiftedGradOp_;
   const double betaStar_;
   double tkeProdLimitRatio_{0.0};
 

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -47,7 +47,20 @@
 #include <SpecificDissipationRateSSTNodeSourceSuppAlg.h>
 #include <SolverAlgorithmDriver.h>
 
+// template for supp algs
+#include <AlgTraits.h>
+#include <kernel/KernelBuilder.h>
+#include <kernel/KernelBuilderLog.h>
+
+// consolidated
+#include <AssembleElemSolverAlgorithm.h>
+#include <kernel/ScalarMassElemKernel.h>
+#include <kernel/ScalarAdvDiffElemKernel.h>
+#include <kernel/ScalarUpwAdvDiffElemKernel.h>
+#include <kernel/SpecificDissipationRateSSTSrcElemKernel.h>
+
 // nso
+#include <nso/ScalarNSOElemKernel.h>
 #include <nso/ScalarNSOKeElemSuppAlg.h>
 #include <nso/ScalarNSOElemSuppAlgDep.h>
 
@@ -210,118 +223,183 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
   }
 
   // solver; interior contribution (advection + diffusion)
-  std::map<AlgorithmType, SolverAlgorithm *>::iterator itsi
-    = solverAlgDriver_->solverAlgMap_.find(algType);
-  if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
-    SolverAlgorithm *theAlg = NULL;
-    if ( realm_.realmUsesEdges_ ) {
-      theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
-    }
-    else {
-      theAlg = new AssembleScalarElemSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
-    }
-    solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+  if (!realm_.solutionOptions_->useConsolidatedSolverAlg_) {
 
-    // look for fully integrated source terms
-    std::map<std::string, std::vector<std::string> >::iterator isrc 
-      = realm_.solutionOptions_->elemSrcTermsMap_.find("specific_dissipation_rate");
-    if ( isrc != realm_.solutionOptions_->elemSrcTermsMap_.end() ) {
-
-      if ( realm_.realmUsesEdges_ )
-        throw std::runtime_error("SpecificDissipationElemSrcTerms::Error can not use element source terms for an edge-based scheme");
-      
-      std::vector<std::string> mapNameVec = isrc->second;
-      for (size_t k = 0; k < mapNameVec.size(); ++k ) {
-        std::string sourceName = mapNameVec[k];
-        SupplementalAlgorithm *suppAlg = NULL;
-        if (sourceName == "NSO_2ND_ALT" ) {
-          suppAlg = new ScalarNSOElemSuppAlgDep(realm_, sdr_, dwdx_, evisc_, 0.0, 1.0);
-        }
-        else if (sourceName == "NSO_4TH_ALT" ) {
-          suppAlg = new ScalarNSOElemSuppAlgDep(realm_, sdr_, dwdx_, evisc_, 1.0, 1.0);
-        }
-        else if (sourceName == "NSO_2ND_KE" ) {
-          const double turbSc = realm_.get_turb_schmidt(sdr_->name());
-          suppAlg = new ScalarNSOKeElemSuppAlg(realm_, sdr_, dwdx_, turbSc, 0.0);
-        }
-        else if (sourceName == "NSO_4TH_KE" ) {
-          const double turbSc = realm_.get_turb_schmidt(sdr_->name());
-          suppAlg = new ScalarNSOKeElemSuppAlg(realm_, sdr_, dwdx_, turbSc, 1.0);
-        }
-        else if (sourceName == "specific_dissipation_rate_time_derivative" ) {
-          suppAlg = new ScalarMassElemSuppAlgDep(realm_, sdr_, false);
-        }
-        else if (sourceName == "lumped_specific_dissipation_rate_time_derivative" ) {
-          suppAlg = new ScalarMassElemSuppAlgDep(realm_, sdr_, true);
-        }
-        else {
-          throw std::runtime_error("SpecificDissipationElemSrcTerms::Error Source term is not supported: " + sourceName);
-        }
-        NaluEnv::self().naluOutputP0() << "SpecificDissipationElemSrcTerms::added() " << sourceName << std::endl;
-        theAlg->supplementalAlg_.push_back(suppAlg); 
-      }
-    }
-  }
-  else {
-    itsi->second->partVec_.push_back(part);
-  }
-
-  // time term; src; both nodally lumped
-  const AlgorithmType algMass = MASS;
-  // Check if the user has requested CMM or LMM algorithms; if so, do not
-  // include Nodal Mass algorithms
-  std::vector<std::string> checkAlgNames = {
-    "specific_dissipation_rate_time_derivative",
-    "lumped_specific_dissipation_rate_time_derivative"};
-  bool elementMassAlg = supp_alg_is_requested(checkAlgNames);
-  std::map<AlgorithmType, SolverAlgorithm *>::iterator itsm =
-    solverAlgDriver_->solverAlgMap_.find(algMass);
-  if ( itsm == solverAlgDriver_->solverAlgMap_.end() ) {
-    // create the solver alg
-    AssembleNodeSolverAlgorithm *theAlg
-      = new AssembleNodeSolverAlgorithm(realm_, part, this);
-    solverAlgDriver_->solverAlgMap_[algMass] = theAlg;
-
-    // now create the supplemental alg for mass term
-    if ( !elementMassAlg ) {
-      if ( realm_.number_of_states() == 2 ) {
-        ScalarMassBackwardEulerNodeSuppAlg *theMass
-          = new ScalarMassBackwardEulerNodeSuppAlg(realm_, sdr_);
-        theAlg->supplementalAlg_.push_back(theMass);
+    std::map<AlgorithmType, SolverAlgorithm *>::iterator itsi
+      = solverAlgDriver_->solverAlgMap_.find(algType);
+    if (itsi == solverAlgDriver_->solverAlgMap_.end()) {
+      SolverAlgorithm* theAlg = NULL;
+      if (realm_.realmUsesEdges_) {
+        theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
       }
       else {
-        ScalarMassBDF2NodeSuppAlg *theMass
-          = new ScalarMassBDF2NodeSuppAlg(realm_, sdr_);
-        theAlg->supplementalAlg_.push_back(theMass);
+        theAlg = new AssembleScalarElemSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
+      }
+      solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+
+      // look for fully integrated source terms
+      std::map<std::string, std::vector<std::string> >::iterator isrc
+        = realm_.solutionOptions_->elemSrcTermsMap_.find("specific_dissipation_rate");
+      if (isrc != realm_.solutionOptions_->elemSrcTermsMap_.end()) {
+
+        if (realm_.realmUsesEdges_)
+          throw std::runtime_error("SpecificDissipationElemSrcTerms::Error can not use element source terms for an edge-based scheme");
+
+        std::vector<std::string> mapNameVec = isrc->second;
+        for (size_t k = 0; k < mapNameVec.size(); ++k) {
+          std::string sourceName = mapNameVec[k];
+          SupplementalAlgorithm* suppAlg = NULL;
+          if (sourceName == "NSO_2ND_ALT") {
+            suppAlg = new ScalarNSOElemSuppAlgDep(realm_, sdr_, dwdx_, evisc_, 0.0, 1.0);
+          }
+          else if (sourceName == "NSO_4TH_ALT") {
+            suppAlg = new ScalarNSOElemSuppAlgDep(realm_, sdr_, dwdx_, evisc_, 1.0, 1.0);
+          }
+          else if (sourceName == "NSO_2ND_KE") {
+            const double turbSc = realm_.get_turb_schmidt(sdr_->name());
+            suppAlg = new ScalarNSOKeElemSuppAlg(realm_, sdr_, dwdx_, turbSc, 0.0);
+          }
+          else if (sourceName == "NSO_4TH_KE") {
+            const double turbSc = realm_.get_turb_schmidt(sdr_->name());
+            suppAlg = new ScalarNSOKeElemSuppAlg(realm_, sdr_, dwdx_, turbSc, 1.0);
+          }
+          else if (sourceName == "specific_dissipation_rate_time_derivative" ) {
+            suppAlg = new ScalarMassElemSuppAlgDep(realm_, sdr_, false);
+          }
+          else if (sourceName == "lumped_specific_dissipation_rate_time_derivative" ) {
+            suppAlg = new ScalarMassElemSuppAlgDep(realm_, sdr_, true);
+          }
+          else {
+            throw std::runtime_error("SpecificDissipationElemSrcTerms::Error Source term is not supported: " + sourceName);
+          }
+          NaluEnv::self().naluOutputP0() << "SpecificDissipationElemSrcTerms::added() " << sourceName << std::endl;
+          theAlg->supplementalAlg_.push_back(suppAlg);
+        }
       }
     }
+    else {
+      itsi->second->partVec_.push_back(part);
+    }
 
-    // now create the src alg for sdr source
-    SpecificDissipationRateSSTNodeSourceSuppAlg *theSrc
-      = new SpecificDissipationRateSSTNodeSourceSuppAlg(realm_);
-    theAlg->supplementalAlg_.push_back(theSrc);
+    // time term; src; both nodally lumped
+    const AlgorithmType algMass = MASS;
+    // Check if the user has requested CMM or LMM algorithms; if so, do not
+    // include Nodal Mass algorithms
+    std::vector<std::string> checkAlgNames = {
+      "specific_dissipation_rate_time_derivative",
+      "lumped_specific_dissipation_rate_time_derivative"};
+    bool elementMassAlg = supp_alg_is_requested(checkAlgNames);
+    std::map<AlgorithmType, SolverAlgorithm*>::iterator itsm =
+      solverAlgDriver_->solverAlgMap_.find(algMass);
+    if (itsm == solverAlgDriver_->solverAlgMap_.end()) {
+      // create the solver alg
+      AssembleNodeSolverAlgorithm *theAlg
+        = new AssembleNodeSolverAlgorithm(realm_, part, this);
+      solverAlgDriver_->solverAlgMap_[algMass] = theAlg;
 
-    // Add src term supp alg...; limited number supported
-    std::map<std::string, std::vector<std::string> >::iterator isrc 
-      = realm_.solutionOptions_->srcTermsMap_.find("specific_dissipation_rate");
-    if ( isrc != realm_.solutionOptions_->srcTermsMap_.end() ) {
-      std::vector<std::string> mapNameVec = isrc->second;   
-      for (size_t k = 0; k < mapNameVec.size(); ++k ) {
-        std::string sourceName = mapNameVec[k];
-        SupplementalAlgorithm *suppAlg = NULL;
-        if ( sourceName == "gcl" ) {
-          suppAlg = new ScalarGclNodeSuppAlg(sdr_,realm_);
+      // now create the supplemental alg for mass term
+      if (!elementMassAlg) {
+        if (realm_.number_of_states() == 2) {
+          ScalarMassBackwardEulerNodeSuppAlg *theMass
+            = new ScalarMassBackwardEulerNodeSuppAlg(realm_, sdr_);
+          theAlg->supplementalAlg_.push_back(theMass);
         }
         else {
-          throw std::runtime_error("SpecificDissipationRateNodalSrcTerms::Error Source term is not supported: " + sourceName);
+          ScalarMassBDF2NodeSuppAlg *theMass
+            = new ScalarMassBDF2NodeSuppAlg(realm_, sdr_);
+          theAlg->supplementalAlg_.push_back(theMass);
         }
-        NaluEnv::self().naluOutputP0() << "SpecificDissipationRateNodalSrcTerms::added() " << sourceName << std::endl;
-        theAlg->supplementalAlg_.push_back(suppAlg);
       }
+
+      // now create the src alg for sdr source
+      SpecificDissipationRateSSTNodeSourceSuppAlg *theSrc
+        = new SpecificDissipationRateSSTNodeSourceSuppAlg(realm_);
+      theAlg->supplementalAlg_.push_back(theSrc);
+
+      // Add src term supp alg...; limited number supported
+      std::map<std::string, std::vector<std::string> >::iterator isrc
+        = realm_.solutionOptions_->srcTermsMap_.find("specific_dissipation_rate");
+      if (isrc != realm_.solutionOptions_->srcTermsMap_.end()) {
+        std::vector<std::string> mapNameVec = isrc->second;
+        for (size_t k = 0; k < mapNameVec.size(); ++k) {
+          std::string sourceName = mapNameVec[k];
+          SupplementalAlgorithm* suppAlg = NULL;
+          if (sourceName == "gcl") {
+            suppAlg = new ScalarGclNodeSuppAlg(sdr_, realm_);
+          }
+          else {
+            throw std::runtime_error("SpecificDissipationRateNodalSrcTerms::Error Source term is not supported: " + sourceName);
+          }
+          NaluEnv::self().naluOutputP0() << "SpecificDissipationRateNodalSrcTerms::added() " << sourceName << std::endl;
+          theAlg->supplementalAlg_.push_back(suppAlg);
+        }
+      }
+    }
+    else {
+      itsm->second->partVec_.push_back(part);
     }
   }
   else {
-    itsm->second->partVec_.push_back(part);
+    // Homogeneous kernel implementation
+    if (realm_.realmUsesEdges_)
+      throw std::runtime_error("SpecificDissipationRateEquationSystem::Error can not use element source terms for an edge-based scheme");
+
+    stk::topology partTopo = part->topology();
+    auto& solverAlgMap = solverAlgDriver_->solverAlgorithmMap_;
+
+    AssembleElemSolverAlgorithm* solverAlg = nullptr;
+    bool solverAlgWasBuilt = false;
+
+    std::tie(solverAlg, solverAlgWasBuilt) =
+      build_or_add_part_to_solver_alg(*this, *part, solverAlgMap);
+
+    ElemDataRequests& dataPreReqs = solverAlg->dataNeededByKernels_;
+    auto& activeKernels = solverAlg->activeKernels_;
+
+    if (solverAlgWasBuilt) {
+      build_topo_kernel_if_requested<ScalarMassElemKernel>
+        (partTopo, *this, activeKernels, "specific_dissipation_rate_time_derivative",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dataPreReqs, false);
+
+      build_topo_kernel_if_requested<ScalarMassElemKernel>
+        (partTopo, *this, activeKernels,  "lumped_specific_dissipation_rate_time_derivative",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dataPreReqs, true);
+
+      build_topo_kernel_if_requested<ScalarAdvDiffElemKernel>
+        (partTopo, *this, activeKernels, "advection_diffusion",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, evisc_, dataPreReqs);
+
+      build_topo_kernel_if_requested<ScalarUpwAdvDiffElemKernel>
+        (partTopo, *this, activeKernels, "upw_advection_diffusion",
+        realm_.bulk_data(), *realm_.solutionOptions_, this, sdr_, dwdx_, evisc_, dataPreReqs);
+
+      build_topo_kernel_if_requested<SpecificDissipationRateSSTSrcElemKernel>
+        (partTopo, *this, activeKernels, "sst",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, false);
+
+      build_topo_kernel_if_requested<SpecificDissipationRateSSTSrcElemKernel>
+        (partTopo, *this, activeKernels, "lumped_sst",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
+
+      build_topo_kernel_if_requested<ScalarNSOElemKernel>
+        (partTopo, *this, activeKernels, "NSO_2ND",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dwdx_, evisc_, 0.0, 0.0, dataPreReqs);
+
+      build_topo_kernel_if_requested<ScalarNSOElemKernel>
+        (partTopo, *this, activeKernels, "NSO_2ND_ALT",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dwdx_, evisc_, 0.0, 1.0, dataPreReqs);
+
+      build_topo_kernel_if_requested<ScalarNSOElemKernel>
+        (partTopo, *this, activeKernels, "NSO_4TH",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dwdx_, evisc_, 1.0, 0.0, dataPreReqs);
+
+      build_topo_kernel_if_requested<ScalarNSOElemKernel>
+        (partTopo, *this, activeKernels, "NSO_4TH_ALT",
+         realm_.bulk_data(), *realm_.solutionOptions_, sdr_, dwdx_, evisc_, 1.0, 1.0, dataPreReqs);
+
+      report_invalid_supp_alg_names();
+      report_built_supp_alg_names();
+    }
   }
 
   // effective diffusive flux coefficient alg for SST

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -64,6 +64,8 @@
 #include <kernel/ScalarUpwAdvDiffElemKernel.h>
 #include <kernel/TurbKineticEnergyKsgsSrcElemKernel.h>
 #include <kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h>
+#include <kernel/TurbKineticEnergySSTSrcElemKernel.h>
+#include <kernel/TurbKineticEnergySSTDESSrcElemKernel.h>
 
 // nso
 #include <nso/ScalarNSOElemKernel.h>
@@ -418,11 +420,27 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
       build_topo_kernel_if_requested<TurbKineticEnergyKsgsSrcElemKernel>
         (partTopo, *this, activeKernels, "ksgs",
          realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs);
-      
+
       build_topo_kernel_if_requested<TurbKineticEnergyKsgsDesignOrderSrcElemKernel>
         (partTopo, *this, activeKernels, "design_order_ksgs",
          realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs);
-      
+
+      build_topo_kernel_if_requested<TurbKineticEnergySSTSrcElemKernel>
+        (partTopo, *this, activeKernels, "sst",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, false);
+
+      build_topo_kernel_if_requested<TurbKineticEnergySSTSrcElemKernel>
+        (partTopo, *this, activeKernels, "lumped_sst",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
+
+      build_topo_kernel_if_requested<TurbKineticEnergySSTDESSrcElemKernel>
+        (partTopo, *this, activeKernels, "sst_des",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, false);
+
+      build_topo_kernel_if_requested<TurbKineticEnergySSTDESSrcElemKernel>
+        (partTopo, *this, activeKernels, "lumped_sst_des",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
+
       build_topo_kernel_if_requested<ScalarNSOElemKernel>
         (partTopo, *this, activeKernels, "NSO_2ND",
          realm_.bulk_data(), *realm_.solutionOptions_, tke_, dkdx_, evisc_, 0.0, 0.0, dataPreReqs);

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -1,0 +1,207 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/SpecificDissipationRateSSTSrcElemKernel.h"
+#include "FieldTypeDef.h"
+#include "SolutionOptions.h"
+
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template <typename AlgTraits>
+SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
+  SpecificDissipationRateSSTSrcElemKernel(
+    const stk::mesh::BulkData& bulkData,
+    const SolutionOptions& solnOpts,
+    ElemDataRequests& dataPreReqs,
+    const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    betaStar_(solnOpts.get_turb_model_constant(TM_betaStar)),
+    sigmaWTwo_(solnOpts.get_turb_model_constant(TM_sigmaWTwo)),
+    betaOne_(solnOpts.get_turb_model_constant(TM_betaOne)),
+    betaTwo_(solnOpts.get_turb_model_constant(TM_betaTwo)),
+    gammaOne_(solnOpts.get_turb_model_constant(TM_gammaOne)),
+    gammaTwo_(solnOpts.get_turb_model_constant(TM_gammaTwo)),
+    tkeProdLimitRatio_(solnOpts.get_turb_model_constant(TM_tkeProdLimitRatio)),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(
+                 AlgTraits::topo_)
+                 ->ipNodeMap())
+{
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_ke");
+  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "specific_dissipation_rate");
+  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* density =
+    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
+  VectorFieldType* velocity =
+    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  tvisc_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_viscosity");
+  fOneBlend_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "sst_f_one_blending");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement* meSCV =
+    sierra::nalu::MasterElementRepo::get_volume_master_element(
+      AlgTraits::topo_);
+
+  // compute shape function
+  if (lumpedMass_)
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shifted_shape_fcn(ptr); }, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shape_fcn(ptr); }, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(
+    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(*fOneBlend_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+}
+
+template <typename AlgTraits>
+SpecificDissipationRateSSTSrcElemKernel<
+  AlgTraits>::~SpecificDissipationRateSSTSrcElemKernel()
+{
+}
+
+template <typename AlgTraits>
+void
+SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType**>& lhs,
+  SharedMemView<DoubleType*>& rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+  DoubleType w_dkdx[AlgTraits::nDim_];
+  DoubleType w_dwdx[AlgTraits::nDim_];
+
+  SharedMemView<DoubleType*>& v_tkeNp1 =
+    scratchViews.get_scratch_view_1D(*tkeNp1_);
+  SharedMemView<DoubleType*>& v_sdrNp1 =
+    scratchViews.get_scratch_view_1D(*sdrNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 =
+    scratchViews.get_scratch_view_1D(*densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNp1 =
+    scratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType*>& v_tvisc =
+    scratchViews.get_scratch_view_1D(*tvisc_);
+  SharedMemView<DoubleType*>& v_fOneBlend =
+    scratchViews.get_scratch_view_1D(*fOneBlend_);
+  SharedMemView<DoubleType***>& v_dndx =
+    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+  SharedMemView<DoubleType*>& v_scv_volume =
+    scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
+
+    // nearest node to ip
+    const int nearestNode = ipNodeMap_[ip];
+
+    // save off scvol
+    const DoubleType scV = v_scv_volume(ip);
+
+    DoubleType rho = 0.0;
+    DoubleType tke = 0.0;
+    DoubleType sdr = 0.0;
+    DoubleType tvisc = 0.0;
+    DoubleType fOneBlend = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i) {
+      w_dkdx[i] = 0.0;
+      w_dwdx[i] = 0.0;
+      for (int j = 0; j < AlgTraits::nDim_; ++j) {
+        w_dudx[i][j] = 0.0;
+      }
+    }
+
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+
+      const DoubleType r = v_shape_function_(ip, ic);
+
+      rho += r * v_densityNp1(ic);
+      tke += r * v_tkeNp1(ic);
+      sdr += r * v_sdrNp1(ic);
+      tvisc += r * v_tvisc(ic);
+      fOneBlend += r * v_fOneBlend(ic);
+
+      for (int i = 0; i < AlgTraits::nDim_; ++i) {
+        const DoubleType dni = v_dndx(ip, ic, i);
+        const DoubleType ui = v_velocityNp1(ic, i);
+        w_dkdx[i] += dni * v_tkeNp1(ic);
+        w_dwdx[i] += dni * v_sdrNp1(ic);
+        for (int j = 0; j < AlgTraits::nDim_; ++j) {
+          w_dudx[i][j] += v_dndx(ip, ic, j) * ui;
+        }
+      }
+    }
+
+    DoubleType Pk = 0.0;
+    DoubleType crossDiff = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i) {
+      crossDiff += w_dkdx[i] * w_dwdx[i];
+      for (int j = 0; j < AlgTraits::nDim_; ++j) {
+        Pk += w_dudx[i][j] * (w_dudx[i][j] + w_dudx[j][i]);
+      }
+    }
+    Pk *= tvisc;
+
+    // dissipation and production (limited)
+    DoubleType Dk = betaStar_ * rho * sdr * tke;
+    Pk = stk::math::min(Pk, tkeProdLimitRatio_ * Dk);
+
+    // start the blending and constants
+    const DoubleType om_fOneBlend = 1.0 - fOneBlend;
+    const DoubleType beta = fOneBlend * betaOne_ + om_fOneBlend * betaTwo_;
+    const DoubleType gamma = fOneBlend * gammaOne_ + om_fOneBlend * gammaTwo_;
+    const DoubleType sigmaD = 2.0 * om_fOneBlend * sigmaWTwo_;
+
+    // Pw includes 1/tvisc scaling; tvisc may be zero at a dirichlet low Re
+    // approach (clip)
+    const DoubleType Pw = gamma * rho * Pk / stk::math::max(tvisc, 1.0e-16);
+    const DoubleType Dw = beta * rho * sdr * sdr;
+    const DoubleType Sw = sigmaD * rho * crossDiff / sdr;
+
+    // assemble RHS and LHS
+    rhs(nearestNode) += (Pw - Dw + Sw) * scV;
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      lhs(nearestNode, ic) +=
+        v_shape_function_(ip, ic) *
+        (2.0 * beta * rho * sdr + stk::math::max(Sw / sdr, 0.0)) * scV;
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(SpecificDissipationRateSSTSrcElemKernel);
+
+} // namespace nalu
+} // namespace sierra

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -30,6 +30,7 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
     const bool lumpedMass)
   : Kernel(),
     lumpedMass_(lumpedMass),
+    shiftedGradOp_(solnOpts.get_shifted_grad_op("velocity")),
     betaStar_(solnOpts.get_turb_model_constant(TM_betaStar)),
     sigmaWTwo_(solnOpts.get_turb_model_constant(TM_sigmaWTwo)),
     betaOne_(solnOpts.get_turb_model_constant(TM_betaOne)),
@@ -86,7 +87,11 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
   dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
   dataPreReqs.add_gathered_nodal_field(*fOneBlend_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
-  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+  if (shiftedGradOp_)
+    dataPreReqs.add_master_element_call(
+      SCV_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
+  else
+    dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
 }
 
 template <typename AlgTraits>
@@ -119,7 +124,9 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& v_fOneBlend =
     scratchViews.get_scratch_view_1D(*fOneBlend_);
   SharedMemView<DoubleType***>& v_dndx =
-    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+    shiftedGradOp_
+      ? scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv_shifted
+      : scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
   SharedMemView<DoubleType*>& v_scv_volume =
     scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 

--- a/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
@@ -1,0 +1,198 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/TurbKineticEnergySSTDESSrcElemKernel.h"
+#include "FieldTypeDef.h"
+#include "SolutionOptions.h"
+
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template <typename AlgTraits>
+TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::
+  TurbKineticEnergySSTDESSrcElemKernel(
+    const stk::mesh::BulkData& bulkData,
+    const SolutionOptions& solnOpts,
+    ElemDataRequests& dataPreReqs,
+    const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    betaStar_(solnOpts.get_turb_model_constant(TM_betaStar)),
+    tkeProdLimitRatio_(solnOpts.get_turb_model_constant(TM_tkeProdLimitRatio)),
+    cDESke_(solnOpts.get_turb_model_constant(TM_cDESke)),
+    cDESkw_(solnOpts.get_turb_model_constant(TM_cDESkw)),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(
+                 AlgTraits::topo_)
+                 ->ipNodeMap())
+{
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_ke");
+  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "specific_dissipation_rate");
+  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* density =
+    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
+  VectorFieldType* velocity =
+    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  tvisc_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_viscosity");
+  maxLengthScale_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "sst_max_length_scale");
+  fOneBlend_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "sst_f_one_blending");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement* meSCV =
+    sierra::nalu::MasterElementRepo::get_volume_master_element(
+      AlgTraits::topo_);
+
+  // compute shape function
+  if (lumpedMass_)
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shifted_shape_fcn(ptr); }, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shape_fcn(ptr); }, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(
+    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(*maxLengthScale_, 1);
+  dataPreReqs.add_gathered_nodal_field(*fOneBlend_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+}
+
+template <typename AlgTraits>
+TurbKineticEnergySSTDESSrcElemKernel<
+  AlgTraits>::~TurbKineticEnergySSTDESSrcElemKernel()
+{
+}
+
+template <typename AlgTraits>
+void
+TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType**>& lhs,
+  SharedMemView<DoubleType*>& rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+
+  SharedMemView<DoubleType*>& v_tkeNp1 =
+    scratchViews.get_scratch_view_1D(*tkeNp1_);
+  SharedMemView<DoubleType*>& v_sdrNp1 =
+    scratchViews.get_scratch_view_1D(*sdrNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 =
+    scratchViews.get_scratch_view_1D(*densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNp1 =
+    scratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType*>& v_tvisc =
+    scratchViews.get_scratch_view_1D(*tvisc_);
+  SharedMemView<DoubleType*>& v_maxLengthScale =
+    scratchViews.get_scratch_view_1D(*maxLengthScale_);
+  SharedMemView<DoubleType*>& v_fOneBlend =
+    scratchViews.get_scratch_view_1D(*fOneBlend_);
+  SharedMemView<DoubleType***>& v_dndx =
+    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+  SharedMemView<DoubleType*>& v_scv_volume =
+    scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
+
+    // nearest node to ip
+    const int nearestNode = ipNodeMap_[ip];
+
+    // save off scvol
+    const DoubleType scV = v_scv_volume(ip);
+
+    DoubleType rho = 0.0;
+    DoubleType tke = 0.0;
+    DoubleType sdr = 0.0;
+    DoubleType tvisc = 0.0;
+    DoubleType maxLengthScale = 0.0;
+    DoubleType fOneBlend = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i)
+      for (int j = 0; j < AlgTraits::nDim_; ++j)
+        w_dudx[i][j] = 0.0;
+
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+
+      const DoubleType r = v_shape_function_(ip, ic);
+
+      rho += r * v_densityNp1(ic);
+      tke += r * v_tkeNp1(ic);
+      sdr += r * v_sdrNp1(ic);
+      tvisc += r * v_tvisc(ic);
+      maxLengthScale += r * v_maxLengthScale(ic);
+      fOneBlend += r * v_fOneBlend(ic);
+
+      for (int i = 0; i < AlgTraits::nDim_; ++i) {
+        const DoubleType ui = v_velocityNp1(ic, i);
+        for (int j = 0; j < AlgTraits::nDim_; ++j) {
+          w_dudx[i][j] += v_dndx(ip, ic, j) * ui;
+        }
+      }
+    }
+
+    DoubleType Pk = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i) {
+      for (int j = 0; j < AlgTraits::nDim_; ++j) {
+        Pk += w_dudx[i][j] * (w_dudx[i][j] + w_dudx[j][i]);
+      }
+    }
+    Pk *= tvisc;
+
+    // blend cDES
+    const DoubleType cDES = fOneBlend * cDESkw_ + (1.0 - fOneBlend) * cDESke_;
+
+    const DoubleType sqrtTke = stk::math::sqrt(tke);
+    const DoubleType lSST = sqrtTke / betaStar_ / sdr;
+    // prevent divide by zero (possible at resolved tke bcs = 0.0)
+    const DoubleType lDES =
+      stk::math::max(1.0e-16, stk::math::min(lSST, cDES * maxLengthScale));
+
+    // tke factor
+    const DoubleType tkeFac = rho * sqrtTke / lDES;
+
+    // dissipation and production (limited)
+    DoubleType Dk = tkeFac * tke;
+    Pk = stk::math::min(Pk, tkeProdLimitRatio_ * Dk);
+
+    // assemble RHS and LHS
+    rhs(nearestNode) += (Pk - Dk) * scV;
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      lhs(nearestNode, ic) += v_shape_function_(ip, ic) * tkeFac * scV;
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(TurbKineticEnergySSTDESSrcElemKernel);
+
+} // namespace nalu
+} // namespace sierra

--- a/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
@@ -1,0 +1,172 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/TurbKineticEnergySSTSrcElemKernel.h"
+#include "FieldTypeDef.h"
+#include "SolutionOptions.h"
+
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template <typename AlgTraits>
+TurbKineticEnergySSTSrcElemKernel<AlgTraits>::TurbKineticEnergySSTSrcElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    betaStar_(solnOpts.get_turb_model_constant(TM_betaStar)),
+    tkeProdLimitRatio_(solnOpts.get_turb_model_constant(TM_tkeProdLimitRatio)),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(
+                 AlgTraits::topo_)
+                 ->ipNodeMap())
+{
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_ke");
+  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "specific_dissipation_rate");
+  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
+  ScalarFieldType* density =
+    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
+  VectorFieldType* velocity =
+    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  tvisc_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "turbulent_viscosity");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement* meSCV =
+    sierra::nalu::MasterElementRepo::get_volume_master_element(
+      AlgTraits::topo_);
+
+  // compute shape function
+  if (lumpedMass_)
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shifted_shape_fcn(ptr); }, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>(
+      [&](double* ptr) { meSCV->shape_fcn(ptr); }, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(
+    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+}
+
+template <typename AlgTraits>
+TurbKineticEnergySSTSrcElemKernel<
+  AlgTraits>::~TurbKineticEnergySSTSrcElemKernel()
+{
+}
+
+template <typename AlgTraits>
+void
+TurbKineticEnergySSTSrcElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType**>& lhs,
+  SharedMemView<DoubleType*>& rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+
+  SharedMemView<DoubleType*>& v_tkeNp1 =
+    scratchViews.get_scratch_view_1D(*tkeNp1_);
+  SharedMemView<DoubleType*>& v_sdrNp1 =
+    scratchViews.get_scratch_view_1D(*sdrNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 =
+    scratchViews.get_scratch_view_1D(*densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNp1 =
+    scratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType*>& v_tvisc =
+    scratchViews.get_scratch_view_1D(*tvisc_);
+  SharedMemView<DoubleType***>& v_dndx =
+    scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+  SharedMemView<DoubleType*>& v_scv_volume =
+    scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
+
+    // nearest node to ip
+    const int nearestNode = ipNodeMap_[ip];
+
+    // save off scvol
+    const DoubleType scV = v_scv_volume(ip);
+
+    DoubleType rho = 0.0;
+    DoubleType tke = 0.0;
+    DoubleType sdr = 0.0;
+    DoubleType tvisc = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i)
+      for (int j = 0; j < AlgTraits::nDim_; ++j)
+        w_dudx[i][j] = 0.0;
+
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+
+      const DoubleType r = v_shape_function_(ip, ic);
+
+      rho += r * v_densityNp1(ic);
+      tke += r * v_tkeNp1(ic);
+      sdr += r * v_sdrNp1(ic);
+      tvisc += r * v_tvisc(ic);
+
+      for (int i = 0; i < AlgTraits::nDim_; ++i) {
+        const DoubleType ui = v_velocityNp1(ic, i);
+        for (int j = 0; j < AlgTraits::nDim_; ++j) {
+          w_dudx[i][j] += v_dndx(ip, ic, j) * ui;
+        }
+      }
+    }
+
+    DoubleType Pk = 0.0;
+    for (int i = 0; i < AlgTraits::nDim_; ++i) {
+      for (int j = 0; j < AlgTraits::nDim_; ++j) {
+        Pk += w_dudx[i][j] * (w_dudx[i][j] + w_dudx[j][i]);
+      }
+    }
+    Pk *= tvisc;
+
+    // tke factor
+    const DoubleType tkeFac = betaStar_ * rho * sdr;
+
+    // dissipation and production (limited)
+    DoubleType Dk = tkeFac * tke;
+    Pk = stk::math::min(Pk, tkeProdLimitRatio_ * Dk);
+
+    // assemble RHS and LHS
+    rhs(nearestNode) += (Pk - Dk) * scV;
+    for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      lhs(nearestNode, ic) += v_shape_function_(ip, ic) * tkeFac * scV;
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(TurbKineticEnergySSTSrcElemKernel);
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -352,6 +352,54 @@ public:
   ScalarFieldType* temperature_{nullptr};
 };
 
+/** Test Fixture for the SST Kernels
+ *
+ */
+class SSTKernelHex8Mesh : public LowMachKernelHex8Mesh
+{
+public:
+  SSTKernelHex8Mesh()
+    : LowMachKernelHex8Mesh(),
+      tke_(&meta_.declare_field<ScalarFieldType>(
+        stk::topology::NODE_RANK, "turbulent_ke")),
+      sdr_(&meta_.declare_field<ScalarFieldType>(
+        stk::topology::NODE_RANK, "specific_dissipation_rate")),
+      tvisc_(&meta_.declare_field<ScalarFieldType>(
+        stk::topology::NODE_RANK, "turbulent_viscosity")),
+      maxLengthScale_(&meta_.declare_field<ScalarFieldType>(
+        stk::topology::NODE_RANK, "sst_max_length_scale")),
+      fOneBlend_(&meta_.declare_field<ScalarFieldType>(
+        stk::topology::NODE_RANK, "sst_f_one_blending"))
+  {
+    stk::mesh::put_field(*tke_, meta_.universal_part(), 1);
+    stk::mesh::put_field(*sdr_, meta_.universal_part(), 1);
+    stk::mesh::put_field(*tvisc_, meta_.universal_part(), 1);
+    stk::mesh::put_field(*maxLengthScale_, meta_.universal_part(), 1);
+    stk::mesh::put_field(*fOneBlend_, meta_.universal_part(), 1);
+  }
+
+  virtual ~SSTKernelHex8Mesh() {}
+
+  virtual void fill_mesh_and_init_fields(bool doPerturb = false)
+  {
+    LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb);
+    stk::mesh::field_fill(0.3, *tvisc_);
+    stk::mesh::field_fill(0.5, *maxLengthScale_);
+    unit_test_kernel_utils::density_test_function(
+      bulk_, *coordinates_, *density_);
+    unit_test_kernel_utils::tke_test_function(bulk_, *coordinates_, *tke_);
+    unit_test_kernel_utils::sdr_test_function(bulk_, *coordinates_, *sdr_);
+    unit_test_kernel_utils::sst_f_one_blending_test_function(
+      bulk_, *coordinates_, *fOneBlend_);
+  }
+
+  ScalarFieldType* tke_{nullptr};
+  ScalarFieldType* sdr_{nullptr};
+  ScalarFieldType* tvisc_{nullptr};
+  ScalarFieldType* maxLengthScale_{nullptr};
+  ScalarFieldType* fOneBlend_{nullptr};
+};
+
 /** Test Fixture for the hybrid turbulence Kernels
  *
  */

--- a/unit_tests/kernels/UnitTestSSTSrcElem.C
+++ b/unit_tests/kernels/UnitTestSSTSrcElem.C
@@ -1,0 +1,288 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "kernel/TurbKineticEnergySSTSrcElemKernel.h"
+#include "kernel/TurbKineticEnergySSTDESSrcElemKernel.h"
+#include "kernel/SpecificDissipationRateSSTSrcElemKernel.h"
+
+namespace {
+namespace hex8_golds {
+namespace TurbKineticEnergySSTSrcElemKernel {
+
+static constexpr double lhs[8][8] = {
+  {
+    0.0069752671206081166, 0.0023250890402027055, 0.00077502968006756855,
+    0.0023250890402027055, 0.0023250890402027055, 0.00077502968006756855,
+    0.00025834322668918952, 0.00077502968006756855,
+  },
+  {
+    0.0017833984706739155, 0.005350195412021746, 0.0017833984706739155,
+    0.00059446615689130516, 0.00059446615689130516, 0.0017833984706739155,
+    0.00059446615689130516, 0.00019815538563043504,
+  },
+  {
+    0.00047062403152685068, 0.0014118720945805519, 0.0042356162837416562,
+    0.0014118720945805519, 0.00015687467717561689, 0.00047062403152685068,
+    0.0014118720945805519, 0.00047062403152685068,
+  },
+  {
+    0.00185533509705029, 0.00061844503235009669, 0.00185533509705029,
+    0.0055660052911508696, 0.00061844503235009669, 0.00020614834411669889,
+    0.00061844503235009669, 0.00185533509705029,
+  },
+  {
+    0.0018553350970502902, 0.0006184450323500968, 0.00020614834411669891,
+    0.0006184450323500968, 0.0055660052911508705, 0.0018553350970502902,
+    0.0006184450323500968, 0.0018553350970502902,
+  },
+  {
+    0.00047062403152685068, 0.0014118720945805519, 0.00047062403152685068,
+    0.00015687467717561689, 0.0014118720945805519, 0.0042356162837416562,
+    0.0014118720945805519, 0.00047062403152685068,
+  },
+  {
+    0.00013065390263746531, 0.00039196170791239594, 0.0011758851237371878,
+    0.00039196170791239594, 0.00039196170791239594, 0.0011758851237371878,
+    0.0035276553712115634, 0.0011758851237371878,
+  },
+  {
+    0.00052603049446954737, 0.00017534349815651577, 0.00052603049446954737,
+    0.0015780914834086419, 0.0015780914834086419, 0.00052603049446954737,
+    0.0015780914834086419, 0.0047342744502259261,
+  },
+};
+
+static constexpr double rhs[8] = {
+  -0.034715637556614845, -0.020697436813089803, -0.014471024253348201,
+  -0.026571541126838166, -0.026997836698597691, -0.014793264290619728,
+  -0.009761402630737508, -0.020407355252450767,
+};
+
+} // namespace TurbKineticEnergySSTSrcElemKernel
+
+namespace TurbKineticEnergySSTDESSrcElemKernel {
+
+static constexpr double lhs[8][8] = {
+  {
+    0.18162464537165954, 0.060541548457219853, 0.020180516152406618,
+    0.060541548457219853, 0.060541548457219853, 0.020180516152406618,
+    0.0067268387174688722, 0.020180516152406618,
+  },
+  {
+    0.045307794491460572, 0.13592338347438171, 0.045307794491460572,
+    0.01510259816382019, 0.01510259816382019, 0.045307794491460572,
+    0.01510259816382019, 0.0050341993879400634,
+  },
+  {
+    0.012383713186335632, 0.037151139559006896, 0.11145341867702067,
+    0.037151139559006896, 0.0041279043954452104, 0.012383713186335632,
+    0.037151139559006896, 0.012383713186335632,
+  },
+  {
+    0.050131830062481619, 0.016710610020827209, 0.050131830062481619,
+    0.15039549018744486, 0.016710610020827209, 0.0055702033402757357,
+    0.016710610020827209, 0.050131830062481619,
+  },
+  {
+    0.045307794491460572, 0.01510259816382019, 0.0050341993879400634,
+    0.01510259816382019, 0.13592338347438171, 0.045307794491460572,
+    0.01510259816382019, 0.045307794491460572,
+  },
+  {
+    0.01090404787216135, 0.03271214361648405, 0.01090404787216135,
+    0.0036346826240537832, 0.03271214361648405, 0.098136430849452144,
+    0.03271214361648405, 0.01090404787216135,
+  },
+  {
+    0.0029833026770613251, 0.008949908031183975, 0.026849724093551925,
+    0.008949908031183975, 0.008949908031183975, 0.026849724093551925,
+    0.080549172280655779, 0.026849724093551925,
+  },
+  {
+    0.012383713186335632, 0.0041279043954452104, 0.012383713186335632,
+    0.037151139559006896, 0.037151139559006896, 0.012383713186335632,
+    0.037151139559006896, 0.11145341867702067,
+  },
+};
+
+static constexpr double rhs[8] = {
+  -0.93004487921220791, -0.67850029644065035, -0.61831603722608175,
+  -0.88075166717605236, -0.68371348724645631, -0.48143775480877343,
+  -0.42776941006248004, -0.62144395170956546,
+};
+
+} // namespace TurbKineticEnergySSTDESSrcElemKernel
+
+namespace SpecificDissipationRateSSTSrcElemKernel {
+
+static constexpr double lhs[8][8] = {
+  {
+    0.014088352257161414, 0.0046961174190538043, 0.0015653724730179349,
+    0.0046961174190538043, 0.0046961174190538043, 0.0015653724730179349,
+    0.0005217908243393116, 0.0015653724730179349,
+  },
+  {
+    0.0034334662835608129, 0.01030039885068244, 0.0034334662835608129,
+    0.0011444887611869376, 0.0011444887611869376, 0.0034334662835608129,
+    0.0011444887611869376, 0.00038149625372897923,
+  },
+  {
+    0.00086754973541695217, 0.0026026492062508565, 0.00780794761875257,
+    0.0026026492062508565, 0.00028918324513898408, 0.00086754973541695217,
+    0.0026026492062508565, 0.00086754973541695217,
+  },
+  {
+    0.003434284360902973, 0.0011447614536343243, 0.003434284360902973,
+    0.010302853082708919, 0.0011447614536343243, 0.00038158715121144144,
+    0.0011447614536343243, 0.003434284360902973,
+  },
+  {
+    0.0040893531148636746, 0.0013631177049545581, 0.00045437256831818606,
+    0.0013631177049545581, 0.012268059344591024, 0.0040893531148636746,
+    0.0013631177049545581, 0.0040893531148636746,
+  },
+  {
+    0.00092327669310721344, 0.0027698300793216404, 0.00092327669310721344,
+    0.00030775889770240448, 0.0027698300793216404, 0.0083094902379649213,
+    0.0027698300793216404, 0.00092327669310721344,
+  },
+  {
+    0.00025058674982000032, 0.00075176024946000102, 0.0022552807483800031,
+    0.00075176024946000102, 0.00075176024946000102, 0.0022552807483800031,
+    0.0067658422451400083, 0.0022552807483800031,
+  },
+  {
+    0.0010674069479120892, 0.00035580231597069639, 0.0010674069479120892,
+    0.0032022208437362675, 0.0032022208437362675, 0.0010674069479120892,
+    0.0032022208437362675, 0.0096066625312088028,
+  },
+};
+
+static constexpr double rhs[8] = {
+  -0.0234919792716402,    -0.015488938741822928, -0.012701346228598396,
+  -0.019963104832714122,  -0.013804481873609888, -0.01064155214884124,
+  -0.0097857771214982167, -0.01451935596563356,
+};
+
+} // namespace SpecificDissipationRateSSTSrcElemKernel
+} // namespace hex8_golds
+} // anonymous namespace
+
+TEST_F(SSTKernelHex8Mesh, turbkineticenergysstsrcelem)
+{
+
+  fill_mesh_and_init_fields();
+
+  // Setup solution options
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::TurbKineticEnergySSTSrcElemKernel<
+      sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_,
+      false));
+
+  // Add to kernels to be tested
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());
+
+  helperObjs.assembleElemSolverAlg->execute();
+
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+
+  namespace gold_values = hex8_golds::TurbKineticEnergySSTSrcElemKernel;
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, gold_values::rhs);
+  unit_test_kernel_utils::expect_all_near<8>(
+    helperObjs.linsys->lhs_, gold_values::lhs);
+}
+
+TEST_F(SSTKernelHex8Mesh, turbkineticenergysstdessrcelem)
+{
+
+  fill_mesh_and_init_fields();
+
+  // Setup solution options
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::TurbKineticEnergySSTDESSrcElemKernel<
+      sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_,
+      false));
+
+  // Add to kernels to be tested
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());
+
+  helperObjs.assembleElemSolverAlg->execute();
+
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+
+  namespace gold_values = hex8_golds::TurbKineticEnergySSTDESSrcElemKernel;
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, gold_values::rhs);
+  unit_test_kernel_utils::expect_all_near<8>(
+    helperObjs.linsys->lhs_, gold_values::lhs);
+}
+
+TEST_F(SSTKernelHex8Mesh, specificdissipationratesstsrcelem)
+{
+
+  fill_mesh_and_init_fields();
+
+  // Setup solution options
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::SpecificDissipationRateSSTSrcElemKernel<
+      sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_,
+      false));
+
+  // Add to kernels to be tested
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());
+
+  helperObjs.assembleElemSolverAlg->execute();
+
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+
+  namespace gold_values = hex8_golds::SpecificDissipationRateSSTSrcElemKernel;
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, gold_values::rhs);
+  unit_test_kernel_utils::expect_all_near<8>(
+    helperObjs.linsys->lhs_, gold_values::lhs);
+}


### PR DESCRIPTION
Most of the code here has already been reviewed (a while back...) but I finally got around to running a comparison using the current CVFEM implementation and a consolidated implementation that uses the new source kernels. The comparison was done using the NASA wall hump and a sample velocity profile can be seen in this graph. Both implementations predict the same velocity fields (same goes for surface coefficients).
![u_2](https://user-images.githubusercontent.com/15038415/38880605-59007a28-4223-11e8-8241-c3aa322930e7.png)

The input files used for the comparison are the following:
- [previous implementation (using SuppAlg)](https://github.com/marchdf/wallHump/blob/master/twod/817x217/wallHump_p1.i)
- [using the new kernels (consolidated approach)](https://github.com/marchdf/wallHump/blob/master/twod/817x217/wallHump_p1_consolidated.i)

Appropriate unit tests were added for the new source kernels.
