### PR TITLE
Create eigenvalue decomposition as its own class

### DIFF
--- a/include/AssembleScalarEigenEdgeSolverAlgorithm.h
+++ b/include/AssembleScalarEigenEdgeSolverAlgorithm.h
@@ -24,7 +24,6 @@ namespace nalu{
 
 class Realm;
 template <typename T> class PecletFunction;
-class EigenDecomposition;
 
 class AssembleScalarEigenEdgeSolverAlgorithm : public SolverAlgorithm
 {
@@ -76,7 +75,6 @@ public:
 
   // peclect function specifics
   PecletFunction<double>* pecletFunction_;
-  EigenDecomposition eigSolver_;
 
   // constants and perturbation from user
   const double cGGDH_;

--- a/include/AssembleScalarEigenEdgeSolverAlgorithm.h
+++ b/include/AssembleScalarEigenEdgeSolverAlgorithm.h
@@ -11,6 +11,7 @@
 
 #include<SolverAlgorithm.h>
 #include<FieldTypeDef.h>
+#include<EigenDecomposition.h>
 
 namespace stk {
 namespace mesh {
@@ -23,6 +24,7 @@ namespace nalu{
 
 class Realm;
 template <typename T> class PecletFunction;
+class EigenDecomposition;
 
 class AssembleScalarEigenEdgeSolverAlgorithm : public SolverAlgorithm
 {
@@ -44,10 +46,7 @@ public:
   virtual void execute();
 
   // eignenvalue helpers
-  void diagonalize( const double (&A)[3][3], double (&Q)[3][3], double (&D)[3][3]);  
   void perturb(double (&D)[3][3]);
-  void form_perturbed_stress( const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3]);
-  void matrix_matrix_multiply( const double (&A)[3][3], const double (&B)[3][3], double (&C)[3][3]);
   void sort(const double (&D)[3][3]);
 
   double van_leer(
@@ -77,6 +76,7 @@ public:
 
   // peclect function specifics
   PecletFunction<double>* pecletFunction_;
+  EigenDecomposition eigSolver_;
 
   // constants and perturbation from user
   const double cGGDH_;

--- a/include/EigenDecomposition.h
+++ b/include/EigenDecomposition.h
@@ -8,18 +8,15 @@
 #ifndef EIGENDECOMPOSITION_H
 #define EIGENDECOMPOSITION_H
 
+#include <SimdInterface.h>
 #include <FieldTypeDef.h>
 
 namespace sierra {
 namespace nalu {
 
 class Realm;
-class EigenDecomposition
+namespace EigenDecomposition
 {
-public:
-  EigenDecomposition();
-  ~EigenDecomposition(); 
-
   void sym_diagonalize(const double (&A)[2][2], double (&Q)[2][2], double (&D)[2][2]);
   void sym_diagonalize(const double (&A)[3][3], double (&Q)[3][3], double (&D)[3][3]);
   void reconstruct_matrix_from_decomposition(const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2]);
@@ -27,7 +24,15 @@ public:
   void matrix_matrix_multiply(const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2]);
   void matrix_matrix_multiply(const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3]);
 
-};
+  // Simd solvers
+  void sym_diagonalize(const DoubleType (&A)[2][2], DoubleType (&Q)[2][2], DoubleType (&D)[2][2]);
+  void sym_diagonalize(const DoubleType (&A)[3][3], DoubleType (&Q)[3][3], DoubleType (&D)[3][3]);
+  void reconstruct_matrix_from_decomposition(const DoubleType (&D)[2][2], const DoubleType (&Q)[2][2], DoubleType (&A)[2][2]);
+  void reconstruct_matrix_from_decomposition(const DoubleType (&D)[3][3], const DoubleType (&Q)[3][3], DoubleType (&A)[3][3]);
+  void matrix_matrix_multiply(const DoubleType (&D)[2][2], const DoubleType (&Q)[2][2], DoubleType (&A)[2][2]);
+  void matrix_matrix_multiply(const DoubleType (&D)[3][3], const DoubleType (&Q)[3][3], DoubleType (&A)[3][3]);
+
+}
 
 } // namespace nalu
 } // namespace sierra

--- a/include/EigenDecomposition.h
+++ b/include/EigenDecomposition.h
@@ -1,0 +1,35 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef EIGENDECOMPOSITION_H
+#define EIGENDECOMPOSITION_H
+
+#include <FieldTypeDef.h>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+class EigenDecomposition
+{
+public:
+  EigenDecomposition();
+  ~EigenDecomposition(); 
+
+  void sym_diagonalize(const double (&A)[2][2], double (&Q)[2][2], double (&D)[2][2]);
+  void sym_diagonalize(const double (&A)[3][3], double (&Q)[3][3], double (&D)[3][3]);
+  void reconstruct_matrix_from_decomposition(const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2]);
+  void reconstruct_matrix_from_decomposition(const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3]);
+  void matrix_matrix_multiply(const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2]);
+  void matrix_matrix_multiply(const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3]);
+
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/src/AssembleScalarEigenEdgeSolverAlgorithm.C
+++ b/src/AssembleScalarEigenEdgeSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <PecletFunction.h>
 #include <Realm.h>
 #include <SolutionOptions.h>
+#include <EigenDecomposition.h>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
@@ -64,6 +65,7 @@ AssembleScalarEigenEdgeSolverAlgorithm::AssembleScalarEigenEdgeSolverAlgorithm(
     velocity_(NULL),
     dudx_(NULL),
     pecletFunction_(NULL),
+    eigSolver_(),
     cGGDH_(3.0/2.0*realm_.get_turb_model_constant(TM_cMu)/turbSigma),
     deltaB_(realm_.solutionOptions_->eigenvaluePerturbDelta_),
     perturbTurbKe_(realm_.solutionOptions_->eigenvaluePerturbTurbKe_)
@@ -86,6 +88,9 @@ AssembleScalarEigenEdgeSolverAlgorithm::AssembleScalarEigenEdgeSolverAlgorithm(
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(scalarQ_->name());
+
+  // instantiate the Eigenvalue solver
+  EigenDecomposition eigSolver_; 
 
   // initialize xic
   const int biasTowards = realm_.solutionOptions_->eigenvaluePerturbBiasTowards_;
@@ -344,9 +349,9 @@ AssembleScalarEigenEdgeSolverAlgorithm::execute()
           b_[i][j] = (-turbNuIp*(duidxj_[i][j] + duidxj_[j][i] - divUTerm))/(2.0*turbKeIp);
         }
       }
-      
+     
       // perform the decomposition
-      diagonalize(b_, Q_, D_);
+      eigSolver_.sym_diagonalize(b_, Q_, D_);
 
       // sort D
       sort(D_);
@@ -355,7 +360,7 @@ AssembleScalarEigenEdgeSolverAlgorithm::execute()
       perturb(D_);
 
       // form new stress
-      form_perturbed_stress(D_, Q_, b_);
+      eigSolver_.reconstruct_matrix_from_decomposition(D_, Q_, b_);
 
       // remove normalization; add in tke (possibly perturbed)
       const double turbKeIpPert = std::max(turbKeIp*(1.0 + perturbTurbKe_), 1.0e-16);
@@ -491,115 +496,6 @@ AssembleScalarEigenEdgeSolverAlgorithm::van_leer(
 }
 
 //--------------------------------------------------------------------------
