### PR TITLE
Fix aligned declarations for SIMD data types

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -12,7 +12,7 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 
-#define NALU_ALIGN(size) __attribute__((aligned(size)))
+#define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
 
 #if defined(__INTEL_COMPILER)
 #define POINTER_RESTRICT restrict
@@ -34,6 +34,9 @@ using TeamHandleType = Kokkos::TeamPolicy<DeviceSpace, DynamicScheduleType>::mem
 
 template <typename T>
 using SharedMemView = Kokkos::View<T, Kokkos::LayoutRight, DeviceShmem, Kokkos::MemoryUnmanaged>;
+
+template<typename T>
+using AlignedViewType = Kokkos::View<T, Kokkos::MemoryTraits<Kokkos::Aligned>>;
 
 using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace>;
 using DeviceTeam = DeviceTeamPolicy::member_type;

--- a/include/SimdInterface.h
+++ b/include/SimdInterface.h
@@ -16,6 +16,7 @@
  */
 
 #include "stk_simd/Simd.hpp"
+#include "Kokkos_Macros.hpp"
 
 #include <vector>
 
@@ -27,7 +28,7 @@ typedef stk::simd::Double SimdDouble;
 typedef SimdDouble DoubleType;
 
 template<typename T>
-using AlignedVector = std::vector<T, non_std::AlignedAllocator<T, 64>>;
+using AlignedVector = std::vector<T, non_std::AlignedAllocator<T, KOKKOS_MEMORY_ALIGNMENT>>;
 
 using ScalarAlignedVector = AlignedVector<DoubleType>;
 

--- a/include/kernel/ContinuityAdvElemKernel.h
+++ b/include/kernel/ContinuityAdvElemKernel.h
@@ -69,7 +69,7 @@ private:
   const double om_interpTogether_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "view_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "view_shape_func" };
 
   const int* lrscv_;
 };

--- a/include/kernel/ContinuityMassElemKernel.h
+++ b/include/kernel/ContinuityMassElemKernel.h
@@ -68,7 +68,7 @@ private:
   const int* ipNodeMap_;
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/ContinuityOpenElemKernel.h
+++ b/include/kernel/ContinuityOpenElemKernel.h
@@ -74,7 +74,7 @@ private:
   MasterElement *meSCS_{nullptr};
   
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumActuatorSrcElemKernel.h
+++ b/include/kernel/MomentumActuatorSrcElemKernel.h
@@ -55,7 +55,7 @@ private:
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/include/kernel/MomentumAdvDiffElemKernel.h
+++ b/include/kernel/MomentumAdvDiffElemKernel.h
@@ -60,8 +60,8 @@ private:
   const bool shiftedGradOp_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
@@ -53,12 +53,12 @@ private:
   double rhoRef_;
   double tRef_;
   double beta_;
-  Kokkos::View<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
+  AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
 
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/include/kernel/MomentumBuoyancySrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancySrcElemKernel.h
@@ -51,12 +51,12 @@ private:
   VectorFieldType *coordinates_{nullptr};
 
   double rhoRef_;
-  Kokkos::View<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
+  AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
 
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/include/kernel/MomentumCoriolisSrcElemKernel.h
+++ b/include/kernel/MomentumCoriolisSrcElemKernel.h
@@ -51,7 +51,7 @@ private:
   const int* ipNodeMap_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 } // namespace nalu

--- a/include/kernel/MomentumHybridTurbElemKernel.h
+++ b/include/kernel/MomentumHybridTurbElemKernel.h
@@ -59,7 +59,7 @@ private:
   const bool shiftedGradOp_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]>
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]>
     v_shape_function_{"v_shape_function"};
 };
 

