### PR TITLE
Towards the penalty approach for element-based open.

### DIFF
--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -101,7 +101,7 @@ public:
               }
 
               smdata.connectedNodes[simdFaceIndex] = bulk.begin_nodes(face);
-              smdata.elemFaceOrdinals[simdFaceIndex] = thisElemFaceOrdinal;
+              smdata.elemFaceOrdinal = thisElemFaceOrdinal;
               elemFaceOrdinal = thisElemFaceOrdinal;
               sierra::nalu::fill_pre_req_data(faceDataNeeded_, bulk, face, *smdata.faceViews[simdFaceIndex], interleaveMeViews);
   
@@ -114,8 +114,8 @@ public:
   
             copy_and_interleave(smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews, interleaveMeViews);
             copy_and_interleave(smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews, interleaveMeViews);
-            fill_master_element_views(faceDataNeeded_, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinals[0]);
-            fill_master_element_views(elemDataNeeded_, bulk, smdata.simdElemViews, smdata.elemFaceOrdinals[0]);
+            fill_master_element_views(faceDataNeeded_, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinal);
+            fill_master_element_views(elemDataNeeded_, bulk, smdata.simdElemViews, smdata.elemFaceOrdinal);
   
             lamdbaFunc(smdata);
           } while(numFacesProcessed < simdGroupLen);