-//-------- diagonalize -----------------------------------------------------
-//--------------------------------------------------------------------------
-void
-AssembleScalarEigenEdgeSolverAlgorithm::diagonalize(
-  const double (&A)[3][3], double (&Q)[3][3], double (&D)[3][3])
-{
-  /*
-    obtained from: 
-    http://stackoverflow.com/questions/4372224/
-    fast-method-for-computing-3x3-symmetric-matrix-spectral-decomposition
-
-    A must be a symmetric matrix.
-    returns Q and D such that 
-    Diagonal matrix D = QT * A * Q;  and  A = Q*D*QT
-  */
-
-  const int maxsteps=24;
-  int k0, k1, k2;
-  double o[3], m[3];
-  double q [4] = {0.0,0.0,0.0,1.0};
-  double jr[4];
-  double sqw, sqx, sqy, sqz;
-  double tmp1, tmp2, mq;
-  double AQ[3][3];
-  double thet, sgn, t, c;
-  for(int i=0;i < maxsteps;++i) {
-    // quat to matrix
-    sqx      = q[0]*q[0];
-    sqy      = q[1]*q[1];
-    sqz      = q[2]*q[2];
-    sqw      = q[3]*q[3];
-    Q[0][0]  = ( sqx - sqy - sqz + sqw);
-    Q[1][1]  = (-sqx + sqy - sqz + sqw);
-    Q[2][2]  = (-sqx - sqy + sqz + sqw);
-    tmp1     = q[0]*q[1];
-    tmp2     = q[2]*q[3];
-    Q[1][0]  = 2.0 * (tmp1 + tmp2);
-    Q[0][1]  = 2.0 * (tmp1 - tmp2);
-    tmp1     = q[0]*q[2];
-    tmp2     = q[1]*q[3];
-    Q[2][0]  = 2.0 * (tmp1 - tmp2);
-    Q[0][2]  = 2.0 * (tmp1 + tmp2);
-    tmp1     = q[1]*q[2];
-    tmp2     = q[0]*q[3];
-    Q[2][1]  = 2.0 * (tmp1 + tmp2);
-    Q[1][2]  = 2.0 * (tmp1 - tmp2);
-    
-    // AQ = A * Q
-    AQ[0][0] = Q[0][0]*A[0][0]+Q[1][0]*A[0][1]+Q[2][0]*A[0][2];
-    AQ[0][1] = Q[0][1]*A[0][0]+Q[1][1]*A[0][1]+Q[2][1]*A[0][2];
-    AQ[0][2] = Q[0][2]*A[0][0]+Q[1][2]*A[0][1]+Q[2][2]*A[0][2];
-    AQ[1][0] = Q[0][0]*A[0][1]+Q[1][0]*A[1][1]+Q[2][0]*A[1][2];
-    AQ[1][1] = Q[0][1]*A[0][1]+Q[1][1]*A[1][1]+Q[2][1]*A[1][2];
-    AQ[1][2] = Q[0][2]*A[0][1]+Q[1][2]*A[1][1]+Q[2][2]*A[1][2];
-    AQ[2][0] = Q[0][0]*A[0][2]+Q[1][0]*A[1][2]+Q[2][0]*A[2][2];
-    AQ[2][1] = Q[0][1]*A[0][2]+Q[1][1]*A[1][2]+Q[2][1]*A[2][2];
-    AQ[2][2] = Q[0][2]*A[0][2]+Q[1][2]*A[1][2]+Q[2][2]*A[2][2];
-    // D = Qt * AQ
-    D[0][0] = AQ[0][0]*Q[0][0]+AQ[1][0]*Q[1][0]+AQ[2][0]*Q[2][0]; 
-    D[0][1] = AQ[0][0]*Q[0][1]+AQ[1][0]*Q[1][1]+AQ[2][0]*Q[2][1]; 
-    D[0][2] = AQ[0][0]*Q[0][2]+AQ[1][0]*Q[1][2]+AQ[2][0]*Q[2][2]; 
-    D[1][0] = AQ[0][1]*Q[0][0]+AQ[1][1]*Q[1][0]+AQ[2][1]*Q[2][0]; 
-    D[1][1] = AQ[0][1]*Q[0][1]+AQ[1][1]*Q[1][1]+AQ[2][1]*Q[2][1]; 
-    D[1][2] = AQ[0][1]*Q[0][2]+AQ[1][1]*Q[1][2]+AQ[2][1]*Q[2][2]; 
-    D[2][0] = AQ[0][2]*Q[0][0]+AQ[1][2]*Q[1][0]+AQ[2][2]*Q[2][0]; 
-    D[2][1] = AQ[0][2]*Q[0][1]+AQ[1][2]*Q[1][1]+AQ[2][2]*Q[2][1]; 
-    D[2][2] = AQ[0][2]*Q[0][2]+AQ[1][2]*Q[1][2]+AQ[2][2]*Q[2][2];
-    o[0]    = D[1][2];
-    o[1]    = D[0][2];
-    o[2]    = D[0][1];
-    m[0]    = std::abs(o[0]);
-    m[1]    = std::abs(o[1]);
-    m[2]    = std::abs(o[2]);
-    
-    k0      = (m[0] > m[1] && m[0] > m[2])?0: (m[1] > m[2])? 1 : 2; // index of largest element of offdiag
-    k1      = (k0+1)%3;
-    k2      = (k0+2)%3;
-    if (o[k0]==0.0) {
-      break;  // diagonal already
-    }
-    thet    = (D[k2][k2]-D[k1][k1])/(2.0*o[k0]);
-    sgn     = (thet > 0.0)?1.0:-1.0;
-    thet   *= sgn; // make it positive
-    t       = sgn /(thet +((thet < 1.E6)? std::sqrt(thet*thet+1.0):thet)) ; // sign(T)/(|T|+sqrt(T^2+1))
-    c       = 1.0/std::sqrt(t*t+1.0); //  c= 1/(t^2+1) , t=s/c 
-    if(c==1.0) {
-      break;  // no room for improvement - reached machine precision.
-    }
-    jr[0 ]  = jr[1] = jr[2] = jr[3] = 0.0;
-    jr[k0]  = sgn*std::sqrt((1.0-c)/2.0);  // using 1/2 angle identity sin(a/2) = std::sqrt((1-cos(a))/2)  
-    jr[k0] *= -1.0; // since our quat-to-matrix convention was for v*M instead of M*v
-    jr[3 ]  = std::sqrt(1.0f - jr[k0] * jr[k0]);
-    if(jr[3]==1.0) {
-      break; // reached limits of floating point precision
-    }
-    q[0]    = (q[3]*jr[0] + q[0]*jr[3] + q[1]*jr[2] - q[2]*jr[1]);
-    q[1]    = (q[3]*jr[1] - q[0]*jr[2] + q[1]*jr[3] + q[2]*jr[0]);
-    q[2]    = (q[3]*jr[2] + q[0]*jr[1] - q[1]*jr[0] + q[2]*jr[3]);
-    q[3]    = (q[3]*jr[3] - q[0]*jr[0] - q[1]*jr[1] - q[2]*jr[2]);
-    mq      = std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
-    q[0]   /= mq;
-    q[1]   /= mq;
-    q[2]   /= mq;
-    q[3]   /= mq;
-  }
-}
-
-
-//--------------------------------------------------------------------------
 //-------- sort ------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