--- a/include/kernel/MomentumMassElemKernel.h
+++ b/include/kernel/MomentumMassElemKernel.h
@@ -72,7 +72,7 @@ private:
   const int* ipNodeMap_;
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -90,10 +90,10 @@ private:
   PecletFunction<DoubleType> *pecletFunction_{nullptr};
 
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"vf_shape_func"};
-  Kokkos::View<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_shape_function_ {"v_shape_func"};
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
-  Kokkos::View<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_adv_shape_function_ {"v_adv_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"vf_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_shape_function_ {"v_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
+  AlignedViewType<DoubleType[BcAlgTraits::numScsIp_][BcAlgTraits::nodesPerElement_]> v_adv_shape_function_ {"v_adv_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -63,7 +63,7 @@ private:
   MasterElement *meSCS_{nullptr};
 
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumUpwAdvDiffElemKernel.h
+++ b/include/kernel/MomentumUpwAdvDiffElemKernel.h
@@ -88,8 +88,8 @@ private:
   PecletFunction<DoubleType>* pecletFunction_{nullptr};
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/MomentumWallFunctionElemKernel.h
+++ b/include/kernel/MomentumWallFunctionElemKernel.h
@@ -64,7 +64,7 @@ private:
   const int *ipNodeMap_{nullptr};
   
   // fixed scratch space
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/ScalarAdvDiffElemKernel.h
+++ b/include/kernel/ScalarAdvDiffElemKernel.h
@@ -60,8 +60,8 @@ private:
   const bool shiftedGradOp_;
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/ScalarDiffElemKernel.h
+++ b/include/kernel/ScalarDiffElemKernel.h
@@ -58,7 +58,7 @@ private:
   const bool shiftedGradOp_;
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/include/kernel/ScalarDiffFemKernel.h
+++ b/include/kernel/ScalarDiffFemKernel.h
@@ -62,7 +62,7 @@ private:
   const bool shiftedGradOp_;
   
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numGp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numGp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 
 }  // nalu

--- a/include/kernel/ScalarFluxPenaltyElemKernel.h
+++ b/include/kernel/ScalarFluxPenaltyElemKernel.h
@@ -64,7 +64,7 @@ private:
   MasterElement *meSCS_{nullptr};
   
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/ScalarMassElemKernel.h
+++ b/include/kernel/ScalarMassElemKernel.h
@@ -72,7 +72,7 @@ private:
   const int* ipNodeMap_;
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
 };
 
 }  // nalu

--- a/include/kernel/ScalarOpenAdvElemKernel.h
+++ b/include/kernel/ScalarOpenAdvElemKernel.h
@@ -85,7 +85,7 @@ private:
   PecletFunction<DoubleType> *pecletFunction_{nullptr};
 
   /// Shape functions
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_adv_shape_function_ {"vf_adv_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/ScalarUpwAdvDiffElemKernel.h
+++ b/include/kernel/ScalarUpwAdvDiffElemKernel.h
@@ -88,8 +88,8 @@ private:
   PecletFunction<DoubleType>* pecletFunction_{nullptr};
 
   /// Shape functions
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_adv_shape_function_{"v_adv_shape_function"};
 };
 
 }  // nalu

--- a/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
+++ b/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
@@ -66,7 +66,7 @@ private:
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
     v_shape_function_{"v_shape_function"};
 };
 

--- a/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
@@ -61,7 +61,7 @@ private:
   const int* ipNodeMap_;
   
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
  
 }  // nalu

--- a/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
@@ -64,7 +64,7 @@ private:
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
     v_shape_function_{"v_shape_function"};
 };
 

--- a/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
@@ -60,7 +60,7 @@ private:
   const int* ipNodeMap_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>
     v_shape_function_{"v_shape_function"};
 };
 

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -192,8 +192,8 @@ private:
 // 3D Quad 27 subcontrol volume
 class Hex27SCV : public HexahedralP2Element
 {
-  using InterpWeightType = Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>;
-  using GradWeightType = Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
+  using InterpWeightType = AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]>;
+  using GradWeightType = AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
 
 public:
   Hex27SCV();
