### PR TITLE
Fix and re-enable Wed/Pyr face_grad_op test

### DIFF
--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -867,8 +867,8 @@ void PyrSCS::face_grad_op_quad(const int face_ordinal, const bool shifted,
 
   constexpr int derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
 
-  DoubleType psi[derivSize];
-  QuadFaceGradType deriv(psi);
+  DoubleType NALU_ALIGN(64) psi[derivSize];
+  QuadFaceGradType deriv(psi,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
 
   const int offset = (face_ordinal != 4) ? 0 : tri_traits::nDim_ * tri_traits::numFaceIp_ * face_ordinal;
   pyr_deriv(quad_traits::numFaceIp_, &p_intgExp[offset], deriv);
@@ -883,8 +883,8 @@ void PyrSCS::face_grad_op_tri(const int face_ordinal, const bool shifted,
   const double *p_intgExp = (!shifted || face_ordinal < 4 ) ? &intgExpFace_[0] : &intgExpFaceShift_[0];
 
   constexpr int derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType psi[derivSize];
-  TriFaceGradType deriv(psi);
+  DoubleType NALU_ALIGN(64) psi[derivSize];
+  TriFaceGradType deriv(psi,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_ );
 
   const int offset = (face_ordinal != 4) ? tri_traits::nDim_ * tri_traits::numFaceIp_ * face_ordinal : 0;
   pyr_deriv(tri_traits::numFaceIp_, &p_intgExp[offset], deriv);
@@ -901,12 +901,12 @@ void PyrSCS::face_grad_op(
   using quad_traits = AlgTraitsQuad4Pyr5;
 
   constexpr int quad_derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType quad_grad_temp[quad_derivSize];
+  DoubleType NALU_ALIGN(64) quad_grad_temp[quad_derivSize];
   QuadFaceGradType quad_gradop(quad_grad_temp,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
   face_grad_op_quad(face_ordinal, shifted, coords, quad_gradop);
 
   constexpr int tri_derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType tri_grad_temp[tri_derivSize];
+  DoubleType NALU_ALIGN(64) tri_grad_temp[tri_derivSize];
   TriFaceGradType tri_gradop(tri_grad_temp,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_ );
   face_grad_op_tri(face_ordinal, shifted, coords, tri_gradop);
 

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -769,8 +769,8 @@ void WedSCS::face_grad_op_tri(const int face_ordinal, const bool shifted,
 
   constexpr int derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
 
-  DoubleType psi[derivSize];
-  TriFaceGradType deriv(psi);
+  DoubleType NALU_ALIGN(64) psi[derivSize];
+  TriFaceGradType deriv(psi,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_);
 
   int offset;
   if (shifted)  offset = sideOffset_[face_ordinal];
@@ -785,8 +785,8 @@ void WedSCS::face_grad_op_quad(const int face_ordinal, const bool shifted,
   using quad_traits = AlgTraitsQuad4Wed6;
 
   constexpr int derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType psi[derivSize];
-  QuadFaceGradType deriv(psi);
+  DoubleType NALU_ALIGN(64) psi[derivSize];
+  QuadFaceGradType deriv(psi,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
 
   int offset;
   if (shifted)  offset = sideOffset_[face_ordinal];
@@ -805,12 +805,12 @@ void WedSCS::face_grad_op(
   using quad_traits = AlgTraitsQuad4Wed6;
 
   constexpr int quad_derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType quad_grad_temp[quad_derivSize];
+  DoubleType NALU_ALIGN(64) quad_grad_temp[quad_derivSize];
   QuadFaceGradType quad_gradop(quad_grad_temp,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
   face_grad_op_quad(face_ordinal, shifted, coords, quad_gradop);
 
   constexpr int tri_derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType tri_grad_temp[tri_derivSize];
+  DoubleType NALU_ALIGN(64) tri_grad_temp[tri_derivSize];
   TriFaceGradType tri_gradop(tri_grad_temp,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_);
   face_grad_op_tri(face_ordinal, shifted, coords, tri_gradop);
 

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -134,3 +134,22 @@ TEST(KokkosMEBC, test_tet4_views)
   }
 }
 
+
+TEST(KokkosMEBC, test_wedge4_views)
+{
+  for (int k = 0; k < 3; ++k) {
+    test_MEBC_views<sierra::nalu::AlgTraitsQuad4Wed6>(k, {sierra::nalu::SCS_FACE_GRAD_OP});
+  }
+
+  for (int k = 3; k < 5; ++k) {
+    test_MEBC_views<sierra::nalu::AlgTraitsTri3Wed6>(k, {sierra::nalu::SCS_FACE_GRAD_OP});
+  }
+}
+
+TEST(KokkosMEBC, test_pyr5_views)
+{
+  for (int k = 0; k < 4; ++k) {
+    test_MEBC_views<sierra::nalu::AlgTraitsTri3Pyr5>(k, {sierra::nalu::SCS_FACE_GRAD_OP});
+  }
+  test_MEBC_views<sierra::nalu::AlgTraitsQuad4Pyr5>(4, {sierra::nalu::SCS_FACE_GRAD_OP});
+}


### PR DESCRIPTION
* Fixes a bug introduced in the wed/pyr SIMD face_grad_op introduced with https://github.com/NaluCFD/Nalu/commit/6cb74b4abc0e91f2fc2bbb79348c705a7852cd16
* Re-enables SIMD face_grad_op unit test for wed/pyr.  I verified that it passes with intel 17 locally.