@@ -653,49 +549,6 @@ AssembleScalarEigenEdgeSolverAlgorithm::perturb(
   D[rowMap_[0]][rowMap_[0]] = pLamdba1;
   D[rowMap_[1]][rowMap_[1]] = pLamdba2;
   D[rowMap_[2]][rowMap_[2]] = pLamdba3;
-}
-
-//--------------------------------------------------------------------------
-//-------- form_perturbed_stress -------------------------------------------
-//--------------------------------------------------------------------------
-void
-AssembleScalarEigenEdgeSolverAlgorithm::form_perturbed_stress(
-  const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3])
-{
-  // A = Q*D*QT
-  double QT[3][3];
-  double B[3][3];
-
-  // compute QT
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
-      QT[j][i] = Q[i][j];	
-    }
-  }
-  //mat-vec, B = Q*D
-  matrix_matrix_multiply(Q,D,B);
-
-  // mat-vec, A = (Q*D)*QT = B*QT
-  matrix_matrix_multiply(B,QT,A);
-}
-
-//--------------------------------------------------------------------------
-//-------- matrix_matrix_multiply ------------------------------------------
-//--------------------------------------------------------------------------
-void
-AssembleScalarEigenEdgeSolverAlgorithm::matrix_matrix_multiply(
-  const double (&A)[3][3], const double (&B)[3][3], double (&C)[3][3])
-{
-  //C = A*B
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      double sum = 0;
-      for (int k = 0; k < 3; ++k) {
-        sum = sum + A[i][k] * B[k][j];
-      }
-      C[i][j] = sum;
-    }
-  }
 }
 
 } // namespace nalu

