### PR TITLE
New momentum entrainment alg must correct for mesh motion

### DIFF
--- a/include/AssembleMomentumEdgeOpenSolverAlgorithm.h
+++ b/include/AssembleMomentumEdgeOpenSolverAlgorithm.h
@@ -30,9 +30,11 @@ public:
   virtual void execute();
 
   const double includeDivU_;
+  const double meshVelocityCorrection_;
 
   // extract fields
   VectorFieldType *velocity_;
+  VectorFieldType *meshVelocity_;
   GenericFieldType *dudx_;
   VectorFieldType *coordinates_;
   ScalarFieldType *density_;

--- a/include/AssembleMomentumElemOpenSolverAlgorithm.h
+++ b/include/AssembleMomentumElemOpenSolverAlgorithm.h
@@ -37,9 +37,10 @@ public:
   virtual void execute();
 
   const double includeDivU_;
-  const bool meshMotion_;
+  const double meshVelocityCorrection_;
 
   VectorFieldType *velocityRTM_;
+  VectorFieldType *meshVelocity_;
   VectorFieldType *velocity_;
   GenericFieldType *dudx_;
   VectorFieldType *coordinates_;

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -65,6 +65,7 @@ private:
   GenericFieldType *Gjui_{nullptr};
   VectorFieldType *velocityNp1_{nullptr};
   VectorFieldType *velocityRTM_{nullptr};
+  VectorFieldType *meshVelocity_{nullptr};
   VectorFieldType *coordinates_{nullptr};
   ScalarFieldType *density_{nullptr};
   GenericFieldType *exposedAreaVec_{nullptr};
@@ -76,6 +77,7 @@ private:
   const double om_alphaUpw_;
   const double hoUpwind_;
   const double includeDivU_;
+  const double meshVelocityCorrection_;
   const bool shiftedGradOp_;
   const double small_{1.0e-16};
 


### PR DESCRIPTION
Notes:

a) for element-based, assumed rho*uj was interpolated together.. I need to
remove the separate interpolation feature since I have not run with this
in the history of nalu variable desnity.