@@ -259,9 +259,9 @@ private:
 // 3D Hex 27 subcontrol surface
 class Hex27SCS : public HexahedralP2Element
 {
-  using InterpWeightType = Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]>;
-  using GradWeightType = Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
-  using ExpGradWeightType = Kokkos::View<DoubleType[6*AlgTraitsQuad9Hex27::numFaceIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
+  using InterpWeightType = AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]>;
+  using GradWeightType = AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
+  using ExpGradWeightType = AlignedViewType<DoubleType[6*AlgTraitsQuad9Hex27::numFaceIp_][AlgTraits::nodesPerElement_][AlgTraits::nDim_]>;
 
 public:
   Hex27SCS();

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -66,12 +66,12 @@ namespace nalu {
       ThrowAssert(weights.extent(i) == referenceGradWeights.extent(i));
 
     for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
-      NALU_ALIGN(64) ftype jact[dim][dim];
+      NALU_ALIGNED ftype jact[dim][dim];
       for (int i=0; i<dim; ++i) 
         for (int j=0; j<dim; ++j) 
           jact[i][j] = ftype(0.0);
 
-      NALU_ALIGN(64) ftype refGrad[AlgTraits::nodesPerElement_][dim];
+      NALU_ALIGNED ftype refGrad[AlgTraits::nodesPerElement_][dim];
       for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
         for (int i=0; i<dim; ++i) {
           refGrad[n][i] = referenceGradWeights(ip, n, i);
@@ -83,17 +83,17 @@ namespace nalu {
         }
       }
 
-      NALU_ALIGN(64) ftype adjJac[dim][dim];
+      NALU_ALIGNED ftype adjJac[dim][dim];
       cofactorMatrix(adjJac, jact);
 
-      NALU_ALIGN(64) ftype det = ftype(0.0);
+      NALU_ALIGNED ftype det = ftype(0.0);
       for (int i=0; i<dim; ++i) det += jact[i][0] * adjJac[i][0];
       ThrowAssertMsg(
         stk::simd::are_any(det > tiny_positive_value()),
         "Problem with Jacobian determinant"
       );
 
-      NALU_ALIGN(64) const ftype inv_detj = ftype(1.0) / det;
+      NALU_ALIGNED const ftype inv_detj = ftype(1.0) / det;
 
       for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
         for (int i=0; i<dim; ++i) {
@@ -126,7 +126,7 @@ namespace nalu {
 
     for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
 
-      ftype jac[3][3] = { {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0} };
+      NALU_ALIGNED ftype jac[3][3] = { {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0} };
       for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
         jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);
         jac[0][1] += referenceGradWeights(ip, n, 1) * coords(n, 0);
@@ -155,7 +155,7 @@ namespace nalu {
 
       // the covariant is the inverse of the contravariant by definition
       // gUpper is symmetric
-      const ftype inv_detj = ftype(1.0) / (
+      NALU_ALIGNED const ftype inv_detj = ftype(1.0) / (
             gup(ip, 0, 0) * ( gup(ip, 1, 1) * gup(ip, 2, 2) - gup(ip, 1, 2) * gup(ip, 1, 2) )
           - gup(ip, 0, 1) * ( gup(ip, 0, 1) * gup(ip, 2, 2) - gup(ip, 1, 2) * gup(ip, 0, 2) )
           + gup(ip, 0, 2) * ( gup(ip, 0, 1) * gup(ip, 1, 2) - gup(ip, 1, 1) * gup(ip, 0, 2) )
@@ -193,7 +193,7 @@ namespace nalu {
     ThrowAssert(detj.extent(0) == referenceGradWeights.extent(0));
 
     for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
-      ftype jac[3][3] = { {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0} };
+      NALU_ALIGNED ftype jac[3][3] = { {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0} };
       for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
         jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);
         jac[0][1] += referenceGradWeights(ip, n, 1) * coords(n, 0);

--- a/include/nso/MomentumNSOElemKernel.h
+++ b/include/nso/MomentumNSOElemKernel.h
@@ -80,8 +80,8 @@ private:
   const double small_{1.0e-16};
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
-  Kokkos::View<DoubleType[AlgTraits::nDim_][AlgTraits::nDim_]> v_kd_{"v_kd"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::nDim_][AlgTraits::nDim_]> v_kd_{"v_kd"};
 };
 
 }  // nalu

--- a/include/nso/MomentumNSOKeElemKernel.h
+++ b/include/nso/MomentumNSOKeElemKernel.h
@@ -65,7 +65,7 @@ private:
   const bool shiftedGradOp_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/nso/MomentumNSOSijElemKernel.h
+++ b/include/nso/MomentumNSOSijElemKernel.h
@@ -62,7 +62,7 @@ private:
   const bool shiftedGradOp_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/nso/ScalarNSOElemKernel.h
+++ b/include/nso/ScalarNSOElemKernel.h
@@ -78,7 +78,7 @@ private:
   const double small_{1.0e-16};
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/nso/ScalarNSOKeElemKernel.h
+++ b/include/nso/ScalarNSOKeElemKernel.h
@@ -67,7 +67,7 @@ private:
   const bool shiftedGradOp_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/pmr/RadTransAbsorptionBlackBodyElemKernel.h
+++ b/include/pmr/RadTransAbsorptionBlackBodyElemKernel.h
@@ -55,7 +55,7 @@ private:
   const int* ipNodeMap_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/pmr/RadTransAdvectionSUCVElemKernel.h
+++ b/include/pmr/RadTransAdvectionSUCVElemKernel.h
@@ -77,8 +77,8 @@ private:
   const int* lrscv_;
 
   // scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
-  Kokkos::View<DoubleType[AlgTraits::nDim_]> v_Sk_{"v_Sk"};
+  AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::nDim_]> v_Sk_{"v_Sk"};
 };
 
 }  // nalu