--- a/src/EigenDecomposition.C
+++ b/src/EigenDecomposition.C
@@ -1,0 +1,275 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <EigenDecomposition.h>
+#include <NaluParsing.h>
+
+// basic c++
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// EigenDecomposition -- Computes an eigenvalue decomposition and other
+//                    -- related functionality
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+EigenDecomposition::EigenDecomposition() 
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+EigenDecomposition::~EigenDecomposition()
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- symmetric diagonalize (2D) --------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::sym_diagonalize(
+  const double (&A)[2][2], double (&Q)[2][2], double (&D)[2][2])
+{
+  // Note that A must be symmetric here
+  const double trace = A[0][0] + A[1][1];
+  const double det = A[0][0]*A[1][1] - A[0][1]*A[1][0];
+
+  // calculate eigenvalues
+  D[0][0] = trace/2.0 + std::sqrt(trace*trace/4.0 - det);
+  D[1][1] = trace/2.0 - std::sqrt(trace*trace/4.0 - det);
+  D[0][1] = 0.0;
+  D[1][0] = 0.0;
+
+  //calculate first eigenvector
+  Q[0][0] = -A[0][1];
+  Q[1][0] =  A[0][0] - D[0][0];
+
+  double norm = std::sqrt(Q[0][0]*Q[0][0] + Q[1][0]*Q[1][0]);
+  Q[0][0] = Q[0][0]/norm;
+  Q[1][0] = Q[1][0]/norm;
+
+  // calculate second eigenvector
+  Q[0][1] = -A[1][1] + D[1][1];
+  Q[1][1] =  A[1][0];
+
+  norm = std::sqrt(Q[0][1]*Q[0][1] + Q[1][1]*Q[1][1]);
+  Q[0][1] = Q[0][1]/norm;
+  Q[1][1] = Q[1][1]/norm;
+
+  // special case when off diagonal entries were 0, we already had a diagonal matrix
+  Q[0][0] = (A[1][0] == 0.0) ? 1.0 : Q[0][0];
+  Q[0][1] = (A[1][0] == 0.0) ? 0.0 : Q[0][1];
+  Q[1][0] = (A[1][0] == 0.0) ? 0.0 : Q[1][0];
+  Q[1][1] = (A[1][0] == 0.0) ? 1.0 : Q[1][1];
+}
+
+//--------------------------------------------------------------------------
+//-------- reconstruct_matrix_from_decomposition ---------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::reconstruct_matrix_from_decomposition(
+  const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2])
+{
+  // A = Q*D*QT
+  double QT[2][2];
+  double B[2][2];
+
+  // compute QT
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 2; j++) {
+      QT[j][i] = Q[i][j];
+    }
+  }
+  //mat-vec, B = Q*D
+  matrix_matrix_multiply(Q,D,B);
+
+  // mat-vec, A = (Q*D)*QT = B*QT
+  matrix_matrix_multiply(B,QT,A);
+}
+
+//--------------------------------------------------------------------------
+//-------- matrix_matrix_multiply ------------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::matrix_matrix_multiply(
+  const double (&A)[2][2], const double (&B)[2][2], double (&C)[2][2])
+{
+  //C = A*B
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      double sum = 0;
+      for (int k = 0; k < 2; ++k) {
+        sum = sum + A[i][k] * B[k][j];
+      }
+      C[i][j] = sum;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- symmetric diagonalize (3D) --------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::sym_diagonalize(
+  const double (&A)[3][3], double (&Q)[3][3], double (&D)[3][3])
+{
+  /*
+    obtained from: 
+    http://stackoverflow.com/questions/4372224/
+    fast-method-for-computing-3x3-symmetric-matrix-spectral-decomposition
+
+    A must be a symmetric matrix.
+    returns Q and D such that 
+    Diagonal matrix D = QT * A * Q;  and  A = Q*D*QT
+  */
+
+  const int maxsteps=24;
+  int k0, k1, k2;
+  double o[3], m[3];
+  double q [4] = {0.0,0.0,0.0,1.0};
+  double jr[4];
+  double sqw, sqx, sqy, sqz;
+  double tmp1, tmp2, mq;
+  double AQ[3][3];
+  double thet, sgn, t, c;
+  for(int i=0;i < maxsteps;++i) {
+    // quat to matrix
+    sqx      = q[0]*q[0];
+    sqy      = q[1]*q[1];
+    sqz      = q[2]*q[2];
+    sqw      = q[3]*q[3];
+    Q[0][0]  = ( sqx - sqy - sqz + sqw);
+    Q[1][1]  = (-sqx + sqy - sqz + sqw);
+    Q[2][2]  = (-sqx - sqy + sqz + sqw);
+    tmp1     = q[0]*q[1];
+    tmp2     = q[2]*q[3];
+    Q[1][0]  = 2.0 * (tmp1 + tmp2);
+    Q[0][1]  = 2.0 * (tmp1 - tmp2);
+    tmp1     = q[0]*q[2];
+    tmp2     = q[1]*q[3];
+    Q[2][0]  = 2.0 * (tmp1 - tmp2);
+    Q[0][2]  = 2.0 * (tmp1 + tmp2);
+    tmp1     = q[1]*q[2];
+    tmp2     = q[0]*q[3];
+    Q[2][1]  = 2.0 * (tmp1 + tmp2);
+    Q[1][2]  = 2.0 * (tmp1 - tmp2);
+
+    // AQ = A * Q
+    AQ[0][0] = Q[0][0]*A[0][0]+Q[1][0]*A[0][1]+Q[2][0]*A[0][2];
+    AQ[0][1] = Q[0][1]*A[0][0]+Q[1][1]*A[0][1]+Q[2][1]*A[0][2];
+    AQ[0][2] = Q[0][2]*A[0][0]+Q[1][2]*A[0][1]+Q[2][2]*A[0][2];
+    AQ[1][0] = Q[0][0]*A[0][1]+Q[1][0]*A[1][1]+Q[2][0]*A[1][2];
+    AQ[1][1] = Q[0][1]*A[0][1]+Q[1][1]*A[1][1]+Q[2][1]*A[1][2];
+    AQ[1][2] = Q[0][2]*A[0][1]+Q[1][2]*A[1][1]+Q[2][2]*A[1][2];
+    AQ[2][0] = Q[0][0]*A[0][2]+Q[1][0]*A[1][2]+Q[2][0]*A[2][2];
+    AQ[2][1] = Q[0][1]*A[0][2]+Q[1][1]*A[1][2]+Q[2][1]*A[2][2];
+    AQ[2][2] = Q[0][2]*A[0][2]+Q[1][2]*A[1][2]+Q[2][2]*A[2][2];
+    // D = Qt * AQ
+    D[0][0] = AQ[0][0]*Q[0][0]+AQ[1][0]*Q[1][0]+AQ[2][0]*Q[2][0];
+    D[0][1] = AQ[0][0]*Q[0][1]+AQ[1][0]*Q[1][1]+AQ[2][0]*Q[2][1];
+    D[0][2] = AQ[0][0]*Q[0][2]+AQ[1][0]*Q[1][2]+AQ[2][0]*Q[2][2];
+    D[1][0] = AQ[0][1]*Q[0][0]+AQ[1][1]*Q[1][0]+AQ[2][1]*Q[2][0];
+    D[1][1] = AQ[0][1]*Q[0][1]+AQ[1][1]*Q[1][1]+AQ[2][1]*Q[2][1];
+    D[1][2] = AQ[0][1]*Q[0][2]+AQ[1][1]*Q[1][2]+AQ[2][1]*Q[2][2];
+    D[2][0] = AQ[0][2]*Q[0][0]+AQ[1][2]*Q[1][0]+AQ[2][2]*Q[2][0];
+    D[2][1] = AQ[0][2]*Q[0][1]+AQ[1][2]*Q[1][1]+AQ[2][2]*Q[2][1];
+    D[2][2] = AQ[0][2]*Q[0][2]+AQ[1][2]*Q[1][2]+AQ[2][2]*Q[2][2];
+    o[0]    = D[1][2];
+    o[1]    = D[0][2];
+    o[2]    = D[0][1];
+    m[0]    = std::abs(o[0]);
+    m[1]    = std::abs(o[1]);
+    m[2]    = std::abs(o[2]);
+
+    k0      = (m[0] > m[1] && m[0] > m[2])?0: (m[1] > m[2])? 1 : 2; // index of largest element of offdiag
+    k1      = (k0+1)%3;
+    k2      = (k0+2)%3;
+    if (o[k0]==0.0) {
+      break;  // diagonal already
+    }
+    thet    = (D[k2][k2]-D[k1][k1])/(2.0*o[k0]);
+    sgn     = (thet > 0.0)?1.0:-1.0;
+    thet   *= sgn; // make it positive
+    t       = sgn /(thet +((thet < 1.E6)? std::sqrt(thet*thet+1.0):thet)) ; // sign(T)/(|T|+sqrt(T^2+1))
+    c       = 1.0/std::sqrt(t*t+1.0); //  c= 1/(t^2+1) , t=s/c 
+    if(c==1.0) {
+      break;  // no room for improvement - reached machine precision.
+    }
+    jr[0 ]  = jr[1] = jr[2] = jr[3] = 0.0;
+    jr[k0]  = sgn*std::sqrt((1.0-c)/2.0);  // using 1/2 angle identity sin(a/2) = std::sqrt((1-cos(a))/2)  
+    jr[k0] *= -1.0; // since our quat-to-matrix convention was for v*M instead of M*v
+    jr[3 ]  = std::sqrt(1.0f - jr[k0] * jr[k0]);
+    if(jr[3]==1.0) {
+      break; // reached limits of floating point precision
+    }
+    q[0]    = (q[3]*jr[0] + q[0]*jr[3] + q[1]*jr[2] - q[2]*jr[1]);
+    q[1]    = (q[3]*jr[1] - q[0]*jr[2] + q[1]*jr[3] + q[2]*jr[0]);
+    q[2]    = (q[3]*jr[2] + q[0]*jr[1] - q[1]*jr[0] + q[2]*jr[3]);
+    q[3]    = (q[3]*jr[3] - q[0]*jr[0] - q[1]*jr[1] - q[2]*jr[2]);
+    mq      = std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    q[0]   /= mq;
+    q[1]   /= mq;
+    q[2]   /= mq;
+    q[3]   /= mq;
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- reconstruct_matrix_from_decomposition ---------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::reconstruct_matrix_from_decomposition(
+  const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3])
+{
+  // A = Q*D*QT
+  double QT[3][3];
+  double B[3][3];
+
+  // compute QT
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      QT[j][i] = Q[i][j];
+    }
+  }
+  //mat-vec, B = Q*D
+  matrix_matrix_multiply(Q,D,B);
+
+  // mat-vec, A = (Q*D)*QT = B*QT
+  matrix_matrix_multiply(B,QT,A);
+}
+
+//--------------------------------------------------------------------------
+//-------- matrix_matrix_multiply ------------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::matrix_matrix_multiply(
+  const double (&A)[3][3], const double (&B)[3][3], double (&C)[3][3])
+{
+  //C = A*B
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      double sum = 0;
+      for (int k = 0; k < 3; ++k) {
+        sum = sum + A[i][k] * B[k][j];
+      }
+      C[i][j] = sum;
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/EigenDecomposition.C
+++ b/src/EigenDecomposition.C
@@ -9,33 +9,13 @@
 #include <EigenDecomposition.h>
 #include <NaluParsing.h>
 
+#include <SimdInterface.h>
+
 // basic c++
 #include <stdexcept>
 
 namespace sierra{
 namespace nalu{
-
-//==========================================================================
-// Class Definition
-//==========================================================================
-// EigenDecomposition -- Computes an eigenvalue decomposition and other
-//                    -- related functionality
-//==========================================================================
-//--------------------------------------------------------------------------
-//-------- constructor -----------------------------------------------------
-//--------------------------------------------------------------------------
-EigenDecomposition::EigenDecomposition() 
-{
-  // does nothing
-}
-
-//--------------------------------------------------------------------------
-//-------- destructor ------------------------------------------------------
-//--------------------------------------------------------------------------
-EigenDecomposition::~EigenDecomposition()
-{
-  // nothing to do
-}
 
 //--------------------------------------------------------------------------
 //-------- symmetric diagonalize (2D) --------------------------------------
@@ -78,7 +58,7 @@ EigenDecomposition::sym_diagonalize(
 }
 
 //--------------------------------------------------------------------------
-//-------- reconstruct_matrix_from_decomposition ---------------------------
+//-------- reconstruct_matrix_from_decomposition 2D ------------------------
 //--------------------------------------------------------------------------
 void
 EigenDecomposition::reconstruct_matrix_from_decomposition(
@@ -102,7 +82,7 @@ EigenDecomposition::reconstruct_matrix_from_decomposition(
 }
 
 //--------------------------------------------------------------------------
-//-------- matrix_matrix_multiply ------------------------------------------
+//-------- matrix_matrix_multiply 2D ---------------------------------------
 //--------------------------------------------------------------------------
 void
 EigenDecomposition::matrix_matrix_multiply(
@@ -229,7 +209,7 @@ EigenDecomposition::sym_diagonalize(
 }
 
 //--------------------------------------------------------------------------
-//-------- reconstruct_matrix_from_decomposition ---------------------------
+//-------- reconstruct_matrix_from_decomposition 3D ------------------------
 //--------------------------------------------------------------------------
 void
 EigenDecomposition::reconstruct_matrix_from_decomposition(
@@ -253,7 +233,7 @@ EigenDecomposition::reconstruct_matrix_from_decomposition(
 }
 
 //--------------------------------------------------------------------------
-//-------- matrix_matrix_multiply ------------------------------------------
+//-------- matrix_matrix_multiply 3D ---------------------------------------
 //--------------------------------------------------------------------------
 void
 EigenDecomposition::matrix_matrix_multiply(
@@ -270,6 +250,267 @@ EigenDecomposition::matrix_matrix_multiply(
     }
   }
 }
+
+//--------------------------------------------------------------------------
+//------------- SIMD solvers -----------------------------------------------
+//--------------------------------------------------------------------------
+
+//--------------------------------------------------------------------------
+//-------- symmetric diagonalize (2D) --------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::sym_diagonalize(
+  const DoubleType (&A)[2][2], DoubleType (&Q)[2][2], DoubleType (&D)[2][2])
+{
+  // Note that A must be symmetric here
+  const DoubleType trace = A[0][0] + A[1][1];
+  const DoubleType det = A[0][0]*A[1][1] - A[0][1]*A[1][0];
+
+  // calculate eigenvalues
+  D[0][0] = trace/2.0 + stk::math::sqrt(trace*trace/4.0 - det);
+  D[1][1] = trace/2.0 - stk::math::sqrt(trace*trace/4.0 - det);
+  D[0][1] = 0.0;
+  D[1][0] = 0.0;
+
+  //calculate first eigenvector
+  Q[0][0] = -A[0][1];
+  Q[1][0] =  A[0][0] - D[0][0];
+
+  DoubleType norm = stk::math::sqrt(Q[0][0]*Q[0][0] + Q[1][0]*Q[1][0]);
+  Q[0][0] = Q[0][0]/norm;
+  Q[1][0] = Q[1][0]/norm;
+
+  // calculate second eigenvector
+  Q[0][1] = -A[1][1] + D[1][1];
+  Q[1][1] =  A[1][0];
+
+  norm = stk::math::sqrt(Q[0][1]*Q[0][1] + Q[1][1]*Q[1][1]);
+  Q[0][1] = Q[0][1]/norm;
+  Q[1][1] = Q[1][1]/norm;
+
+  // special case when off diagonal entries were 0, we already had a diagonal matrix
+  Q[0][0] = stk::math::if_then_else(A[1][0] == 0.0, 1.0, Q[0][0]);
+  Q[0][1] = stk::math::if_then_else(A[1][0] == 0.0, 0.0, Q[0][1]);
+  Q[1][0] = stk::math::if_then_else(A[1][0] == 0.0, 0.0, Q[1][0]);
+  Q[1][1] = stk::math::if_then_else(A[1][0] == 0.0, 1.0, Q[1][1]);
+}
+
+//--------------------------------------------------------------------------
+//-------- reconstruct_matrix_from_decomposition 2D ------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::reconstruct_matrix_from_decomposition(
+  const DoubleType (&D)[2][2], const DoubleType (&Q)[2][2], DoubleType (&A)[2][2])
+{
+  // A = Q*D*QT
+  DoubleType QT[2][2];
+  DoubleType B[2][2];
+
+  // compute QT
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 2; j++) {
+      QT[j][i] = Q[i][j];
+    }
+  }
+  //mat-vec, B = Q*D
+  matrix_matrix_multiply(Q,D,B);
+
+  // mat-vec, A = (Q*D)*QT = B*QT
+  matrix_matrix_multiply(B,QT,A);
+}
+
+//--------------------------------------------------------------------------
+//-------- matrix_matrix_multiply 2D ---------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::matrix_matrix_multiply(
+  const DoubleType (&A)[2][2], const DoubleType (&B)[2][2], DoubleType (&C)[2][2])
+{
+  //C = A*B
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 2; ++j) {
+      DoubleType sum = 0;
+      for (int k = 0; k < 2; ++k) {
+        sum = sum + A[i][k] * B[k][j];
+      }
+      C[i][j] = sum;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- symmetric diagonalize (3D) --------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::sym_diagonalize(
+  const DoubleType (&A)[3][3], DoubleType (&Q)[3][3], DoubleType (&D)[3][3])
+{
+  /*
+    obtained from: 
+    http://stackoverflow.com/questions/4372224/
+    fast-method-for-computing-3x3-symmetric-matrix-spectral-decomposition
+
+    A must be a symmetric matrix.
+    returns Q and D such that 
+    Diagonal matrix D = QT * A * Q;  and  A = Q*D*QT
+  */
+
+  const int maxsteps=24;
+  DoubleType o[3], m[3];
+  DoubleType q [4] = {0.0,0.0,0.0,1.0};
+  DoubleType jr[4];
+  DoubleType sqw, sqx, sqy, sqz;
+  DoubleType tmp1, tmp2, mq;
+  DoubleType AQ[3][3];
+  DoubleType thet, sgn, t, c;
+
+  DoubleType jrL, oLarge, lIndex, dDiff;
+
+  for(int i = 0; i < maxsteps; ++i) {
+    // quat to matrix
+    sqx      = q[0]*q[0];
+    sqy      = q[1]*q[1];
+    sqz      = q[2]*q[2];
+    sqw      = q[3]*q[3];
+    Q[0][0]  = ( sqx - sqy - sqz + sqw);
+    Q[1][1]  = (-sqx + sqy - sqz + sqw);
+    Q[2][2]  = (-sqx - sqy + sqz + sqw);
+    tmp1     = q[0]*q[1];
+    tmp2     = q[2]*q[3];
+    Q[1][0]  = 2.0 * (tmp1 + tmp2);
+    Q[0][1]  = 2.0 * (tmp1 - tmp2);
+    tmp1     = q[0]*q[2];
+    tmp2     = q[1]*q[3];
+    Q[2][0]  = 2.0 * (tmp1 - tmp2);
+    Q[0][2]  = 2.0 * (tmp1 + tmp2);
+    tmp1     = q[1]*q[2];
+    tmp2     = q[0]*q[3];
+    Q[2][1]  = 2.0 * (tmp1 + tmp2);
+    Q[1][2]  = 2.0 * (tmp1 - tmp2);
+
+    // AQ = A * Q
+    AQ[0][0] = Q[0][0]*A[0][0]+Q[1][0]*A[0][1]+Q[2][0]*A[0][2];
+    AQ[0][1] = Q[0][1]*A[0][0]+Q[1][1]*A[0][1]+Q[2][1]*A[0][2];
+    AQ[0][2] = Q[0][2]*A[0][0]+Q[1][2]*A[0][1]+Q[2][2]*A[0][2];
+    AQ[1][0] = Q[0][0]*A[0][1]+Q[1][0]*A[1][1]+Q[2][0]*A[1][2];
+    AQ[1][1] = Q[0][1]*A[0][1]+Q[1][1]*A[1][1]+Q[2][1]*A[1][2];
+    AQ[1][2] = Q[0][2]*A[0][1]+Q[1][2]*A[1][1]+Q[2][2]*A[1][2];
+    AQ[2][0] = Q[0][0]*A[0][2]+Q[1][0]*A[1][2]+Q[2][0]*A[2][2];
+    AQ[2][1] = Q[0][1]*A[0][2]+Q[1][1]*A[1][2]+Q[2][1]*A[2][2];
+    AQ[2][2] = Q[0][2]*A[0][2]+Q[1][2]*A[1][2]+Q[2][2]*A[2][2];
+    // D = Qt * AQ
+    D[0][0] = AQ[0][0]*Q[0][0]+AQ[1][0]*Q[1][0]+AQ[2][0]*Q[2][0];
+    D[0][1] = AQ[0][0]*Q[0][1]+AQ[1][0]*Q[1][1]+AQ[2][0]*Q[2][1];
+    D[0][2] = AQ[0][0]*Q[0][2]+AQ[1][0]*Q[1][2]+AQ[2][0]*Q[2][2];
+    D[1][0] = AQ[0][1]*Q[0][0]+AQ[1][1]*Q[1][0]+AQ[2][1]*Q[2][0];
+    D[1][1] = AQ[0][1]*Q[0][1]+AQ[1][1]*Q[1][1]+AQ[2][1]*Q[2][1];
+    D[1][2] = AQ[0][1]*Q[0][2]+AQ[1][1]*Q[1][2]+AQ[2][1]*Q[2][2];
+    D[2][0] = AQ[0][2]*Q[0][0]+AQ[1][2]*Q[1][0]+AQ[2][2]*Q[2][0];
+    D[2][1] = AQ[0][2]*Q[0][1]+AQ[1][2]*Q[1][1]+AQ[2][2]*Q[2][1];
+    D[2][2] = AQ[0][2]*Q[0][2]+AQ[1][2]*Q[1][2]+AQ[2][2]*Q[2][2];
+    o[0]    = D[1][2];
+    o[1]    = D[0][2];
+    o[2]    = D[0][1];
+    m[0]    = stk::math::abs(o[0]);
+    m[1]    = stk::math::abs(o[1]);
+    m[2]    = stk::math::abs(o[2]);
+
+    // index of largest element of offdiag
+    oLarge  = stk::math::if_then_else((m[0] > m[1]) && (m[0] > m[2]), D[1][2], 0.0);
+    oLarge  = stk::math::if_then_else((m[1] > m[2]) && (m[1] > m[0]), D[0][2], oLarge);
+    oLarge  = stk::math::if_then_else((m[2] > m[1]) && (m[2] > m[0]), D[0][1], oLarge);
+
+    dDiff   = stk::math::if_then_else((m[0] > m[1]) && (m[0] > m[2]), D[2][2] - D[1][1], 0.0);
+    dDiff   = stk::math::if_then_else((m[1] > m[2]) && (m[1] > m[0]), D[0][0] - D[2][2], dDiff);
+    dDiff   = stk::math::if_then_else((m[2] > m[1]) && (m[2] > m[0]), D[1][1] - D[0][0], dDiff);
+
+    // if oLarge == 0.0, then we are already diagonal
+    // we need to be able to divide by thet, so set to 1.0 temporarily and 
+    // catch c at the end and correct it to 1 to handle the diagonal case
+    thet = stk::math::if_then_else(oLarge == 0.0, 1.0, (dDiff)/(2.0*oLarge));
+    sgn  = stk::math::if_then_else(thet > 0.0, 1.0, -1.0);
+    thet = thet * sgn;
+    // sign(T)/(|T|+sqrt(T^2+1))
+    t    = stk::math::if_then_else(thet < 1.E6, sgn/(thet + stk::math::sqrt(thet*thet+1.0)), 0.5*sgn/thet);
+    c    = stk::math::if_then_else(oLarge == 0.0, 1.0, 1.0/stk::math::sqrt(t*t+1.0));
+
+    // using 1/2 angle identity sin(a/2) = std::sqrt((1-cos(a))/2)
+    // -1.0 since our quat-to-matrix convention was for v*M instead of M*v
+    jr[0] = stk::math::if_then_else((m[0] > m[1]) && (m[0] > m[2]), -1.0 * (sgn*stk::math::sqrt((1.0-c)/2.0)), 0.0); 
+    jr[1] = stk::math::if_then_else((m[1] > m[2]) && (m[1] > m[0]), -1.0 * (sgn*stk::math::sqrt((1.0-c)/2.0)), 0.0);
+    jr[2] = stk::math::if_then_else((m[2] > m[1]) && (m[2] > m[0]), -1.0 * (sgn*stk::math::sqrt((1.0-c)/2.0)), 0.0);
+
+    jrL = stk::math::if_then_else((m[0] > m[1]) && (m[0] > m[2]), jr[0], 0.0);
+    jrL = stk::math::if_then_else((m[1] > m[2]) && (m[1] > m[0]), jr[1], jrL);
+    jrL = stk::math::if_then_else((m[2] > m[1]) && (m[2] > m[0]), jr[2], jrL);
+
+    jr[3] = stk::math::sqrt(1.0f - jrL * jrL);
+
+    // FIXME: Is there a better way to deal with the exit condition than having to hack to examine
+    //        each object in the SIMD array.  Maybe some sort of max/min operation?
+    int cnt = 0;
+    for(int simdIndex=0; simdIndex<simdLen; ++simdIndex)
+      if (stk::simd::get_data(jr[3], simdIndex) == 1.0) cnt++;
+
+    if(cnt == simdLen) {
+      break; // reached limits of floating point precision
+    }
+
+    q[0]    = (q[3]*jr[0] + q[0]*jr[3] + q[1]*jr[2] - q[2]*jr[1]);
+    q[1]    = (q[3]*jr[1] - q[0]*jr[2] + q[1]*jr[3] + q[2]*jr[0]);
+    q[2]    = (q[3]*jr[2] + q[0]*jr[1] - q[1]*jr[0] + q[2]*jr[3]);
+    q[3]    = (q[3]*jr[3] - q[0]*jr[0] - q[1]*jr[1] - q[2]*jr[2]);
+    mq      = stk::math::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    q[0]   /= mq;
+    q[1]   /= mq;
+    q[2]   /= mq;
+    q[3]   /= mq;
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- reconstruct_matrix_from_decomposition 3D ------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::reconstruct_matrix_from_decomposition(
+  const DoubleType (&D)[3][3], const DoubleType (&Q)[3][3], DoubleType (&A)[3][3])
+{
+  // A = Q*D*QT
+  DoubleType QT[3][3];
+  DoubleType B[3][3];
+
+  // compute QT
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      QT[j][i] = Q[i][j];
+    }
+  }
+  //mat-vec, B = Q*D
+  matrix_matrix_multiply(Q,D,B);
+
+  // mat-vec, A = (Q*D)*QT = B*QT
+  matrix_matrix_multiply(B,QT,A);
+}
+
+//--------------------------------------------------------------------------
+//-------- matrix_matrix_multiply 3D ---------------------------------------
+//--------------------------------------------------------------------------
+void
+EigenDecomposition::matrix_matrix_multiply(
+  const DoubleType (&A)[3][3], const DoubleType (&B)[3][3], DoubleType (&C)[3][3])
+{
+  //C = A*B
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      DoubleType sum = 0;
+      for (int k = 0; k < 3; ++k) {
+        sum = sum + A[i][k] * B[k][j];
+      }
+      C[i][j] = sum;
+    }
+  }
+}
+
 
 } // namespace nalu
 } // namespace Sierra

