### PR TITLE
Alter face-element algorithm looping to ensure uniform face-element

### DIFF
--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -86,24 +86,38 @@ public:
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, simdBucketLen), [&](const size_t& bktIndex)
         {
-          smdata.numSimdFaces = sierra::nalu::get_length_of_next_simd_group(bktIndex, bucketLen);
+          size_t simdGroupLen = sierra::nalu::get_length_of_next_simd_group(bktIndex, bucketLen);
+          size_t numFacesProcessed = 0;
+          do {
+            int elemFaceOrdinal = -1;
+            int simdFaceIndex = 0;
+            while((numFacesProcessed+simdFaceIndex)<simdGroupLen) {
+              stk::mesh::Entity face = b[bktIndex*simdLen + numFacesProcessed + simdFaceIndex];
+              ThrowAssertMsg(bulk.num_elements(face)==1, "Expecting just 1 element attached to face!");
+              int thisElemFaceOrdinal = bulk.begin_element_ordinals(face)[0];
 
-          for(int simdFaceIndex=0; simdFaceIndex<smdata.numSimdFaces; ++simdFaceIndex) {
-            stk::mesh::Entity face = b[bktIndex*simdLen + simdFaceIndex];
-            smdata.elemFaceOrdinals[simdFaceIndex] = bulk.begin_element_ordinals(face)[0];
-            sierra::nalu::fill_pre_req_data(faceDataNeeded_, bulk, face, *smdata.faceViews[simdFaceIndex], interleaveMeViews);
+              if (elemFaceOrdinal >= 0 && thisElemFaceOrdinal != elemFaceOrdinal) {
+                break;
+              }
 
-            const stk::mesh::Entity* elems = bulk.begin_elements(face);
-            ThrowAssertMsg(bulk.num_elements(face)==1, "Expecting just 1 element attached to face!");
-            sierra::nalu::fill_pre_req_data(elemDataNeeded_, bulk, elems[0], *smdata.elemViews[simdFaceIndex], interleaveMeViews);
-          }
-
-          copy_and_interleave(smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews, interleaveMeViews);
-          copy_and_interleave(smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews, interleaveMeViews);
-          fill_master_element_views(faceDataNeeded_, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinals[0]);
-          fill_master_element_views(elemDataNeeded_, bulk, smdata.simdElemViews, smdata.elemFaceOrdinals[0]);
-
-          lamdbaFunc(smdata);
+              smdata.elemFaceOrdinals[simdFaceIndex] = thisElemFaceOrdinal;
+              elemFaceOrdinal = thisElemFaceOrdinal;
+              sierra::nalu::fill_pre_req_data(faceDataNeeded_, bulk, face, *smdata.faceViews[simdFaceIndex], interleaveMeViews);
+  
+              const stk::mesh::Entity* elems = bulk.begin_elements(face);
+              sierra::nalu::fill_pre_req_data(elemDataNeeded_, bulk, elems[0], *smdata.elemViews[simdFaceIndex], interleaveMeViews);
+              ++simdFaceIndex;
+            }
+            smdata.numSimdFaces = simdFaceIndex;
+            numFacesProcessed += simdFaceIndex;
+  
+            copy_and_interleave(smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews, interleaveMeViews);
+            copy_and_interleave(smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews, interleaveMeViews);
+            fill_master_element_views(faceDataNeeded_, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinals[0]);
+            fill_master_element_views(elemDataNeeded_, bulk, smdata.simdElemViews, smdata.elemFaceOrdinals[0]);
+  
+            lamdbaFunc(smdata);
+          } while(numFacesProcessed < simdGroupLen);
         });
       });
   }

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -43,8 +43,7 @@ public:
         elemDataNeeded.add_gathered_nodal_field(*idField, 1);
     }
 
-    void execute(/*perhaps bundle args into something like SharedMemData... */
-                 sierra::nalu::ScratchViews<DoubleType>& faceViews,
+    void execute( sierra::nalu::ScratchViews<DoubleType>& faceViews,
                  sierra::nalu::ScratchViews<DoubleType>& elemViews,
                  int numSimdFaces,
                  const int* elemFaceOrdinals)
@@ -66,6 +65,17 @@ public:
         }
 
         ++numTimesExecuted_;
+    }
+
+    void execute(int numSimdFaces, const int* elemFaceOrdinals)
+    {
+      int elemFaceOrdinal = -1;
+      for(int i=0; i<numSimdFaces; ++i) {
+        EXPECT_TRUE(elemFaceOrdinal==-1 || elemFaceOrdinal==elemFaceOrdinals[i])<<"elemFaceOrdinals "<<elemFaceOrdinal<<" and "<<elemFaceOrdinals[i]<<" in same simd group! Not allowed.";
+        elemFaceOrdinal = elemFaceOrdinals[i];
+      }
+
+      ++numTimesExecuted_;
     }
 
     unsigned numTimesExecuted_;