--- a/include/pmr/RadTransIsotropicScatteringElemKernel.h
+++ b/include/pmr/RadTransIsotropicScatteringElemKernel.h
@@ -56,7 +56,7 @@ private:
   const int* ipNodeMap_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/include/pmr/RadTransWallElemKernel.h
+++ b/include/pmr/RadTransWallElemKernel.h
@@ -63,8 +63,8 @@ private:
   const int *ipNodeMap_{nullptr};
 
   // scratch space
-  Kokkos::View<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
-  Kokkos::View<DoubleType[BcAlgTraits::nDim_]> v_Sk_{"v_Sk"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
+  AlignedViewType<DoubleType[BcAlgTraits::nDim_]> v_Sk_{"v_Sk"};
 };
 
 }  // nalu

--- a/include/user_functions/SteadyThermal3dContactSrcElemKernel.h
+++ b/include/user_functions/SteadyThermal3dContactSrcElemKernel.h
@@ -51,7 +51,7 @@ private:
   const double pi_;
 
   // fixed scratch space
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"v_shape_function"};
 };
 
 }  // nalu

--- a/src/kernel/ContinuityAdvElemKernel.C
+++ b/src/kernel/ContinuityAdvElemKernel.C
@@ -96,10 +96,10 @@ ContinuityAdvElemKernel<AlgTraits>::execute(
   ScratchViews<DoubleType>& scratchViews)
 {
   // Work arrays (fixed size)
-  DoubleType w_uIp     [AlgTraits::nDim_];
-  DoubleType w_rho_uIp [AlgTraits::nDim_];
-  DoubleType w_Gpdx_Ip [AlgTraits::nDim_];
-  DoubleType w_dpdxIp  [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uIp     [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_rho_uIp [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_Gpdx_Ip [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxIp  [AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
   SharedMemView<DoubleType*>& v_pressure = scratchViews.get_scratch_view_1D(*pressure_);

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -78,8 +78,8 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType *>&rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType NALU_ALIGN(64) w_uBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_rho_uBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_rho_uBip[BcAlgTraits::nDim_];
   
   SharedMemView<DoubleType**>& vf_velocityBC = scratchViews.get_scratch_view_2D(*velocityBC_);
   SharedMemView<DoubleType*>& vf_density = scratchViews.get_scratch_view_1D(*densityBC_);

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -99,10 +99,10 @@ ContinuityOpenElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType> &elemScratchViews,
   int elemFaceOrdinal)
 {
-  DoubleType NALU_ALIGN(64) w_uBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_rho_uBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_GpdxBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_dpdxBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_rho_uBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_GpdxBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxBip[BcAlgTraits::nDim_];
  
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  

--- a/src/kernel/MomentumActuatorSrcElemKernel.C
+++ b/src/kernel/MomentumActuatorSrcElemKernel.C
@@ -77,7 +77,7 @@ MomentumActuatorSrcElemKernel<AlgTraits>::execute(
 
     const int nearestNode = ipNodeMap_[ip];
 
-    DoubleType actuatorSourceIp[AlgTraits::nDim_];
+    NALU_ALIGNED DoubleType actuatorSourceIp[AlgTraits::nDim_];
     for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
       actuatorSourceIp[i] = 0.0;
     }

--- a/src/kernel/MomentumAdvDiffElemKernel.C
+++ b/src/kernel/MomentumAdvDiffElemKernel.C
@@ -76,7 +76,7 @@ MomentumAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_uIp[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uIp[AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);

--- a/src/kernel/MomentumCoriolisSrcElemKernel.C
+++ b/src/kernel/MomentumCoriolisSrcElemKernel.C
@@ -79,7 +79,7 @@ MomentumCoriolisSrcElemKernel<AlgTraits>::execute(
 
   for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
     const int nnDim = ipNodeMap_[ip] * AlgTraits::nDim_;
-    DoubleType uIp[3] = { 0.0, 0.0, 0.0 };
+    NALU_ALIGNED DoubleType uIp[3] = { 0.0, 0.0, 0.0 };
     DoubleType rhoIp = 0.0;
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       DoubleType r = v_shape_function_(ip,n);

--- a/src/kernel/MomentumHybridTurbElemKernel.C
+++ b/src/kernel/MomentumHybridTurbElemKernel.C
@@ -86,7 +86,7 @@ MomentumHybridTurbElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_mutijScs[AlgTraits::nDim_ * AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_mutijScs[AlgTraits::nDim_ * AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_uNp1 =
     scratchViews.get_scratch_view_2D(*velocityNp1_);

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -103,10 +103,10 @@ MomentumMassElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_uNm1 [AlgTraits::nDim_];
-  DoubleType w_uN   [AlgTraits::nDim_];
-  DoubleType w_uNp1 [AlgTraits::nDim_];
-  DoubleType w_Gjp  [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uNm1 [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uN   [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uNp1 [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_Gjp  [AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(*densityNm1_);
   SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(*densityN_);

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -114,16 +114,16 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType> &elemScratchViews,
   int elemFaceOrdinal)
 {
-  DoubleType NALU_ALIGN(64) w_uBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_uScs[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_uBipExtrap[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_uspecBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_coordBip[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_nx[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_GuBip[BcAlgTraits::nDim_*BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_NOC[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_coordScs[BcAlgTraits::nDim_];
-  DoubleType NALU_ALIGN(64) w_dxBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uScs[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uBipExtrap[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uspecBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_coordBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_nx[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_GuBip[BcAlgTraits::nDim_*BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_NOC[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_coordScs[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dxBip[BcAlgTraits::nDim_];
 
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  

--- a/src/kernel/MomentumUpwAdvDiffElemKernel.C
+++ b/src/kernel/MomentumUpwAdvDiffElemKernel.C
@@ -114,14 +114,14 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_uIp[AlgTraits::nDim_];
-  DoubleType w_uIpL[AlgTraits::nDim_];
-  DoubleType w_uIpR[AlgTraits::nDim_];
-  DoubleType w_coordIp[AlgTraits::nDim_];
-  DoubleType w_duL[AlgTraits::nDim_];
-  DoubleType w_duR[AlgTraits::nDim_];
-  DoubleType w_limitL[AlgTraits::nDim_];
-  DoubleType w_limitR[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uIp[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uIpL[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uIpR[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_coordIp[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_duL[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_duR[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_limitL[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_limitR[AlgTraits::nDim_];
   for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
     w_limitL[i] = 1.0;
     w_limitR[i] = 1.0;

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -79,7 +79,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType> &elemScratchViews,
   int elemFaceOrdinal)
 {
-  DoubleType NALU_ALIGN(64) w_dqdxBip[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dqdxBip[BcAlgTraits::nDim_];
  
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  

--- a/src/kernel/ScalarUpwAdvDiffElemKernel.C
+++ b/src/kernel/ScalarUpwAdvDiffElemKernel.C
@@ -119,7 +119,7 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::execute(
   ScratchViews<DoubleType>& scratchViews)
 {
   /// Scratch space to hold coordinates at the integration point
-  DoubleType w_coordIp[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_coordIp[AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(*velocityRTM_);
   SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -107,9 +107,9 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
-  DoubleType w_dkdx[AlgTraits::nDim_];
-  DoubleType w_dwdx[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dkdx[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dwdx[AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
     scratchViews.get_scratch_view_1D(*tkeNp1_);

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -77,7 +77,7 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>&rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dudx [AlgTraits::nDim_][AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dudx [AlgTraits::nDim_][AlgTraits::nDim_];
  
   SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<DoubleType*>& v_tkeNp1 = scratchViews.get_scratch_view_1D(

--- a/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
@@ -107,7 +107,7 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
     scratchViews.get_scratch_view_1D(*tkeNp1_);

--- a/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
@@ -98,7 +98,7 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
     scratchViews.get_scratch_view_1D(*tkeNp1_);

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -867,7 +867,7 @@ void PyrSCS::face_grad_op_quad(const int face_ordinal, const bool shifted,
 
   constexpr int derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
 
-  DoubleType NALU_ALIGN(64) psi[derivSize];
+  NALU_ALIGNED DoubleType psi[derivSize];
   QuadFaceGradType deriv(psi,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
 
   const int offset = (face_ordinal != 4) ? 0 : tri_traits::nDim_ * tri_traits::numFaceIp_ * face_ordinal;
@@ -883,7 +883,7 @@ void PyrSCS::face_grad_op_tri(const int face_ordinal, const bool shifted,
   const double *p_intgExp = (!shifted || face_ordinal < 4 ) ? &intgExpFace_[0] : &intgExpFaceShift_[0];
 
   constexpr int derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType NALU_ALIGN(64) psi[derivSize];
+  NALU_ALIGNED DoubleType psi[derivSize];
   TriFaceGradType deriv(psi,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_ );
 
   const int offset = (face_ordinal != 4) ? tri_traits::nDim_ * tri_traits::numFaceIp_ * face_ordinal : 0;
@@ -901,12 +901,12 @@ void PyrSCS::face_grad_op(
   using quad_traits = AlgTraitsQuad4Pyr5;
 
   constexpr int quad_derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType NALU_ALIGN(64) quad_grad_temp[quad_derivSize];
+  NALU_ALIGNED DoubleType quad_grad_temp[quad_derivSize];
   QuadFaceGradType quad_gradop(quad_grad_temp,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
   face_grad_op_quad(face_ordinal, shifted, coords, quad_gradop);
 
   constexpr int tri_derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType NALU_ALIGN(64) tri_grad_temp[tri_derivSize];
+  NALU_ALIGNED DoubleType tri_grad_temp[tri_derivSize];
   TriFaceGradType tri_gradop(tri_grad_temp,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_ );
   face_grad_op_tri(face_ordinal, shifted, coords, tri_gradop);
 

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -769,7 +769,7 @@ void WedSCS::face_grad_op_tri(const int face_ordinal, const bool shifted,
 
   constexpr int derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
 
-  DoubleType NALU_ALIGN(64) psi[derivSize];
+  NALU_ALIGNED DoubleType psi[derivSize];
   TriFaceGradType deriv(psi,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_);
 
   int offset;
@@ -785,7 +785,7 @@ void WedSCS::face_grad_op_quad(const int face_ordinal, const bool shifted,
   using quad_traits = AlgTraitsQuad4Wed6;
 
   constexpr int derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType NALU_ALIGN(64) psi[derivSize];
+  NALU_ALIGNED DoubleType psi[derivSize];
   QuadFaceGradType deriv(psi,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
 
   int offset;
@@ -805,12 +805,12 @@ void WedSCS::face_grad_op(
   using quad_traits = AlgTraitsQuad4Wed6;
 
   constexpr int quad_derivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * quad_traits::nDim_;
-  DoubleType NALU_ALIGN(64) quad_grad_temp[quad_derivSize];
+  NALU_ALIGNED DoubleType quad_grad_temp[quad_derivSize];
   QuadFaceGradType quad_gradop(quad_grad_temp,quad_traits::numFaceIp_,quad_traits::nodesPerElement_,quad_traits::nDim_);
   face_grad_op_quad(face_ordinal, shifted, coords, quad_gradop);
 
   constexpr int tri_derivSize = tri_traits::numFaceIp_ *  tri_traits::nodesPerElement_ * tri_traits::nDim_;
-  DoubleType NALU_ALIGN(64) tri_grad_temp[tri_derivSize];
+  NALU_ALIGNED DoubleType tri_grad_temp[tri_derivSize];
   TriFaceGradType tri_gradop(tri_grad_temp,tri_traits::numFaceIp_,tri_traits::nodesPerElement_,tri_traits::nDim_);
   face_grad_op_tri(face_ordinal, shifted, coords, tri_gradop);
 

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -128,9 +128,9 @@ MomentumNSOElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dukdxScs   [AlgTraits::nDim_];
-  DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
-  DoubleType w_dpdxScs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dukdxScs   [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxScs    [AlgTraits::nDim_];
 
   SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(*Gju_);
   SharedMemView<DoubleType**>& v_uNm1 = scratchViews.get_scratch_view_2D(*velocityNm1_);

--- a/src/nso/MomentumNSOKeElemKernel.C
+++ b/src/nso/MomentumNSOKeElemKernel.C
@@ -92,12 +92,12 @@ MomentumNSOKeElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_ke         [AlgTraits::nodesPerElement_];
-  DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
-  DoubleType w_uNp1Scs    [AlgTraits::nDim_];
-  DoubleType w_dpdxScs    [AlgTraits::nDim_];
-  DoubleType w_GjpScs     [AlgTraits::nDim_];
-  DoubleType w_dkedxScs   [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_ke         [AlgTraits::nodesPerElement_];
+  NALU_ALIGNED DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uNp1Scs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxScs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_GjpScs     [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dkedxScs   [AlgTraits::nDim_];
 
   SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(*Gju_);
   SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -88,12 +88,12 @@ MomentumNSOSijElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_ke         [AlgTraits::nodesPerElement_];
-  DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
-  DoubleType w_uNp1Scs    [AlgTraits::nDim_];
-  DoubleType w_dpdxScs    [AlgTraits::nDim_];
-  DoubleType w_GjpScs     [AlgTraits::nDim_];
-  DoubleType w_dkedxScs   [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_ke         [AlgTraits::nodesPerElement_];
+  NALU_ALIGNED DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uNp1Scs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxScs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_GjpScs     [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dkedxScs   [AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(*velocityRTM_);

--- a/src/nso/ScalarNSOElemKernel.C
+++ b/src/nso/ScalarNSOElemKernel.C
@@ -116,8 +116,8 @@ ScalarNSOElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_dqdxScs    [AlgTraits::nDim_];
-  DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dqdxScs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_Gjq = scratchViews.get_scratch_view_2D(*Gjq_);
   SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(*velocityRTM_);

--- a/src/nso/ScalarNSOKeElemKernel.C
+++ b/src/nso/ScalarNSOKeElemKernel.C
@@ -93,12 +93,12 @@ ScalarNSOKeElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  DoubleType w_ke         [AlgTraits::nodesPerElement_];
-  DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
-  DoubleType w_uNp1Scs    [AlgTraits::nDim_];
-  DoubleType w_dpdxScs    [AlgTraits::nDim_];
-  DoubleType w_GjpScs     [AlgTraits::nDim_];
-  DoubleType w_dkedxScs   [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_ke         [AlgTraits::nodesPerElement_];
+  NALU_ALIGNED DoubleType w_rhoVrtmScs [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_uNp1Scs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dpdxScs    [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_GjpScs     [AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dkedxScs   [AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_Gjq = scratchViews.get_scratch_view_2D(*Gjq_);
   SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);

--- a/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
@@ -62,7 +62,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::execute(
 
   // Forcing nDim = 3 instead of using AlgTraits::nDim_ here to avoid compiler
   // warnings when this template is instantiated for 2-D topologies. 
-  DoubleType NALU_ALIGN(64) w_scvCoords[3];
+  NALU_ALIGNED DoubleType w_scvCoords[3];
 
   SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -111,8 +111,8 @@ public:
   sierra::nalu::MasterElement* meSCS_{nullptr};
 
 
-  Kokkos::View<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> scv_shape_fcn_ {"scv_shape_function"};
-  Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> scs_shape_fcn_ {"scs_shape_function"};
+  sierra::nalu::AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> scv_shape_fcn_ {"scv_shape_function"};
+  sierra::nalu::AlignedViewType<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> scs_shape_fcn_ {"scs_shape_function"};
 };
 
 } // namespace unit_test_utils


### PR DESCRIPTION
- Define NALU_ALIGNED that uses KOKKOS_MEMORY_ALIGNMENT instead of the hard-coded 64 used in the code currently.

- Define new type-alias AlignedView that enforces Kokkos::MemoryTraits<Kokkos::Aligned>

- Ensure all declarations of DoubleType arrays in Kernels and MasterElement sources are aligned types.