--- a/unit_tests/UnitTestEigenDecomposition.C
+++ b/unit_tests/UnitTestEigenDecomposition.C
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+#include <limits>
+#include <random>
+#include <stdexcept>
+
+#include "EigenDecomposition.h"
+
+// NGP-based includes
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
+#include "UnitTestUtils.h"
+
+
+#include <stk_util/parallel/Parallel.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Bucket.hpp>
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+
+#include <master_element/MasterElement.h>
+
+#include <fstream>
+
+
+
+namespace {
+
+    std::random_device rd; 
+    std::mt19937 rng(rd());
+    std::uniform_real_distribution<double> rand(0.0, 1.0);
+ 
+    double a11 = rand(rng);
+    double a22 = rand(rng);
+    double a33 = rand(rng);
+    double a12 = rand(rng);
+    double a13 = rand(rng);
+    double a23 = rand(rng);
+
+static double A3d_rand[3][3] = {
+  {a11, a12, a13}, {a12, a22, a23}, {a13, a23, a33},
+};
+
+static double A3d_fixed[3][3] = {
+  {0.0562500000000000,  0.1875000000000000,  0.0125000000000000},
+  {0.1875000000000000,  0.0093750000000000, -0.4218750000000000},
+  {0.0125000000000000, -0.4218750000000000,  0.0031250000000000},
+};
+
+static double A2d_rand[2][2] = {
+  {a11, a12}, {a12, a22},
+};
+
+static double A2d_fixed[2][2] = {
+  { 0.0562500000000000, -0.0187500000000000},  
+  {-0.018750000000000,   0.0093750000000000}, 
+};
+
+} // namespace
+
+// This tests whether the correct eigenvalues are obtained 
+TEST(TestEigen, testeigendecomp3d)
+{
+  double Q_[3][3], D_[3][3];
+
+  sierra::nalu::EigenDecomposition eigSolver;
+  eigSolver.sym_diagonalize(A3d_fixed, Q_, D_);
+
+  // Perform tests -- lambda evaluated in Mathematica
+  const double tol = 1e-15;
+  const double lambda_gold[3] = {
+      0.056736539229635605, 0.46782517604126655, -0.45581171527090225};
+
+  for (unsigned j = 0 ; j < 3; ++j) {
+    EXPECT_NEAR(D_[j][j], lambda_gold[j], tol);
+  }
+}
+
+TEST(TestEigen, testeigendecomp2d)
+{
+  double Q_[2][2], D_[2][2];
+
+  sierra::nalu::EigenDecomposition eigSolver;
+  eigSolver.sym_diagonalize(A2d_fixed, Q_, D_);
+
+  // Perform tests -- lambda evaluated in Mathematica
+  const double tol = 1e-15;
+  const double lambda_gold[2] = {
+      0.06282714486296648, 0.0027978551370335227};
+
+  for (unsigned j = 0; j < 2; ++j) {
+    EXPECT_NEAR(D_[j][j], lambda_gold[j], tol);
+  }
+}
+
+// This tests that the eignevalue decomposition and reconstruction
+// returns the original matrix
+TEST(TestEigen, testeigendecompandreconstruct3d)
+{
+  double b_[3][3], Q_[3][3], D_[3][3];
+
+  sierra::nalu::EigenDecomposition eigSolver;
+  eigSolver.sym_diagonalize(A3d_rand, Q_, D_);
+  eigSolver.reconstruct_matrix_from_decomposition(D_, Q_, b_);
+
+  // Perform tests
+  const double tol = 1e-15;
+
+  // Reconstructed matrix should be within tol of original
+  for (unsigned j = 0 ; j < 3; ++j) {
+    for (unsigned i = 0; i < 3; ++i) {
+      EXPECT_NEAR(b_[i][j], A3d_rand[i][j], tol);
+    }
+  }
+}
+
+// This tests that the eignevalue decomposition and reconstruction
+// returns the original matrix
+TEST(TestEigen, testeigendecompandreconstruct2d)
+{
+  double b_[2][2], Q_[2][2], D_[2][2];
+
+  sierra::nalu::EigenDecomposition eigSolver;
+  eigSolver.sym_diagonalize(A2d_rand, Q_, D_);
+  eigSolver.reconstruct_matrix_from_decomposition(D_, Q_, b_);
+
+  // Perform tests
+  const double tol = 1e-15;
+  
+  // Reconstructed matrix should be within tol of original
+  for (unsigned j = 0 ; j < 2; ++j) {
+    for (unsigned i = 0; i < 2; ++i) {
+      EXPECT_NEAR(b_[i][j], A2d_rand[i][j], tol);
+    }
+  }
+}
+