--- a/include/ComputeMdotElemOpenPenaltyAlgorithm.h
+++ b/include/ComputeMdotElemOpenPenaltyAlgorithm.h
@@ -1,0 +1,53 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef ComputeMdotElemOpenPenaltyAlgorithm_h
+#define ComputeMdotElemOpenPenaltyAlgorithm_h
+
+#include<Algorithm.h>
+#include<FieldTypeDef.h>
+
+// stk
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class ComputeMdotElemOpenPenaltyAlgorithm : public Algorithm
+{
+public:
+
+  ComputeMdotElemOpenPenaltyAlgorithm(
+    Realm &realm,
+    stk::mesh::Part *part);
+  ~ComputeMdotElemOpenPenaltyAlgorithm();
+
+  void execute();
+
+  VectorFieldType *velocityRTM_;
+  VectorFieldType *Gpdx_;
+  VectorFieldType *coordinates_;
+  ScalarFieldType *pressure_;
+  ScalarFieldType *density_;
+  GenericFieldType *exposedAreaVec_;
+  GenericFieldType *openMassFlowRate_;
+  ScalarFieldType *pressureBc_;
+
+  const double interpTogether_;
+  const double om_interpTogether_;
+  const bool shiftMdot_;
+  const bool shiftedGradOp_;
+  const double stabFac_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -64,7 +64,7 @@ public:
 
   virtual void register_open_bc(
     stk::mesh::Part *part,
-    const stk::topology &theTopo,
+    const stk::topology &partTopo,
     const OpenBoundaryConditionData &openBCData);
 
   virtual void register_surface_pp_algorithm(
@@ -139,12 +139,12 @@ public:
 
   virtual void register_wall_bc(
     stk::mesh::Part *part,
-    const stk::topology &theTopo,
+    const stk::topology &partTopo,
     const WallBoundaryConditionData &wallBCData);
     
   virtual void register_symmetry_bc(
     stk::mesh::Part *part,
-    const stk::topology &theTopo,
+    const stk::topology &partTopo,
     const SymmetryBoundaryConditionData &symmetryBCData);
 
   virtual void register_non_conformal_bc(
@@ -219,7 +219,7 @@ public:
 
   virtual void register_open_bc(
     stk::mesh::Part *part,
-    const stk::topology &theTopo,
+    const stk::topology &partTopo,
     const OpenBoundaryConditionData &openBCData);
 
   virtual void register_wall_bc(

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -78,7 +78,7 @@ struct SharedMemData_FaceElem {
 
     const stk::mesh::Entity* connectedNodes[simdLen];
     int numSimdFaces;
-    int elemFaceOrdinals[simdLen];
+    int elemFaceOrdinal;
     std::unique_ptr<ScratchViews<double>> faceViews[simdLen];
     std::unique_ptr<ScratchViews<double>> elemViews[simdLen];
     ScratchViews<DoubleType> simdFaceViews;

--- a/include/kernel/ContinuityOpenElemKernel.h
+++ b/include/kernel/ContinuityOpenElemKernel.h
@@ -5,13 +5,8 @@
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 
-#ifndef ScalarOpenAdvElemKernel_h
-#define ScalarOpenAdvElemKernel_h
-
-#include "master_element/MasterElement.h"
-
-// scratch space
-#include "ScratchViews.h"
+#ifndef ContinuityOpenElemKernel_h
+#define ContinuityOpenElemKernel_h
 
 #include "kernel/Kernel.h"
 #include "FieldTypeDef.h"
@@ -24,30 +19,27 @@
 namespace sierra {
 namespace nalu {
 
-class ElemDataRequests;
-class EquationSystem;
-class MasterElement;
-template <typename T> class PecletFunction;
 class SolutionOptions;
+class ElemDataRequests;
+class MasterElement;
 
-/** Symmetry kernel for scalar equation
+/** specificed open bc (face/elem) kernel for continuity equation (pressure DOF)
  */
 template<typename BcAlgTraits>
-class ScalarOpenAdvElemKernel: public Kernel
+class ContinuityOpenElemKernel: public Kernel
 {
 public:
-  ScalarOpenAdvElemKernel(
+  ContinuityOpenElemKernel(
     const stk::mesh::MetaData &metaData,
     const SolutionOptions &solnOpts,
-    EquationSystem* eqSystem,  
-    ScalarFieldType *scalarQ,
-    ScalarFieldType *bcScalarQ,
-    VectorFieldType *Gjq,
-    ScalarFieldType *diffFluxCoeff,
     ElemDataRequests &faceDataPreReqs,
     ElemDataRequests &elemDataPreReqs);
 
-  virtual ~ScalarOpenAdvElemKernel();
+  virtual ~ContinuityOpenElemKernel();
+
+  /** Perform pre-timestep work for the computational kernel
+   */
+  virtual void setup(const TimeIntegrator&);
 
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
@@ -60,35 +52,32 @@ public:
     int elemFaceOrdinal);
 
 private:
-  ScalarOpenAdvElemKernel() = delete;
+  ContinuityOpenElemKernel() = delete;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *bcScalarQ_{nullptr};
-  VectorFieldType *Gjq_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
   VectorFieldType *velocityRTM_{nullptr};
+  VectorFieldType *Gpdx_{nullptr};
   VectorFieldType *coordinates_{nullptr};
+  ScalarFieldType *pressure_{nullptr};
+  ScalarFieldType *pressureBc_{nullptr};
   ScalarFieldType *density_{nullptr};
-  GenericFieldType *openMassFlowRate_{nullptr};
+  GenericFieldType *exposedAreaVec_{nullptr};
+
+  double projTimeScale_{1.0};
+  const double mdotCorrection_{0.0};
+  const double penaltyFac_{2.0};
   
-  // numerical parameters
-  const double alphaUpw_;
-  const double om_alphaUpw_;
-  const double hoUpwind_;
-  const double small_{1.0e-16};
-
-  // Integration point to node mapping and master element for interior
-  const int *faceIpNodeMap_{nullptr};
+  const bool shiftedGradOp_;
+  const bool reducedSensitivities_;
+  const double pstabFac_;
+  const double interpTogether_;
+  const double om_interpTogether_;
   MasterElement *meSCS_{nullptr};
-
-  // Peclet function
-  PecletFunction<DoubleType> *pecletFunction_{nullptr};
-
+  
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
+  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
 };
 
 }  // nalu
 }  // sierra
 
-#endif /* ScalarOpenAdvElemKernel_h */
+#endif /* MOMENTUMSYMMETRYELEMKERNEL_H */

--- a/include/kernel/Kernel.h
+++ b/include/kernel/Kernel.h
@@ -119,7 +119,8 @@ public:
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,
     ScratchViews<DoubleType> &faceScratchViews,
-    ScratchViews<DoubleType> &elemScratchViews)
+    ScratchViews<DoubleType> &elemScratchViews,
+    int elemFaceOrdinal)
   {}
 };
 

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -55,7 +55,8 @@ public:
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,
     ScratchViews<DoubleType> &faceScratchViews,
-    ScratchViews<DoubleType> &elemScratchViews);
+    ScratchViews<DoubleType> &elemScratchViews,
+    int elemFaceOrdinal);
 
 private:
   MomentumOpenAdvDiffElemKernel() = delete;