@@ -113,6 +123,78 @@ TEST_F(Hex8Mesh, faceElemBasic)
 
   unsigned expectedNumFaces = 6;
   EXPECT_EQ(expectedNumFaces, faceElemKernel.numTimesExecuted_);
+}
+
+void move_face_from_surface2_to_surface3(stk::mesh::BulkData& bulk)
+{
+  stk::mesh::Part& surface2 = *bulk.mesh_meta_data().get_part("surface_2");
+  stk::mesh::Part& surface3 = *bulk.mesh_meta_data().get_part("surface_3");
+  stk::mesh::Part& surface3_q4 = *bulk.mesh_meta_data().get_part("surface_3_quad4");
+  const stk::mesh::BucketVector& s2buckets = bulk.get_buckets(stk::topology::FACE_RANK, surface2);
+  EXPECT_EQ(1u, s2buckets.size());
+  EXPECT_EQ(2u, s2buckets[0]->size());
+  stk::mesh::Entity s2face = (*s2buckets[0])[0];
+
+  bulk.modification_begin();
+  bulk.change_entity_parts(s2face, stk::mesh::ConstPartVector{&surface3, &surface3_q4}, stk::mesh::ConstPartVector{&surface2});
+  bulk.modification_end();
+
+  const stk::mesh::BucketVector& s3buckets = bulk.get_buckets(stk::topology::FACE_RANK, surface3);
+  EXPECT_EQ(1u, s3buckets.size());
+  EXPECT_EQ(3u, s3buckets[0]->size());
+
+  const stk::mesh::Bucket& faceBucket = *s3buckets[0];
+  stk::mesh::Entity firstFace = faceBucket[0];
+  stk::mesh::Entity secondFace = faceBucket[1];
+  //Each face should have just 1 attached element:
+  EXPECT_EQ(1u, bulk.num_elements(firstFace));
+  EXPECT_EQ(1u, bulk.num_elements(secondFace));
+
+  //now make sure the first two faces in the bucket have different face-elem ordinals:
+  const stk::mesh::ConnectivityOrdinal* firstFaceElemOrds = bulk.begin_element_ordinals(firstFace);
+  const stk::mesh::ConnectivityOrdinal* secondFaceElemOrds = bulk.begin_element_ordinals(secondFace);
+  EXPECT_NE(firstFaceElemOrds[0], secondFaceElemOrds[0]);
+}
+
+TEST_F(Hex8Mesh, faceElem_ordinals)
+{
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
+    return;
+  }
+  fill_mesh("generated:1x1x2|sideset:xXyYzZ");
+  verify_faces_exist(bulk);
+  fill_with_node_ids(bulk, idField);
+
+  move_face_from_surface2_to_surface3(bulk);
+
+  stk::topology faceTopo = stk::topology::QUAD_4;
+  stk::topology elemTopo = stk::topology::HEX_8;
+  sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(faceTopo);
+  sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(elemTopo);
+  sierra::nalu::MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
+
+  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  unsigned numDof = 3;
+
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, numDof, surface1);
+
+  sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
+                                                          faceTopo.num_nodes(), elemTopo.num_nodes());
+  faceElemAlg.faceDataNeeded_.add_cvfem_face_me(meFC);
+  faceElemAlg.elemDataNeeded_.add_cvfem_surface_me(meSCS);
+  faceElemAlg.elemDataNeeded_.add_cvfem_volume_me(meSCV);
+
+  TestFaceElemKernel faceElemKernel(faceTopo, elemTopo, idField,
+                                    faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
+
+  faceElemAlg.run_face_elem_algorithm(bulk,
+          [&](sierra::nalu::SharedMemData_FaceElem &smdata)
+      {
+          faceElemKernel.execute(smdata.numSimdFaces, smdata.elemFaceOrdinals);
+      });
+
+  unsigned expectedNumCalls = 8;
+  EXPECT_EQ(expectedNumCalls, faceElemKernel.numTimesExecuted_);
 }
 
 TEST_F(Hex8ElementWithBCFields, faceElemMomentumSymmetry)


### PR DESCRIPTION
ordinals in simd groups.

Our master-element and kernel implementations require that within
a simd group, all faces have the same element-ordinal.

Created a unit-test which alters a mesh to ensure at least two faces
with different element-ordinals are in the same bucket, then added
a custom kernel::execute method which checks for different ordinals
in the same simd group. Then put the corrected algorithm looping
in place to make the test pass.