--- a/unit_tests/UnitTestEigenDecomposition.C
+++ b/unit_tests/UnitTestEigenDecomposition.C
@@ -40,6 +40,10 @@ namespace {
     double a13 = rand(rng);
     double a23 = rand(rng);
 
+    double b11 = rand(rng);
+    double b22 = rand(rng);
+    double b33 = rand(rng);
+
 static double A3d_rand[3][3] = {
   {a11, a12, a13}, {a12, a22, a23}, {a13, a23, a33},
 };
@@ -59,6 +63,11 @@ static double A2d_fixed[2][2] = {
   {-0.018750000000000,   0.0093750000000000}, 
 };
 
+DoubleType A3d_rand_simd[3][3];
+DoubleType A3d_fixed_simd[3][3];
+DoubleType A2d_rand_simd[2][2];
+DoubleType A2d_fixed_simd[2][2];
+
 } // namespace
 
 // This tests whether the correct eigenvalues are obtained 
@@ -66,8 +75,7 @@ TEST(TestEigen, testeigendecomp3d)
 {
   double Q_[3][3], D_[3][3];
 
-  sierra::nalu::EigenDecomposition eigSolver;
-  eigSolver.sym_diagonalize(A3d_fixed, Q_, D_);
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A3d_fixed, Q_, D_);
 
   // Perform tests -- lambda evaluated in Mathematica
   const double tol = 1e-15;
