### PR TITLE
Restrict SST kernel tests to nprocs = 1

### DIFF
--- a/unit_tests/kernels/UnitTestSSTSrcElem.C
+++ b/unit_tests/kernels/UnitTestSSTSrcElem.C
@@ -179,6 +179,9 @@ static constexpr double rhs[8] = {
 TEST_F(SSTKernelHex8Mesh, turbkineticenergysstsrcelem)
 {
 
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
+    return;
+
   fill_mesh_and_init_fields();
 
   // Setup solution options
@@ -216,6 +219,9 @@ TEST_F(SSTKernelHex8Mesh, turbkineticenergysstsrcelem)
 TEST_F(SSTKernelHex8Mesh, turbkineticenergysstdessrcelem)
 {
 
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
+    return;
+
   fill_mesh_and_init_fields();
 
   // Setup solution options
@@ -252,6 +258,9 @@ TEST_F(SSTKernelHex8Mesh, turbkineticenergysstdessrcelem)
 
 TEST_F(SSTKernelHex8Mesh, specificdissipationratesstsrcelem)
 {
+
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
+    return;
 
   fill_mesh_and_init_fields();
 


### PR DESCRIPTION
These tests use 3D tests functions (functions with z-component
dependence). Running the unit tests with nproc > 1, results in the
kernels being evaluated on elements with different z-coordinates,
thereby diffing with the gold values. As is done with other tests,
this commit restricts these tests to run only when nprocs < 1.

This addresses comments in #366.