--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -46,7 +46,8 @@ public:
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,
     ScratchViews<DoubleType> &faceScratchViews,
-    ScratchViews<DoubleType> &elemScratchViews);
+    ScratchViews<DoubleType> &elemScratchViews,
+    int elemFaceOrdinal);
 
 private:
   MomentumSymmetryElemKernel() = delete;

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -92,7 +92,7 @@ AssembleFaceElemSolverAlgorithm::execute()
         set_zero(smdata.simdlhs.data(), smdata.simdlhs.size());
 
         for (auto kernel : activeKernels_)
-          kernel->execute( smdata.simdlhs, smdata.simdrhs, smdata.simdFaceViews, smdata.simdElemViews );
+          kernel->execute( smdata.simdlhs, smdata.simdrhs, smdata.simdFaceViews, smdata.simdElemViews, smdata.elemFaceOrdinal );
 
         for(int simdIndex=0; simdIndex<smdata.numSimdFaces; ++simdIndex) {
           extract_vector_lane(smdata.simdrhs, simdIndex, smdata.rhs);

--- a/src/ComputeMdotElemOpenPenaltyAlgorithm.C
+++ b/src/ComputeMdotElemOpenPenaltyAlgorithm.C
@@ -1,0 +1,337 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+// nalu
+#include "ComputeMdotElemOpenPenaltyAlgorithm.h"
+#include "Algorithm.h"
+
+#include "FieldTypeDef.h"
+#include "Realm.h"
+#include "SolutionOptions.h"
+#include "master_element/MasterElement.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ComputeMdotElemOpenPenaltyAlgorithm - mdot continuity open bc
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+ComputeMdotElemOpenPenaltyAlgorithm::ComputeMdotElemOpenPenaltyAlgorithm(
+  Realm &realm,
+  stk::mesh::Part *part)
+  : Algorithm(realm, part),
+    velocityRTM_(NULL),
+    Gpdx_(NULL),
+    coordinates_(NULL),
+    pressure_(NULL),
+    density_(NULL),
+    exposedAreaVec_(NULL),
+    pressureBc_(NULL),
+    interpTogether_(realm_.get_mdot_interp()),
+    om_interpTogether_(1.0 - interpTogether_),
+    shiftMdot_(realm_.get_cvfem_shifted_mdot()),
+    shiftedGradOp_(realm_.get_shifted_grad_op("pressure")),
+    stabFac_(2.0)
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  if ( realm_.does_mesh_move() )
+    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+  else
+    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
+  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, realm_.solutionOptions_->activateOpenMdotCorrection_ ? "pressure" : "pressure_bc");
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+ComputeMdotElemOpenPenaltyAlgorithm::~ComputeMdotElemOpenPenaltyAlgorithm()
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ComputeMdotElemOpenPenaltyAlgorithm::execute()
+{
+
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+  
+  // extract global algorithm options, if active
+  const double pstabFac = realm_.solutionOptions_->activateOpenMdotCorrection_ 
+    ? 0.0
+    : 1.0;
+
+  // ip values; both boundary and opposing surface
+  std::vector<double> uBip(nDim);
+  std::vector<double> rho_uBip(nDim);
+  std::vector<double> GpdxBip(nDim);
+  std::vector<double> dpdxBip(nDim);
+
+  // pointers to fixed values
+  double *p_uBip = &uBip[0];
+  double *p_rho_uBip = &rho_uBip[0];
+  double *p_GpdxBip = &GpdxBip[0];
+  double *p_dpdxBip = &dpdxBip[0];
+
+  // nodal fields to gather
+  std::vector<double> ws_coordinates;
+  std::vector<double> ws_face_pressure;
+  std::vector<double> ws_pressure;
+  std::vector<double> ws_vrtm;
+  std::vector<double> ws_Gpdx;
+  std::vector<double> ws_density;
+  std::vector<double> ws_bcPressure;
+
+  // master element
+  std::vector<double> ws_face_shape_function;
+  std::vector<double> ws_dndx; 
+  std::vector<double> ws_det_j;
+
+  // time step; scale projection time scale by pstabFac (no divide by here)
+  const double dt = realm_.get_time_step();
+  const double gamma1 = realm_.get_gamma1();
+  const double projTimeScale = dt/gamma1*pstabFac;
+
+  // set accumulation variables
+  double mdotOpen = 0.0;
+  size_t mdotOpenIpCount = 0;
+
+  // deal with state
+  ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
+
+  // define vector of parent topos; should always be UNITY in size
+  std::vector<stk::topology> parentTopo;
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    &stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets( meta_data.side_rank(), s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+        ib != face_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    // extract connected element topology
+    b.parent_topology(stk::topology::ELEMENT_RANK, parentTopo);
+    ThrowAssert ( parentTopo.size() == 1 );
+    stk::topology theElemTopo = parentTopo[0];
+
+    // volume master element
+    MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(theElemTopo);
+    const int nodesPerElement = meSCS->nodesPerElement_;
+   
+    // face master element
+    MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(b.topology());
+    const int nodesPerFace = b.topology().num_nodes();
+    const int numScsBip = meFC->numIntPoints_;
+
+    // algorithm related; element (exposed face and element)
+    ws_coordinates.resize(nodesPerElement*nDim);
+    ws_face_pressure.resize(nodesPerFace);
+    ws_pressure.resize(nodesPerElement);
+    ws_vrtm.resize(nodesPerFace*nDim);
+    ws_Gpdx.resize(nodesPerFace*nDim);
+    ws_density.resize(nodesPerFace);
+    ws_bcPressure.resize(nodesPerFace);
+    ws_face_shape_function.resize(numScsBip*nodesPerFace);
+    ws_dndx.resize(nDim*numScsBip*nodesPerElement);
+    ws_det_j.resize(numScsBip);    
+
+    // pointers
+    double *p_coordinates = &ws_coordinates[0];
+    double *p_face_pressure = &ws_face_pressure[0];
+    double *p_pressure = &ws_pressure[0];
+    double *p_vrtm = &ws_vrtm[0];
+    double *p_Gpdx = &ws_Gpdx[0];
+    double *p_density = &ws_density[0];
+    double *p_bcPressure = &ws_bcPressure[0];
+    double *p_face_shape_function = &ws_face_shape_function[0];
+    double *p_dndx = &ws_dndx[0];
+
+    // shape functions; boundary
+    if ( shiftMdot_ )
+      meFC->shifted_shape_fcn(&p_face_shape_function[0]);
+    else
+      meFC->shape_fcn(&p_face_shape_function[0]);
+    
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    mdotOpenIpCount += length*numScsBip;
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // get face
+      stk::mesh::Entity face = b[k];
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
+      // sanity check on num nodes
+      ThrowAssert( num_face_nodes == nodesPerFace );
+      for ( int ni = 0; ni < num_face_nodes; ++ni ) {
+        stk::mesh::Entity node = face_node_rels[ni];
+
+        // gather scalars
+        p_face_pressure[ni]    = *stk::mesh::field_data(*pressure_, node);
+        p_bcPressure[ni] = *stk::mesh::field_data(*pressureBc_, node);
+        p_density[ni]    = *stk::mesh::field_data(densityNp1, node);
+
+        // gather vectors
+        double * vrtm = stk::mesh::field_data(*velocityRTM_, node);
+        double * Gjp = stk::mesh::field_data(*Gpdx_, node);
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_vrtm[offSet+j] = vrtm[j];
+          p_Gpdx[offSet+j] = Gjp[j];
+        }
+      }
+
+      // pointer to face data
+      const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+      double * mdot = stk::mesh::field_data(*openMassFlowRate_, face);
+
+      // extract the connected element to this exposed face; should be single in size!
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
+      ThrowAssert( bulk_data.num_elements(face) == 1 );
+
+      // get element; its face ordinal number and populate face_node_ordinals
+      stk::mesh::Entity element = face_elem_rels[0];
+      const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
+
+      //======================================
+      // gather nodal data off of element
+      //======================================
+      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      int num_nodes = bulk_data.num_nodes(element);
+      // sanity check on num nodes
+      ThrowAssert( num_nodes == nodesPerElement );
+      for ( int ni = 0; ni < num_nodes; ++ni ) {
+        stk::mesh::Entity node = elem_node_rels[ni];
+
+        // gather scalars
+        p_pressure[ni]    = *stk::mesh::field_data(*pressure_, node);
+
+        // gather vectors
+        double * coords = stk::mesh::field_data(*coordinates_, node);
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_coordinates[offSet+j] = coords[j];
+        }
+      }
+
+      // compute dndx
+      double scs_error = 0.0;
+      if ( shiftedGradOp_ )
+        meSCS->shifted_face_grad_op(1, face_ordinal, &p_coordinates[0], &p_dndx[0], &ws_det_j[0], &scs_error);
+      else
+        meSCS->face_grad_op(1, face_ordinal, &p_coordinates[0], &p_dndx[0], &ws_det_j[0], &scs_error);
+
+      // loop over boundary ips
+      for ( int ip = 0; ip < numScsBip; ++ip ) {
+
+        // zero out vector quantities; form aMag
+        double aMag = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          p_uBip[j] = 0.0;
+          p_rho_uBip[j] = 0.0;
+          p_GpdxBip[j] = 0.0;
+          p_dpdxBip[j] = 0.0;
+          const double axj = areaVec[ip*nDim+j];
+          aMag += axj*axj;
+        }
+        aMag = std::sqrt(aMag);
+
+        // form L^-1
+        double inverseLengthScale = 0.0;
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const int faceNodeNumber = face_node_ordinals[ic];
+          const int offSetDnDx = nDim*nodesPerElement*ip + faceNodeNumber*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            inverseLengthScale += p_dndx[offSetDnDx+j]*areaVec[ip*nDim+j];
+          }
+        }        
+        inverseLengthScale /= aMag;
+
+        // interpolate to bip
+        double pBip = 0.0;
+        double pbcBip = 0.0;
+        double rhoBip = 0.0;
+        const int offSetSF_face = ip*nodesPerFace;
+        for ( int ic = 0; ic < nodesPerFace; ++ic ) {
+          const double r = p_face_shape_function[offSetSF_face+ic];
+          const double rhoIC = p_density[ic];
+          rhoBip += r*rhoIC;
+          pBip += r*p_face_pressure[ic];
+          pbcBip += r*p_bcPressure[ic];
+          const int icNdim = ic*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            p_uBip[j] += r*p_vrtm[icNdim+j];
+            p_rho_uBip[j] += r*rhoIC*p_vrtm[icNdim+j];
+            p_GpdxBip[j] += r*p_Gpdx[icNdim+j];
+          }
+        }
+
+        // form dpdxBip
+        for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+          const int offSetDnDx = nDim*nodesPerElement*ip + ic*nDim;
+          const double pIc = p_pressure[ic];
+          for ( int j = 0; j < nDim; ++j ) {
+            p_dpdxBip[j] += p_dndx[offSetDnDx+j]*pIc;
+          }
+        }
+     
+        // form mdot; rho*uj*Aj - projT*(dpdxj - Gjp)*Aj + stabFac*projTimeScale*invL*(pBip - pbcBip)*aMag
+        double tmdot = stabFac_*projTimeScale*inverseLengthScale*(pBip - pbcBip)*aMag*pstabFac;
+        for ( int j = 0; j < nDim; ++j ) {
+          const double axj = areaVec[ip*nDim+j];
+          tmdot += (interpTogether_*p_rho_uBip[j] + om_interpTogether_*rhoBip*p_uBip[j]
+                    - projTimeScale*(p_dpdxBip[j] - p_GpdxBip[j])*pstabFac)*axj;
+        }
+        
+        // scatter to mdot and accumulate
+        mdot[ip] = tmdot;
+        mdotOpen += tmdot;
+      }
+    }
+  }
+  // scatter back to solution options; not thread safe
+  realm_.solutionOptions_->mdotAlgOpen_ += mdotOpen;
+  realm_.solutionOptions_->mdotAlgOpenIpCount_ += mdotOpenIpCount;
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -1,0 +1,210 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/ContinuityOpenElemKernel.h"
+#include "master_element/MasterElement.h"
+#include "SolutionOptions.h"
+#include "TimeIntegrator.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename BcAlgTraits>
+ContinuityOpenElemKernel<BcAlgTraits>::ContinuityOpenElemKernel(
+  const stk::mesh::MetaData &metaData,
+  const SolutionOptions &solnOpts,
+  ElemDataRequests &faceDataPreReqs,
+  ElemDataRequests &elemDataPreReqs)
+  : Kernel(),
+    shiftedGradOp_(solnOpts.get_shifted_grad_op("pressure")),
+    reducedSensitivities_(solnOpts.cvfemReducedSensPoisson_),
+    pstabFac_(solnOpts.activateOpenMdotCorrection_ ? 0.0 : 1.0),
+    interpTogether_(solnOpts.get_mdot_interp()),
+    om_interpTogether_(1.0 - interpTogether_),
+    meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
+{
+  if ( solnOpts.does_mesh_move())
+    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+  else
+    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, solnOpts.activateOpenMdotCorrection_ 
+                                                    ? "pressure" : "pressure_bc");
+  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  
+  // extract master elements
+  MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
+  
+  // add master elements
+  faceDataPreReqs.add_cvfem_face_me(meFC);
+  elemDataPreReqs.add_cvfem_surface_me(meSCS_);
+
+  // fields and data; face and then element
+  faceDataPreReqs.add_gathered_nodal_field(*pressure_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(*pressureBc_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(*density_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(*velocityRTM_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(*Gpdx_, BcAlgTraits::nDim_);  
+  faceDataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(*pressure_, 1);
+
+  // manage dndx
+  if ( !shiftedGradOp_ || !reducedSensitivities_ )
+    elemDataPreReqs.add_master_element_call(SCS_FACE_GRAD_OP, CURRENT_COORDINATES);
+  if ( shiftedGradOp_ || reducedSensitivities_ )
+    elemDataPreReqs.add_master_element_call(SCS_SHIFTED_FACE_GRAD_OP, CURRENT_COORDINATES);
+
+  if ( solnOpts.cvfemShiftMdot_ )
+    get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFC->shape_fcn(ptr);}, vf_shape_function_);
+  else
+    get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFC->shifted_shape_fcn(ptr);}, vf_shape_function_);
+}
+
+template<typename BcAlgTraits>
+ContinuityOpenElemKernel<BcAlgTraits>::~ContinuityOpenElemKernel()
+{}
+
+template<typename BcAlgTraits>
+void
+ContinuityOpenElemKernel<BcAlgTraits>::setup(const TimeIntegrator& timeIntegrator)
+{
+  const double dt = timeIntegrator.get_time_step();
+  const double gamma1 = timeIntegrator.get_gamma1();
+  projTimeScale_ = dt/gamma1;
+}
+
+template<typename BcAlgTraits>
+void
+ContinuityOpenElemKernel<BcAlgTraits>::execute(
+  SharedMemView<DoubleType**> &lhs,
+  SharedMemView<DoubleType *> &rhs,
+  ScratchViews<DoubleType> &faceScratchViews,
+  ScratchViews<DoubleType> &elemScratchViews,
+  int elemFaceOrdinal)
+{
+  DoubleType NALU_ALIGN(64) w_uBip[BcAlgTraits::nDim_];
+  DoubleType NALU_ALIGN(64) w_rho_uBip[BcAlgTraits::nDim_];
+  DoubleType NALU_ALIGN(64) w_GpdxBip[BcAlgTraits::nDim_];
+  DoubleType NALU_ALIGN(64) w_dpdxBip[BcAlgTraits::nDim_];
+ 
+  const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
+ 
+  // face
+  SharedMemView<DoubleType*>& vf_pressure = faceScratchViews.get_scratch_view_1D(*pressure_);
+  SharedMemView<DoubleType*>& vf_pressureBc = faceScratchViews.get_scratch_view_1D(*pressureBc_);
+  SharedMemView<DoubleType**>& vf_Gpdx = faceScratchViews.get_scratch_view_2D(*Gpdx_);
+  SharedMemView<DoubleType*>& vf_density = faceScratchViews.get_scratch_view_1D(*density_);
+  SharedMemView<DoubleType**>& vf_vrtm = faceScratchViews.get_scratch_view_2D(*velocityRTM_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(*exposedAreaVec_);
+ 
+  // element
+  SharedMemView<DoubleType*>& v_pressure = elemScratchViews.get_scratch_view_1D(*pressure_);
+
+  // dndx for both rhs and lhs
+  SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+  SharedMemView<DoubleType***>& v_dndx_lhs = (shiftedGradOp_ || reducedSensitivities_)
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+
+  for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
+    
+    const int nearestNode = meSCS_->ipNodeMap(elemFaceOrdinal)[ip]; // "Right"
+    
+    // zero out vector quantities; form aMag
+    DoubleType aMag = 0.0;
+    for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+      w_uBip[j] = 0.0;
+      w_rho_uBip[j] = 0.0;
+      w_GpdxBip[j] = 0.0;
+      w_dpdxBip[j] = 0.0;
+      const DoubleType axj = vf_exposedAreaVec(ip,j);
+      aMag += axj*axj;
+    }
+    aMag = stk::math::sqrt(aMag);
+    
+    // form L^-1
+    DoubleType inverseLengthScale = 0.0;
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const int faceNodeNumber = face_node_ordinals[ic];
+      for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+        inverseLengthScale += v_dndx(ip,faceNodeNumber,j)*vf_exposedAreaVec(ip,j);
+      }
+    }        
+    inverseLengthScale /= aMag;
+
+    // interpolate to bip
+    DoubleType pBip = 0.0;
+    DoubleType pbcBip = 0.0;
+    DoubleType rhoBip = 0.0;
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const DoubleType r = vf_shape_function_(ip,ic);
+      const DoubleType rhoIC = vf_density(ic);
+      rhoBip += r*rhoIC;
+      pBip += r*vf_pressure(ic);
+      pbcBip += r*vf_pressureBc(ic);
+      for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+        w_uBip[j] += r*vf_vrtm(ic,j);
+        w_rho_uBip[j] += r*rhoIC*vf_vrtm(ic,j);
+        w_GpdxBip[j] += r*vf_Gpdx(ic,j);
+      }
+    }
+    
+    // form dpdxBip
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerElement_; ++ic ) {
+      const DoubleType pIc = v_pressure(ic);
+      for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+        w_dpdxBip[j] += v_dndx(ip,ic,j)*pIc;
+      }
+    }
+    
+    // form mdot; rho*uj*Aj - projT*(dpdxj - Gjp)*Aj + penaltyFac*projTimeScale*invL*(pBip - pbcBip)*aMag
+    DoubleType mdot = -mdotCorrection_ + penaltyFac_*projTimeScale_*inverseLengthScale*(pBip - pbcBip)*aMag*pstabFac_;
+    for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
+      const DoubleType axj = vf_exposedAreaVec(ip,j);
+      mdot += (interpTogether_*w_rho_uBip[j] + om_interpTogether_*rhoBip*w_uBip[j] 
+               - projTimeScale_*(w_dpdxBip[j] - w_GpdxBip[j])*pstabFac_)*axj;
+    }
+    
+    // face-based penalty; divide by projTimeScale
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
+      const int faceNodeNumber = face_node_ordinals[ic];
+      const DoubleType r = vf_shape_function_(ip,ic);
+      lhs(nearestNode,faceNodeNumber) += r*penaltyFac_*inverseLengthScale*aMag*pstabFac_;
+    }
+    
+    // element-based gradient; divide by projTimeScale
+    for ( int ic = 0; ic < BcAlgTraits::nodesPerElement_; ++ic ) {
+      DoubleType lhsFac = 0.0;
+      for ( int j = 0; j < BcAlgTraits::nDim_; ++j )
+        lhsFac += -v_dndx_lhs(ip,ic,j)*vf_exposedAreaVec(ip,j);
+      lhs(nearestNode,ic) += lhsFac*pstabFac_;
+    }
+    
+    // residual
+    rhs(nearestNode) -= mdot/projTimeScale_;
+  }
+}
+
+INSTANTIATE_KERNEL_FACE_ELEMENT(ContinuityOpenElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -110,7 +110,8 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType**> &lhs,
   SharedMemView<DoubleType *> &rhs,
   ScratchViews<DoubleType> &faceScratchViews,
-  ScratchViews<DoubleType> &elemScratchViews)
+  ScratchViews<DoubleType> &elemScratchViews,
+  int elemFaceOrdinal)
 {
   DoubleType w_uBip[BcAlgTraits::nDim_];
   DoubleType w_uScs[BcAlgTraits::nDim_];
@@ -119,10 +120,8 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   DoubleType w_coordBip[BcAlgTraits::nDim_];
   DoubleType w_nx[BcAlgTraits::nDim_];
 
-  // FIXME #1 and #2 hard-code a face_node_ordinal and ordinal
-  const int face_node_ordinals[BcAlgTraits::nodesPerFace_] = {};
-  const int face_ordinal = 1;
-
+  const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
+ 
   // face
   SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(*viscosity_);
   SharedMemView<DoubleType**>& vf_velocityNp1 = faceScratchViews.get_scratch_view_2D(*velocityNp1_);
@@ -144,9 +143,9 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
-    const int opposingNode = meSCS_->opposingNodes(face_ordinal,ip); // "Left"
-    const int nearestNode = meSCS_->ipNodeMap(face_ordinal)[ip]; // "Right"
-    const int opposingScsIp = meSCS_->opposingFace(face_ordinal,ip);
+    const int opposingNode = meSCS_->opposingNodes(elemFaceOrdinal,ip); // "Left"
+    const int nearestNode = meSCS_->ipNodeMap(elemFaceOrdinal)[ip]; // "Right"
+    const int opposingScsIp = meSCS_->opposingFace(elemFaceOrdinal,ip);
     const int localFaceNode = faceIpNodeMap_[ip];
     
     // zero out vector quantities

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -73,12 +73,10 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType**> &lhs,
   SharedMemView<DoubleType *> &rhs,
   ScratchViews<DoubleType> &faceScratchViews,
-  ScratchViews<DoubleType> &elemScratchViews)
+  ScratchViews<DoubleType> &elemScratchViews,
+  int elemFaceOrdinal)
 {
   DoubleType w_nx[BcAlgTraits::nDim_];
-
-  // FIXME #2 hard-code a face_node_ordinal and ordinal
-  const int face_ordinal = 1;
 
   // face
   SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(*viscosity_);
@@ -92,7 +90,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
-    const int nearestNode = meSCS_->ipNodeMap(face_ordinal)[ip]; // "Right"
+    const int nearestNode = meSCS_->ipNodeMap(elemFaceOrdinal)[ip]; // "Right"
     
     // form unit normal
     DoubleType asq = 0.0;

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -93,14 +93,13 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType**> &lhs,
   SharedMemView<DoubleType *> &rhs,
   ScratchViews<DoubleType> &faceScratchViews,
-  ScratchViews<DoubleType> &elemScratchViews)
+  ScratchViews<DoubleType> &elemScratchViews,
+  int elemFaceOrdinal)
 {
   DoubleType w_coordBip[BcAlgTraits::nDim_];
 
-  // FIXME #1 and #2 hard-code a face_node_ordinal and ordinal
-  const int face_node_ordinals[BcAlgTraits::nodesPerFace_] = {};
-  const int face_ordinal = 1;
-
+  const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
+ 
   // face
   SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(*scalarQ_);
   SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(*bcScalarQ_);
@@ -116,8 +115,8 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
-    const int opposingNode = meSCS_->opposingNodes(face_ordinal,ip); // "Left"
-    const int nearestNode = meSCS_->ipNodeMap(face_ordinal)[ip]; // "Right"
+    const int opposingNode = meSCS_->opposingNodes(elemFaceOrdinal,ip); // "Left"
+    const int nearestNode = meSCS_->ipNodeMap(elemFaceOrdinal)[ip]; // "Right"
     const int localFaceNode = faceIpNodeMap_[ip];
     
     // zero out vector quantities


### PR DESCRIPTION
Design-order penalty continuity approach has been established. Time to deprecate
the old (Pbip - Pscs_op) approach.

* This push required a number of plumbing fixes to the former face/element
approach. BC creation is currently automatic. Formerly, symmetry bc
was being created if the lumped_mass and adveciton element source terms
were active. I fixed this to use automatic. Diffs expected as now only
one symmetry kernel will be called:)

* Generalized the face/element kernel creation allowing for
quad4/hex8/pyr5/wedge6 and tri3/tet4/pyr5/wedge6 combinations. Before,
it was only creating quad4/hex8 and tri3/tet4. This covers the full
hybrid element topos.

* Provide elemOrdinal to all face/elem kernels through a new argument. This
resolves the former FIXME #2 in which face_ordinal was hard coded. This also
means that the former symmetry run was possibly using the wrong ordinals.

Now, proceed with the new Continuity consolidated bc.

* Added ContinuityOpenElemKernel

* Added ComputeMdotElemOpenPenaltyAlg (will drop the penalty once we deprecate
the former capability). Now, if a user asksfor a consolidated approach,
the new path forward is provided.

* Hooked in the new open penalty approach for ContEQS for this consolidated
bc approach.

Notes:

a) I crossed implementations here as I started on the penalty approach before
I realized claen-up of face/elements was required. Deactivate penalty
appraoch while I sort through the possible issue.
b) symmetry seems to work, however, the model case is uniform flow..