@@ -83,8 +91,7 @@ TEST(TestEigen, testeigendecomp2d)
 {
   double Q_[2][2], D_[2][2];
 
-  sierra::nalu::EigenDecomposition eigSolver;
-  eigSolver.sym_diagonalize(A2d_fixed, Q_, D_);
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A2d_fixed, Q_, D_);
 
   // Perform tests -- lambda evaluated in Mathematica
   const double tol = 1e-15;
@@ -102,9 +109,8 @@ TEST(TestEigen, testeigendecompandreconstruct3d)
 {
   double b_[3][3], Q_[3][3], D_[3][3];
 
-  sierra::nalu::EigenDecomposition eigSolver;
-  eigSolver.sym_diagonalize(A3d_rand, Q_, D_);
-  eigSolver.reconstruct_matrix_from_decomposition(D_, Q_, b_);
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A3d_rand, Q_, D_);
+  sierra::nalu::EigenDecomposition::reconstruct_matrix_from_decomposition(D_, Q_, b_);
 
   // Perform tests
   const double tol = 1e-15;
@@ -123,9 +129,8 @@ TEST(TestEigen, testeigendecompandreconstruct2d)
 {
   double b_[2][2], Q_[2][2], D_[2][2];
 
-  sierra::nalu::EigenDecomposition eigSolver;
-  eigSolver.sym_diagonalize(A2d_rand, Q_, D_);
-  eigSolver.reconstruct_matrix_from_decomposition(D_, Q_, b_);
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A2d_rand, Q_, D_);
+  sierra::nalu::EigenDecomposition::reconstruct_matrix_from_decomposition(D_, Q_, b_);
 
   // Perform tests
   const double tol = 1e-15;
@@ -137,4 +142,149 @@ TEST(TestEigen, testeigendecompandreconstruct2d)
     }
   }
 }
+
+
+// SIMD tests
+
+// This tests whether the correct eigenvalues are obtained 
+TEST(TestEigen, testeigendecomp3d_simd)
+{
+  DoubleType Q_[3][3], D_[3][3];
+
+  // Initialize matrices
+  for (unsigned j = 0; j < stk::simd::ndoubles; ++j) {
+    A3d_fixed_simd[0][0]._data[j] = A3d_fixed[0][0]*(j + 1);
+    A3d_fixed_simd[0][1]._data[j] = A3d_fixed[0][1]*(j + 1);
+    A3d_fixed_simd[0][2]._data[j] = A3d_fixed[0][2]*(j + 1);
+    A3d_fixed_simd[1][1]._data[j] = A3d_fixed[1][1]*(j + 1);
+    A3d_fixed_simd[1][2]._data[j] = A3d_fixed[1][2]*(j + 1);
+    A3d_fixed_simd[2][2]._data[j] = A3d_fixed[2][2]*(j + 1);
+  }
+  A3d_fixed_simd[1][0] = A3d_fixed_simd[0][1];
+  A3d_fixed_simd[2][0] = A3d_fixed_simd[0][2];
+  A3d_fixed_simd[2][1] = A3d_fixed_simd[1][2];
+ 
+
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A3d_fixed_simd, Q_, D_);
+
+  // Perform tests -- lambda evaluated in Mathematica
+  const double tol = 1e-15;
+  const double lambda_gold[3] = {
+      0.056736539229635605, 0.46782517604126655, -0.45581171527090225};
+
+  for (unsigned j = 0; j < 3; ++j) {
+    for (unsigned is = 0; is < stk::simd::ndoubles; is++) {
+      EXPECT_NEAR(stk::simd::get_data(D_[j][j], is), (is+1)*lambda_gold[j], tol);
+    }
+  }
+}
+
+TEST(TestEigen, testeigendecomp2d_simd)
+{
+  DoubleType Q_[2][2], D_[2][2];
+
+  // Initialize matrices
+  for (unsigned j = 0; j < stk::simd::ndoubles; ++j) {
+    A2d_fixed_simd[0][0]._data[j] = A2d_fixed[0][0]*(j + 1);
+    A2d_fixed_simd[0][1]._data[j] = A2d_fixed[0][1]*(j + 1);
+    A2d_fixed_simd[1][1]._data[j] = A2d_fixed[1][1]*(j + 1);
+  }
+  A2d_fixed_simd[1][0] = A2d_fixed_simd[0][1];
+
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A2d_fixed_simd, Q_, D_);
+
+  // Perform tests -- lambda evaluated in Mathematica
+  const double tol = 1e-15;
+  const double lambda_gold[2] = {
+      0.06282714486296648, 0.0027978551370335227};
+
+  for (unsigned j = 0; j < 2; ++j) {
+    for (unsigned is = 0; is < stk::simd::ndoubles; is++) {
+      EXPECT_NEAR(stk::simd::get_data(D_[j][j], is), (is+1)*lambda_gold[j], tol);
+    }
+  }
+}
+
+// This tests that the eigenvalue decomposition and reconstruction
+// returns the original matrix
+TEST(TestEigen, testeigendecompandreconstruct3d_simd)
+{
+  DoubleType b_[3][3], Q_[3][3], D_[3][3];
+
+  // Initialize matrices
+  for (unsigned j = 0; j < stk::simd::ndoubles; ++j) {
+    if (j % 2 == 0) {
+      A3d_rand_simd[0][0]._data[j] = a11*(j + 1);
+      A3d_rand_simd[0][1]._data[j] = a12*(j + 1);
+      A3d_rand_simd[0][2]._data[j] = a13*(j + 1);
+      A3d_rand_simd[1][1]._data[j] = a22*(j + 1);
+      A3d_rand_simd[1][2]._data[j] = a23*(j + 1);
+      A3d_rand_simd[2][2]._data[j] = a33*(j + 1);
+    }
+    // Test if some of the simd entries are already diagonal
+    else {
+      A3d_rand_simd[0][0]._data[j] = b11*(j + 1);
+      A3d_rand_simd[0][1]._data[j] = 0.0;
+      A3d_rand_simd[0][2]._data[j] = 0.0;
+      A3d_rand_simd[1][1]._data[j] = b22*(j + 1);
+      A3d_rand_simd[1][2]._data[j] = 0.0;
+      A3d_rand_simd[2][2]._data[j] = b33*(j + 1);
+    }
+  }
+  A3d_rand_simd[1][0] = A3d_rand_simd[0][1];
+  A3d_rand_simd[2][0] = A3d_rand_simd[0][2];
+  A3d_rand_simd[2][1] = A3d_rand_simd[1][2];
+
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A3d_rand_simd, Q_, D_);
+  sierra::nalu::EigenDecomposition::reconstruct_matrix_from_decomposition(D_, Q_, b_);
+
+  // Perform tests
+  const double tol = 1e-15;
+
+  // Reconstructed matrix should be within tol of original
+  for (unsigned j = 0; j < 3; ++j) {
+    for (unsigned i = 0; i < 3; ++i) {
+      for (unsigned is = 0; is < stk::simd::ndoubles; is++) {
+        EXPECT_NEAR(stk::simd::get_data(b_[i][j], is), stk::simd::get_data(A3d_rand_simd[i][j], is), tol);
+      }
+    }
+  }
+}
+
+TEST(TestEigen, testeigendecompandreconstruct2d_simd)
+{
+  DoubleType b_[2][2], Q_[2][2], D_[2][2];
+
+  // Initialize matrices
+  for (unsigned j = 0; j < stk::simd::ndoubles; ++j) {
+    if (j % 2 == 0) {
+      A2d_rand_simd[0][0]._data[j] = a11*(j + 1);
+      A2d_rand_simd[0][1]._data[j] = a12*(j + 1);
+      A2d_rand_simd[1][1]._data[j] = a22*(j + 1);
+    }
+    // Test if some of the simd entries are already diagonal
+    else {
+      A2d_rand_simd[0][0]._data[j] = b11*(j + 1);
+      A2d_rand_simd[0][1]._data[j] = 0.0;
+      A2d_rand_simd[1][1]._data[j] = b22*(j + 1);
+    }
+  }
+  A2d_rand_simd[1][0] = A2d_rand_simd[0][1];
+
+  sierra::nalu::EigenDecomposition::sym_diagonalize(A2d_rand_simd, Q_, D_);
+  sierra::nalu::EigenDecomposition::reconstruct_matrix_from_decomposition(D_, Q_, b_);
+
+  // Perform tests
+  const double tol = 1e-15;
+
+  // Reconstructed matrix should be within tol of original
+  for (unsigned j = 0 ; j < 2; ++j) {
+    for (unsigned i = 0; i < 2; ++i) {
+      for (unsigned is = 0; is < stk::simd::ndoubles; is++) {
+        EXPECT_NEAR(stk::simd::get_data(b_[i][j], is), stk::simd::get_data(A2d_rand_simd[i][j], is), tol);
+      }
+    }
+  }
+}
+
 


### PR DESCRIPTION
Extracted the eigenvalue decomposition from the AssembleScalarEigenEdgeSolverAlgorithm and created a separate EigenDecomposition class to handle this.  This will allow additional units, such as those involved with the new Hybrid model to have access to the EVD solver.

I also created unit tests for the EVD solvers.  

To test the implementation, I ran the ablNetural reg test and added the below to solution options to force it to invoke the EigenEdgeSolverAlgorithm and verified my solution was unchanged with the included code modifications.

eigenvalue_perturbation: yes

I didn't find any existing unit tests or reg tests that tested AssembleScalarEigenEdgeSolverAlgorithm, if there is one, please let me know and I will run it against that.  Thanks.