### PR TITLE
Support multi-material approaches in Nalu

### DIFF
--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -40,7 +40,7 @@ class Transfers;
 
 class DataProbeInfo {
 public:
-  DataProbeInfo() { }
+  DataProbeInfo() {}
   ~DataProbeInfo() {}
 
   // for each type of probe, e.g., line of site, hold some stuff

--- a/include/InitialConditions.h
+++ b/include/InitialConditions.h
@@ -39,10 +39,7 @@ class InitialCondition {
   Simulation *root();
   InitialConditions *parent();
   
-  void breadboard()
-  {
-    // nothing
-  }
+  void breadboard() {}
   
   InitialConditions& initialConditions_;
   
@@ -51,7 +48,7 @@ class InitialCondition {
   UserDataType theIcType_;
 };
  
- typedef std::vector<InitialCondition *> InitialConditionVector;
+typedef std::vector<InitialCondition *> InitialConditionVector;
  
  class InitialConditions {
  public:

--- a/include/MaterialProperty.h
+++ b/include/MaterialProperty.h
@@ -9,11 +9,12 @@
 #ifndef MaterialProperty_h
 #define MaterialProperty_h
 
-#include <Enums.h>
+#include "Enums.h"
 
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
 
+// basic c++
 #include <map>
 #include <string>
 #include <vector>
@@ -22,23 +23,37 @@ namespace sierra{
 namespace nalu{
 
 class MaterialPropertys;
+class MaterialPropertyData;
+class ReferencePropertyData;
+class PropertyEvaluator;
 
 class MaterialProperty {
 public:
-  MaterialProperty(MaterialPropertys& matPropertys);
+  MaterialProperty(MaterialPropertys &materialPropertys, const std::string materialBlockName);
   
   ~MaterialProperty();
   
   void load(const YAML::Node & node);
+
+  MaterialPropertys *parent();
   
-  virtual void breadboard(){}
+  void extract_universal_constant( 
+    const std::string name, double &value, const bool useDefault);
+ 
+  MaterialPropertys &materialPropertys_;
+  const std::string materialBlockName_;
 
-  Simulation *root();
-  EquationSystems *parent();
-
-  MaterialPropertys &matPropertys_;
+  // start the parameters
+  std::string propertyTableName_;
+  
+  // vectors and maps required to manage full set of options
+  std::vector<std::string> targetNames_;
+  std::map<std::string, double> universalConstantMap_;
+  std::map<PropertyIdentifier, MaterialPropertyData*> propertyDataMap_;
+  std::map<std::string, ReferencePropertyData*> referencePropertyDataMap_; /* defines overall species ordering */
+  std::map<PropertyIdentifier, PropertyEvaluator*> propertyEvalMap_;
+  std::map<std::string, ReferencePropertyData*> tablePropertyMap_;
 };
-
 
 } // namespace nalu
 } // namespace Sierra

--- a/include/MaterialPropertys.h
+++ b/include/MaterialPropertys.h
@@ -9,13 +9,12 @@
 #ifndef MaterialPropertys_h
 #define MaterialPropertys_h
 
-#include <Enums.h>
+#include "Enums.h"
 
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
 
-#include <map>
-#include <string>
+// basic c++
 #include <vector>
 
 namespace YAML {
@@ -27,9 +26,6 @@ namespace nalu{
 
 class Realm;
 class MaterialProperty;
-class MaterialPropertyData;
-class ReferencePropertyData;
-class PropertyEvaluator;
 class Simulation;
 
 typedef std::vector<MaterialProperty *> MaterialPropertyVector;
@@ -52,16 +48,9 @@ public:
   Realm *parent();  
 
   Realm &realm_;
-  MaterialPropertyVector materialPropertyVector_;
-  std::string propertyTableName_;
 
-  // vectors and maps required to manage full set of options
+  MaterialPropertyVector materialPropertyVector_;
   std::vector<std::string> targetNames_;
-  std::map<std::string, double> universalConstantMap_;
-  std::map<PropertyIdentifier, MaterialPropertyData*> propertyDataMap_;
-  std::map<std::string, ReferencePropertyData*> referencePropertyDataMap_; /* defines overall species ordering */
-  std::map<PropertyIdentifier, PropertyEvaluator*> propertyEvalMap_;
-  std::map<std::string, ReferencePropertyData*> tablePropertyMap_;
 };
 
 

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -123,8 +123,6 @@ class Realm {
   void enforce_bc_on_exposed_faces();
   void setup_initial_conditions();
   void setup_property();
-  void extract_universal_constant( 
-    const std::string name, double &value, const bool useDefault);
   void augment_property_map(
     PropertyIdentifier propID,
     ScalarFieldType *theField);
@@ -331,9 +329,9 @@ class Realm {
   bool get_nc_alg_include_pstab();
   bool get_nc_alg_current_normal();
 
-  PropertyEvaluator *
-  get_material_prop_eval(
-    const PropertyIdentifier thePropID);
+  void get_material_prop_eval(
+    const PropertyIdentifier thePropID,
+    std::vector<PropertyEvaluator*> &propEvalVec);
 
   bool is_turbulent();
   void is_turbulent(

--- a/reg_tests/test_files/dgNonConformal/dgNonConformal.i
+++ b/reg_tests/test_files/dgNonConformal/dgNonConformal.i
@@ -41,17 +41,42 @@ realms:
          temperature: steady_2d_thermal
 
     material_properties:
-      target_name: [block_1, block_2]
-      specifications:
-        - name: density
-          type: constant
-          value: 1.0
-        - name: thermal_conductivity
-          type: constant
-          value: 1.0
-        - name: specific_heat
-          type: constant
-          value: 1.0
+
+      properties:
+
+        - name: mat_b1
+          target_name: [block_1]
+
+          specifications:
+
+            - name: density
+              type: constant
+              value: 1.0
+
+            - name: specific_heat
+              type: constant
+              value: 1.0
+
+            - name: thermal_conductivity
+              type: constant
+              value: 1.0
+
+        - name: mat_b2
+          target_name: [block_2]
+
+          specifications:
+
+            - name: density
+              type: constant
+              value: 1.0
+
+            - name: specific_heat
+              type: constant
+              value: 1.0
+
+            - name: thermal_conductivity
+              type: constant
+              value: 1.0
 
     boundary_conditions:
 

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -200,6 +200,12 @@ EnthalpyEquationSystem::EnthalpyEquationSystem(
   if ( managePNG_ ) {
     manage_projected_nodal_gradient(eqSystems);
   }
+
+  // protect against multi-material
+  std::vector<PropertyEvaluator *> enthEvalVec;
+  realm_.get_material_prop_eval(ENTHALPY_ID, enthEvalVec);
+  if ( enthEvalVec.size() > 1 )
+    throw std::runtime_error("EnthalpyElemSrcTerms::Error: Only a single material gas phase is currently supported");
 }
 
 //--------------------------------------------------------------------------
@@ -600,13 +606,13 @@ EnthalpyEquationSystem::register_interior_algorithm(
   }
 
   // extract material prop evaluation for enthalpy and create alg to compute h
-  PropertyEvaluator *thePropEval
-    = realm_.get_material_prop_eval(ENTHALPY_ID);
-
+  std::vector<PropertyEvaluator *> enthEvalVec;
+  realm_.get_material_prop_eval(ENTHALPY_ID, enthEvalVec);
+ 
+  // create property algorithm; FIXME: uses first material block (enforces size of 1)
   TemperaturePropAlgorithm *auxAlg
-    = new TemperaturePropAlgorithm( realm_, part, &enthalpyNp1, thePropEval);
+    = new TemperaturePropAlgorithm( realm_, part, &enthalpyNp1, enthEvalVec[0]);
   enthalpyFromTemperatureAlg_.push_back(auxAlg);
-
 }
 
 //--------------------------------------------------------------------------
@@ -1233,27 +1239,15 @@ EnthalpyEquationSystem::extract_temperature()
   // quality metrics
   size_t troubleCount[3] = {};
 
-  // extract h evaluator
-  PropertyEvaluator *enthEval = NULL;
-  std::map<PropertyIdentifier, PropertyEvaluator*>::iterator ith =
-    realm_.materialPropertys_.propertyEvalMap_.find(ENTHALPY_ID);
-  if ( ith == realm_.materialPropertys_.propertyEvalMap_.end() ) {
-    throw std::runtime_error("Enthalpy prop evaluator not found:");
-  }
-  else {
-    enthEval = (*ith).second;
-  }
+  // extract h evaluator; FIXME: uses first material block (EQS enforces size of 1)
+  std::vector<PropertyEvaluator *> enthEvalVec;
+  realm_.get_material_prop_eval(ENTHALPY_ID, enthEvalVec);
+  PropertyEvaluator *enthEval = enthEvalVec[0];
 
-  // extract Cp evaluator
-  PropertyEvaluator *cpEval = NULL;
-  std::map<PropertyIdentifier, PropertyEvaluator*>::iterator itc =
-    realm_.materialPropertys_.propertyEvalMap_.find(SPEC_HEAT_ID);
-  if ( itc == realm_.materialPropertys_.propertyEvalMap_.end() ) {
-    throw std::runtime_error("Specific heat prop evaluator not found:");
-  }
-  else {
-    cpEval = (*itc).second;
-  }
+  // extract Cp evaluator; FIXME: uses first material block (EQS enforces size of 1)
+  std::vector<PropertyEvaluator *> cpEvalVec;
+  realm_.get_material_prop_eval(SPEC_HEAT_ID, cpEvalVec);
+  PropertyEvaluator *cpEval = cpEvalVec[0];
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
@@ -1475,11 +1469,12 @@ EnthalpyEquationSystem::temperature_bc_setup(
   }
 
   // extract material prop evaluation for enthalpy and create alg to compute h_bc
-  PropertyEvaluator *thePropEval
-    = realm_.get_material_prop_eval(ENTHALPY_ID);
-
+  std::vector<PropertyEvaluator *> enthEvalVec;
+  realm_.get_material_prop_eval(ENTHALPY_ID, enthEvalVec);
+ 
+  // create temp algorithm; FIXME: uses first material block (EQS enforces size of 1)
   TemperaturePropAlgorithm *enthAlg
-    = new TemperaturePropAlgorithm( realm_, part, enthalpyBc, thePropEval, temperatureBc->name());
+    = new TemperaturePropAlgorithm( realm_, part, enthalpyBc, enthEvalVec[0], temperatureBc->name());
 
   // copy enthalpy_bc to enthalpy np1...
   CopyFieldAlgorithm *theEnthCopyAlg = NULL;

--- a/src/MaterialProperty.C
+++ b/src/MaterialProperty.C
@@ -6,13 +6,23 @@
 /*------------------------------------------------------------------------*/
 
 
-#include <Realm.h>
-#include <MaterialProperty.h>
-#include <MaterialPropertys.h>
+#include "MaterialProperty.h"
+
+#include "Realm.h"
+#include "MaterialPropertys.h"
+#include "NaluEnv.h"
+
+// props; algs, evaluators and data
+#include "property_evaluator/MaterialPropertyData.h"
+#include "property_evaluator/ReferencePropertyData.h"
+#include "property_evaluator/PropertyEvaluator.h"
 
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
-#include <NaluParsing.h>
+
+// basic c++
+#include <stdexcept>
+#include <map>
 
 namespace sierra{
 namespace nalu{
@@ -26,8 +36,11 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 MaterialProperty::MaterialProperty(
-  MaterialPropertys &matPropertys)
-  : matPropertys_(matPropertys)
+  MaterialPropertys &materialPropertys, 
+  const std::string materialBlockName)
+  : materialPropertys_(materialPropertys),
+    materialBlockName_(materialBlockName),
+    propertyTableName_("na")
 {
   // nothing to do
 }
@@ -36,19 +49,311 @@ MaterialProperty::MaterialProperty(
 //-------- destructor ------------------------------------------------------
 //--------------------------------------------------------------------------
 MaterialProperty::~MaterialProperty()
-{ 
-  // does nothing
+{   
+  // delete prop data and evaluator
+  std::map<PropertyIdentifier, MaterialPropertyData *>::iterator ii;
+  for( ii=propertyDataMap_.begin(); ii!=propertyDataMap_.end(); ++ii )
+    delete (*ii).second;
+  
+  std::map<PropertyIdentifier, PropertyEvaluator *>::iterator ie;
+  for( ie=propertyEvalMap_.begin(); ie!=propertyEvalMap_.end(); ++ie )
+    delete (*ie).second;
+  
+  // delete reference property map
+  std::map<std::string, ReferencePropertyData *>::iterator irf;
+  for( irf=referencePropertyDataMap_.begin(); irf!=referencePropertyDataMap_.end(); ++irf )
+    delete (*irf).second;
 }
 
 //--------------------------------------------------------------------------
 //-------- load ------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MaterialProperty::load(const YAML::Node &node) 
+MaterialProperty::load(const YAML::Node &y_prop) 
 {
-  // nothing...
+  // extract the set of target names
+  const YAML::Node targets = y_prop["target_name"];
+  if (targets.Type() == YAML::NodeType::Scalar) {
+    targetNames_.resize(1);
+    targetNames_[0] = targets.as<std::string>() ;
+  }
+  else {
+    targetNames_.resize(targets.size());
+    for (size_t i=0; i < targets.size(); ++i) {
+      targetNames_[i] = targets[i].as<std::string>() ;
+    }
+  }
+  
+  // has a table?
+  if ( y_prop["table_file_name"] ) {
+    propertyTableName_ = y_prop["table_file_name"].as<std::string>() ;
+  }
+  
+  // property constants
+  const YAML::Node y_constants = expect_map(y_prop, "constant_specification", true);
+  if ( y_constants ) {
+    universalConstantMap_ = y_constants.as<std::map<std::string, double> >() ;
+  }
+  
+  // reference quantities
+  const YAML::Node y_refs = expect_sequence(y_prop, "reference_quantities", true);
+  if (y_refs) {
+    for (size_t ispec = 0; ispec < y_refs.size(); ++ispec) {
+      const YAML::Node y_ref = y_refs[ispec] ;
+      
+      // new the info object
+      ReferencePropertyData *refData = new ReferencePropertyData();
+      
+      // extract the data; name and mw are always required
+      get_required(y_ref, "species_name", refData->speciesName_);
+      get_required(y_ref, "mw", refData->mw_);
+      get_if_present(y_ref, "mass_fraction", refData->massFraction_);
+      get_if_present(y_ref, "stoichiometry", refData->stoichiometry_);
+      get_if_present(y_ref, "primary_mass_fraction", refData->primaryMassFraction_);
+      get_if_present(y_ref, "secondary_mass_fraction", refData->secondaryMassFraction_);
+      
+      // store the map
+      referencePropertyDataMap_[refData->speciesName_] = refData;      
+    }
+  }
+  
+  // extract the sequence of types
+  const YAML::Node y_specs = expect_sequence(y_prop, "specifications", false);
+  if (y_specs) {
+    for (size_t ispec = 0; ispec < y_specs.size(); ++ispec) {
+      const YAML::Node y_spec = y_specs[ispec];
+      
+      // new the info object
+      MaterialPropertyData *matData = new MaterialPropertyData();
+      
+      std::string thePropName;
+      std::string thePropType;
+      get_required(y_spec, "name", thePropName);
+      get_required(y_spec, "type", thePropType);
+      
+      // extract propery enum
+      bool foundIt = false;
+      PropertyIdentifier thePropEnum = PropertyIdentifier_END;
+      for ( int k=0; k < PropertyIdentifier_END; ++k ) {
+        if ( thePropName == PropertyIdentifierNames[k] ) {
+          thePropEnum = PropertyIdentifier(k);
+          foundIt = true;
+          break;
+        }
+      }
+      if ( !foundIt ) {
+        throw std::runtime_error("could not find property name from enum list");
+      }
+      
+      if ( thePropType == "constant" ) {
+        matData->type_ = CONSTANT_MAT;
+        
+        // check for standard constant
+        const YAML::Node standardConst = y_spec["value"];
+        if ( standardConst ) {
+          double theValue = 0.0;
+          theValue = standardConst.as<double>() ;
+          matData->constValue_ = theValue;
+          NaluEnv::self().naluOutputP0() << thePropName
+                                         << " is a constant property: " << theValue << std::endl;
+        }
+        else {
+          // check for possible species Cp_k specification
+          const YAML::Node coeffDeclare = y_spec["coefficient_declaration"];
+          if (coeffDeclare) {
+            const YAML::Node y_coeffds = expect_sequence(y_spec, "coefficient_declaration", true);
+            if (y_coeffds) {
+              for (size_t icoef = 0; icoef < y_coeffds.size(); ++icoef) {
+                const YAML::Node y_coeffd = y_coeffds[icoef];
+                std::string speciesName = "";
+                get_required(y_coeffd, "species_name", speciesName);
+                // standard coefficients single in size
+                const YAML::Node coeffds = y_coeffd["coefficients"];
+                if ( coeffds ) {
+                  double theValue = 0.0;
+                  theValue = coeffds.as<double>() ;
+                  matData->cpConstMap_[speciesName] = theValue;
+                }
+                else {
+                  throw std::runtime_error("no coefficients specified for Cp_k");
+                }
+                
+                // standard hf single in size
+                const YAML::Node hfs = y_coeffd["heat_of_formation"];
+                if ( hfs ) {
+                  double theValue = 0.0;
+                  theValue = hfs.as<double>() ;
+                  matData->hfConstMap_[speciesName] = theValue;
+                }
+                else {
+                  NaluEnv::self().naluOutputP0() << "default heat of formation set to zero" << std::endl;
+                  matData->hfConstMap_[speciesName] = 0.0;
+                }
+              }
+            }
+          }
+          else {
+            throw std::runtime_error("Cp must be either a constant single value or a set of constant coefficients provided");
+          }
+        }
+      }
+      else if ( thePropType == "mixture_fraction") {
+        double primaryVal;
+        double secondaryVal;
+        get_required(y_spec, "primary_value", primaryVal);
+        get_required(y_spec, "secondary_value", secondaryVal);
+        matData->type_ = MIXFRAC_MAT;
+        matData->primary_ = primaryVal;
+        matData->secondary_ = secondaryVal;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is a mix frac prop: "
+                                       << primaryVal << " "
+                                       << secondaryVal << std::endl;
+      }
+      else if ( thePropType == "polynomial" ) {
+        matData->type_ = POLYNOMIAL_MAT;
+        
+        // check for coeff declaration
+        const YAML::Node y_coeffds = expect_sequence(y_spec, "coefficient_declaration", true);
+        if (y_coeffds) {
+          for (size_t icoef = 0; icoef < y_coeffds.size(); ++icoef) {
+            const YAML::Node y_coeffd = y_coeffds[icoef];
+            std::string speciesName = "";
+            get_required(y_coeffd, "species_name", speciesName);
+            
+            // standard coefficients
+            const YAML::Node coeffds = y_coeffd["coefficients"];
+            if ( coeffds ) {
+              const size_t coeffSize = coeffds.size();
+              std::vector<double> tmpPolyCoeffs(coeffSize);
+              tmpPolyCoeffs = coeffds.as<std::vector<double> >();
+              matData->polynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
+            }
+            
+            // low temperature coefficient
+            const YAML::Node lowcoeffds = y_coeffd["low_coefficients"];
+            if ( lowcoeffds ) {
+              const size_t coeffSize = lowcoeffds.size();
+              std::vector<double> tmpPolyCoeffs(coeffSize);
+              tmpPolyCoeffs = lowcoeffds.as<std::vector<double> >();
+              matData->lowPolynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
+            }
+	    
+            // high temperature coefficient
+            const YAML::Node highcoeffds = y_coeffd["high_coefficients"];
+            if ( highcoeffds ) {
+              const size_t coeffSize = highcoeffds.size();
+              std::vector<double> tmpPolyCoeffs(coeffSize);
+              tmpPolyCoeffs = highcoeffds.as<std::vector<double> >();
+              matData->highPolynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
+            }
+          }
+        }
+        else  {
+          // complain if both are null
+          throw std::runtime_error("polynominal property did not provide a set of coefficients");
+        }
+      }
+      else if ( thePropType == "ideal_gas_t" ) {
+        matData->type_ = IDEAL_GAS_T_MAT;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is an ideal gas property (function of T, Pref and mwRef): " << std::endl;
+      }
+      else if ( thePropType == "ideal_gas_t_p" ) {
+        matData->type_ = IDEAL_GAS_T_P_MAT;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is an ideal gas property (function of T, mwRef and P): " << std::endl;
+      }
+      else if ( thePropType == "ideal_gas_yk" ) {
+        matData->type_ = IDEAL_GAS_YK_MAT;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is an ideal gas property (function of mw, Tref, and Pref): " << std::endl;
+      }
+      else if ( thePropType == "geometric" ) {
+        matData->type_ = GEOMETRIC_MAT;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is a geometric property: " << std::endl;
+      }
+      else if ( thePropType == "hdf5table") {
+        matData->type_ = HDF5_TABLE_MAT;
+        NaluEnv::self().naluOutputP0() << thePropName << " is a hdf5 table look-up property: " << std::endl;
+ 	
+        // what we might expect 
+        std::string tablePropName = "na"; 
+        std::string auxVarName = "na"; std::string tableAuxVarName = "na";
+        
+        // extract possible vector
+        const YAML::Node names = y_spec["independent_variable_set"];
+        if (names.Type() == YAML::NodeType::Scalar) {
+          matData->indVarName_.resize(1);
+          matData->indVarName_[0] = names.as<std::string>() ;
+        }
+        else {
+          matData->indVarName_.resize(names.size());
+          for (size_t i=0; i < names.size(); ++i) {
+            matData->indVarName_[i] = names[i].as<std::string>();
+          }
+        }
+	
+        // extract possible vector of independent table names
+        const YAML::Node &tableNames = y_spec["table_name_for_independent_variable_set"];
+        if (tableNames.Type() == YAML::NodeType::Scalar) {
+          matData->indVarTableName_.resize(1);
+          matData->indVarTableName_[0] = tableNames.as<std::string>();
+        }
+        else {
+          matData->indVarTableName_.resize(names.size());
+          for (size_t i=0; i < tableNames.size(); ++i) {
+            matData->indVarTableName_[i] = tableNames[i].as<std::string>() ;
+          }
+        }
+	
+        // the following are all single in size
+        get_if_present_no_default(y_spec, "table_name_for_property", tablePropName);
+        get_if_present_no_default(y_spec, "aux_variables", auxVarName);
+        get_if_present_no_default(y_spec, "table_name_for_aux_variables", tableAuxVarName);
+	
+        // set matData
+        matData->auxVarName_ = auxVarName;
+        matData->tablePropName_ = tablePropName;
+        matData->tableAuxVarName_ = tableAuxVarName;
+      }
+      else if ( thePropType == "generic" ) {
+        matData->type_ = GENERIC;
+        get_required(y_spec, "generic_property_evaluator_name", matData->genericPropertyEvaluatorName_);
+      }
+      else {
+        throw std::runtime_error("unknown property type");  
+      }
+      
+      // store the map
+      propertyDataMap_[thePropEnum] = matData;
+    }  
+  } 
 }
 
+//--------------------------------------------------------------------------
+//-------- extract_universal_constant --------------------------------------
+//--------------------------------------------------------------------------
+void
+MaterialProperty::extract_universal_constant( 
+  const std::string name, double &value, const bool useDefault)
+{
+  std::map<std::string, double >::iterator it
+    = universalConstantMap_.find(name);
+  if ( it == universalConstantMap_.end() ) {
+    // not found
+    if ( useDefault ) {
+      NaluEnv::self().naluOutputP0() << "WARNING: Reference value for " << name << " not found " << " using " << value << std::endl;
+    }
+    else {
+      throw std::runtime_error("Realm::setup_property: reference value not found: " + name);
+    }
+  }
+  else {
+    value = (*it).second;
+  }
+}
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/MaterialPropertys.C
+++ b/src/MaterialPropertys.C
@@ -6,24 +6,16 @@
 /*------------------------------------------------------------------------*/
 
 
-#include <MaterialPropertys.h>
+#include "MaterialPropertys.h"
 
-#include <Enums.h>
-#include <Realm.h>
-#include <NaluEnv.h>
-
-// props; algs, evaluators and data
-#include <property_evaluator/MaterialPropertyData.h>
-#include <property_evaluator/ReferencePropertyData.h>
-#include <property_evaluator/PropertyEvaluator.h>
+#include "MaterialProperty.h"
+#include "Realm.h"
 
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
-#include <NaluParsing.h>
 
 // basic c++
-#include <stdexcept>
-#include <map>
+#include <vector>
 
 namespace sierra{
 namespace nalu{
@@ -37,8 +29,7 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 MaterialPropertys::MaterialPropertys(Realm& realm)
-  : realm_(realm),
-    propertyTableName_("na")
+  : realm_(realm)
 {
   // nothing to do
 }
@@ -48,19 +39,9 @@ MaterialPropertys::MaterialPropertys(Realm& realm)
 //--------------------------------------------------------------------------
 MaterialPropertys::~MaterialPropertys()
 { 
-  // delete prop data and evaluator
-  std::map<PropertyIdentifier, MaterialPropertyData *>::iterator ii;
-  for( ii=propertyDataMap_.begin(); ii!=propertyDataMap_.end(); ++ii )
-    delete (*ii).second;
-  
-  std::map<PropertyIdentifier, PropertyEvaluator *>::iterator ie;
-  for( ie=propertyEvalMap_.begin(); ie!=propertyEvalMap_.end(); ++ie )
-    delete (*ie).second;
-
-  // delete reference property map
-  std::map<std::string, ReferencePropertyData *>::iterator irf;
-  for( irf=referencePropertyDataMap_.begin(); irf!=referencePropertyDataMap_.end(); ++irf )
-    delete (*irf).second;
+  for ( size_t i = 0; i < materialPropertyVector_.size(); ++i ) {
+    delete materialPropertyVector_[i];
+  }
 }
 
 //--------------------------------------------------------------------------
@@ -69,269 +50,44 @@ MaterialPropertys::~MaterialPropertys()
 void
 MaterialPropertys::load(const YAML::Node & node) 
 {
-  const YAML::Node y_material_propertys = expect_map(node,"material_properties", false);
+  const YAML::Node y_material_propertys = node["material_properties"];
   if (y_material_propertys) {
     
-    // extract the set of target names
-    const YAML::Node targets = y_material_propertys["target_name"];
-    if (targets.Type() == YAML::NodeType::Scalar) {
-      targetNames_.resize(1);
-      targetNames_[0] = targets.as<std::string>() ;
+    // support two input file options
+    const YAML::Node y_props = expect_sequence(y_material_propertys, "properties", true);
+    if (y_props) {
+      for (size_t iprop = 0; iprop < y_props.size(); ++iprop) {
+        const YAML::Node y_prop = y_props[iprop] ;
+
+        // extract name
+        std::string materialBlockName = "na";
+        get_required(y_prop, "name", materialBlockName);
+          
+        // create a new material property object
+        MaterialProperty *matPropBlock = new MaterialProperty(*this, materialBlockName);
+        
+        // load and push back
+        matPropBlock->load(y_prop);
+        materialPropertyVector_.push_back(matPropBlock);
+        
+        // push back target names to material propertys
+        targetNames_.insert(targetNames_.begin(), matPropBlock->targetNames_.begin(), matPropBlock->targetNames_.end()); 
+      }
     }
     else {
-      targetNames_.resize(targets.size());
-      for (size_t i=0; i < targets.size(); ++i) {
-        targetNames_[i] = targets[i].as<std::string>() ;
-      }
+      // create a new material property object with default name
+      MaterialProperty *matPropBlock = new MaterialProperty(*this, "default");
+      
+      // load and push back
+      matPropBlock->load(y_material_propertys);
+      materialPropertyVector_.push_back(matPropBlock);
+      
+      // push back target names to material propertys
+      targetNames_.insert(targetNames_.begin(), matPropBlock->targetNames_.begin(), matPropBlock->targetNames_.end()); 
     }
-    
-    // has a table?
-    if ( y_material_propertys["table_file_name"] ) {
-      propertyTableName_ = y_material_propertys["table_file_name"].as<std::string>() ;
-    }
-
-    // property constants
-    const YAML::Node y_prop = expect_map(y_material_propertys, "constant_specification", true);
-    if ( y_prop ) {
-      universalConstantMap_ = y_prop.as<std::map<std::string, double> >() ;
-    }
-
-    // reference quantities
-    const YAML::Node y_refs = expect_sequence(y_material_propertys, "reference_quantities", true);
-    if (y_refs) {
-      for (size_t ispec = 0; ispec < y_refs.size(); ++ispec) {
-        const YAML::Node y_ref = y_refs[ispec] ;
-
-        // new the info object
-        ReferencePropertyData *refData = new ReferencePropertyData();
-
-        // extract the data; name and mw are always required
-        get_required(y_ref, "species_name", refData->speciesName_);
-        get_required(y_ref, "mw", refData->mw_);
-        get_if_present(y_ref, "mass_fraction", refData->massFraction_);
-        get_if_present(y_ref, "stoichiometry", refData->stoichiometry_);
-        get_if_present(y_ref, "primary_mass_fraction", refData->primaryMassFraction_);
-        get_if_present(y_ref, "secondary_mass_fraction", refData->secondaryMassFraction_);
-
-        // store the map
-        referencePropertyDataMap_[refData->speciesName_] = refData;
-
-      }
-    }
-
-    // extract the sequence of types
-    const YAML::Node y_specs = expect_sequence(y_material_propertys, "specifications", false);
-    if (y_specs) {
-      for (size_t ispec = 0; ispec < y_specs.size(); ++ispec) {
-        const YAML::Node y_spec = y_specs[ispec];
-
-        // new the info object
-        MaterialPropertyData *matData = new MaterialPropertyData();
-        
-        std::string thePropName;
-        std::string thePropType;
-        get_required(y_spec, "name", thePropName);
-        get_required(y_spec, "type", thePropType);
-
-        // extract propery enum
-        bool foundIt = false;
-        PropertyIdentifier thePropEnum = PropertyIdentifier_END;
-        for ( int k=0; k < PropertyIdentifier_END; ++k ) {
-          if ( thePropName == PropertyIdentifierNames[k] ) {
-            thePropEnum = PropertyIdentifier(k);
-            foundIt = true;
-            break;
-          }
-        }
-        if ( !foundIt ) {
-          throw std::runtime_error("could not find property name from enum list");
-        }
-        
-        if ( thePropType == "constant" ) {
-          matData->type_ = CONSTANT_MAT;
-
-          // check for standard constant
-          const YAML::Node standardConst = y_spec["value"];
-          if ( standardConst ) {
-            double theValue = 0.0;
-            theValue = standardConst.as<double>() ;
-            matData->constValue_ = theValue;
-            NaluEnv::self().naluOutputP0() << thePropName
-                << " is a constant property: " << theValue << std::endl;
-          }
-          else {
-            // check for possible species Cp_k specification
-            const YAML::Node coeffDeclare = y_spec["coefficient_declaration"];
-            if (coeffDeclare) {
-              const YAML::Node y_coeffds = expect_sequence(y_spec, "coefficient_declaration", true);
-              if (y_coeffds) {
-                for (size_t icoef = 0; icoef < y_coeffds.size(); ++icoef) {
-                  const YAML::Node y_coeffd = y_coeffds[icoef];
-                  std::string speciesName = "";
-                  get_required(y_coeffd, "species_name", speciesName);
-                  // standard coefficients single in size
-                  const YAML::Node coeffds = y_coeffd["coefficients"];
-                  if ( coeffds ) {
-                    double theValue = 0.0;
-                    theValue = coeffds.as<double>() ;
-                    matData->cpConstMap_[speciesName] = theValue;
-                  }
-                  else {
-                    throw std::runtime_error("no coefficients specified for Cp_k");
-                  }
- 
-                  // standard hf single in size
-                  const YAML::Node hfs = y_coeffd["heat_of_formation"];
-                  if ( hfs ) {
-                    double theValue = 0.0;
-                    theValue = hfs.as<double>() ;
-                    matData->hfConstMap_[speciesName] = theValue;
-                  }
-                  else {
-                    NaluEnv::self().naluOutputP0() << "default heat of formation set to zero" << std::endl;
-                    matData->hfConstMap_[speciesName] = 0.0;
-                  }
-                }
-              }
-            }
-            else {
-              throw std::runtime_error("Cp must be either a constant single value or a set of constant coefficients provided");
-            }
-          }
-        }
-        else if ( thePropType == "mixture_fraction") {
-          double primaryVal;
-          double secondaryVal;
-          get_required(y_spec, "primary_value", primaryVal);
-          get_required(y_spec, "secondary_value", secondaryVal);
-          matData->type_ = MIXFRAC_MAT;
-          matData->primary_ = primaryVal;
-          matData->secondary_ = secondaryVal;
-          NaluEnv::self().naluOutputP0() << thePropName
-                          << " is a mix frac prop: "
-                          << primaryVal << " "
-                          << secondaryVal << std::endl;
-        }
-        else if ( thePropType == "polynomial" ) {
-          matData->type_ = POLYNOMIAL_MAT;
-          
-          // check for coeff declaration
-          const YAML::Node y_coeffds = expect_sequence(y_spec, "coefficient_declaration", true);
-          if (y_coeffds) {
-            for (size_t icoef = 0; icoef < y_coeffds.size(); ++icoef) {
-              const YAML::Node y_coeffd = y_coeffds[icoef];
-              std::string speciesName = "";
-              get_required(y_coeffd, "species_name", speciesName);
-
-              // standard coefficients
-              const YAML::Node coeffds = y_coeffd["coefficients"];
-              if ( coeffds ) {
-                const size_t coeffSize = coeffds.size();
-                std::vector<double> tmpPolyCoeffs(coeffSize);
-		tmpPolyCoeffs = coeffds.as<std::vector<double> >();
-                matData->polynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
-              }
-
-              // low temperature coefficient
-              const YAML::Node lowcoeffds = y_coeffd["low_coefficients"];
-              if ( lowcoeffds ) {
-                const size_t coeffSize = lowcoeffds.size();
-                std::vector<double> tmpPolyCoeffs(coeffSize);
-		tmpPolyCoeffs = lowcoeffds.as<std::vector<double> >();
-                matData->lowPolynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
-              }
-	      
-              // high temperature coefficient
-              const YAML::Node highcoeffds = y_coeffd["high_coefficients"];
-              if ( highcoeffds ) {
-                const size_t coeffSize = highcoeffds.size();
-                std::vector<double> tmpPolyCoeffs(coeffSize);
-		tmpPolyCoeffs = highcoeffds.as<std::vector<double> >();
-                matData->highPolynomialCoeffsMap_[speciesName] = tmpPolyCoeffs;
-              }
-            }
-          }
-	  else  {
-          // complain if both are null
-            throw std::runtime_error("polynominal property did not provide a set of coefficients");
-	  }
-        }
-        else if ( thePropType == "ideal_gas_t" ) {
-          matData->type_ = IDEAL_GAS_T_MAT;
-          NaluEnv::self().naluOutputP0() << thePropName
-                          << " is an ideal gas property (function of T, Pref and mwRef): " << std::endl;
-        }
-        else if ( thePropType == "ideal_gas_t_p" ) {
-            matData->type_ = IDEAL_GAS_T_P_MAT;
-            NaluEnv::self().naluOutputP0() << thePropName
-                            << " is an ideal gas property (function of T, mwRef and P): " << std::endl;
-        }
-        else if ( thePropType == "ideal_gas_yk" ) {
-            matData->type_ = IDEAL_GAS_YK_MAT;
-            NaluEnv::self().naluOutputP0() << thePropName
-                            << " is an ideal gas property (function of mw, Tref, and Pref): " << std::endl;
-        }
-        else if ( thePropType == "geometric" ) {
-                  matData->type_ = GEOMETRIC_MAT;
-                  NaluEnv::self().naluOutputP0() << thePropName
-                                  << " is a geometric property: " << std::endl;
-        }
-	else if ( thePropType == "hdf5table") {
-	  matData->type_ = HDF5_TABLE_MAT;
-	  NaluEnv::self().naluOutputP0() << thePropName << " is a hdf5 table look-up property: " << std::endl;
- 	  
-	  // what we might expect 
-	  std::string tablePropName = "na"; 
-	  std::string auxVarName = "na"; std::string tableAuxVarName = "na";
-
-	  // extract possible vector
-	  const YAML::Node names = y_spec["independent_variable_set"];
-	  if (names.Type() == YAML::NodeType::Scalar) {
-	    matData->indVarName_.resize(1);
-	    matData->indVarName_[0] = names.as<std::string>() ;
-	  }
-	  else {
-	    matData->indVarName_.resize(names.size());
-	    for (size_t i=0; i < names.size(); ++i) {
-	      matData->indVarName_[i] = names[i].as<std::string>();
-	    }
-	  }
-	  
-	  // extract possible vector of independent table names
-	  const YAML::Node &tableNames = y_spec["table_name_for_independent_variable_set"];
-	  if (tableNames.Type() == YAML::NodeType::Scalar) {
-	    matData->indVarTableName_.resize(1);
-	    matData->indVarTableName_[0] = tableNames.as<std::string>();
-	  }
-	  else {
-	    matData->indVarTableName_.resize(names.size());
-	    for (size_t i=0; i < tableNames.size(); ++i) {
-	      matData->indVarTableName_[i] = tableNames[i].as<std::string>() ;
-	    }
-	  }
-	  
-	  // the following are all single in size
-	  get_if_present_no_default(y_spec, "table_name_for_property", tablePropName);
-          get_if_present_no_default(y_spec, "aux_variables", auxVarName);
-          get_if_present_no_default(y_spec, "table_name_for_aux_variables", tableAuxVarName);
-	  
-	  // set matData
-          matData->auxVarName_ = auxVarName;
-          matData->tablePropName_ = tablePropName;
-          matData->tableAuxVarName_ = tableAuxVarName;
-	}
-        else if ( thePropType == "generic" ) {
-          matData->type_ = GENERIC;
-          get_required(y_spec, "generic_property_evaluator_name", matData->genericPropertyEvaluatorName_);
-        }
-        else {
-          throw std::runtime_error("unknown property type");  
-        }
-        
-        // store the map
-        propertyDataMap_[thePropEnum] = matData;
-      }  
-    } 
+  }
+  else {
+    throw std::runtime_error("Error: material_properties::load(): 'material_properties' line does not exist");
   }
 }
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -33,6 +33,7 @@
 #include "FieldTypeDef.h"
 #include "LinearSystem.h"
 #include "master_element/MasterElement.h"
+#include "MaterialProperty.h"
 #include "MaterialPropertys.h"
 #include "MeshMotionInfo.h"
 #include "NaluParsing.h"
@@ -1134,45 +1135,50 @@ Realm::setup_initial_conditions()
 void
 Realm::setup_property()
 {
-  // loop over all target names
-  const std::vector<std::string> targetNames = get_physics_target_names();
-  for (size_t itarget=0; itarget < targetNames.size(); ++itarget) {
-
-    // target need not be subsetted since nothing below will depend on topo
-    stk::mesh::Part *targetPart = metaData_->get_part(targetNames[itarget]);
-
-    // loop over propertyMap
-    std::map<PropertyIdentifier, ScalarFieldType *>::iterator ii;
-    for ( ii=propertyMap_.begin(); ii!=propertyMap_.end(); ++ii ) {
-
-      // extract property id and field pointer
-      PropertyIdentifier thePropId = (*ii).first;
-      ScalarFieldType *thePropField = (*ii).second;
-
-      // find the material property data object
-      MaterialPropertyData *matData = NULL;
-      std::map<PropertyIdentifier, MaterialPropertyData*>::iterator itf =
-        materialPropertys_.propertyDataMap_.find(thePropId);
-      if ( itf == materialPropertys_.propertyDataMap_.end() ) {
-        // will need to throw
-        NaluEnv::self().naluOutputP0() << "issue with property: " << PropertyIdentifierNames[thePropId] << std::endl;
-        throw std::runtime_error("Please add property specification ");
-      }
-      else {
-        matData = (*itf).second;
-      }
-
-      switch( matData->type_) {
+  // loop overall material property blocks
+  for ( size_t i = 0; i < materialPropertys_.materialPropertyVector_.size(); ++i ) {
+    
+    MaterialProperty *matPropBlock = materialPropertys_.materialPropertyVector_[i];
+    
+    // loop over all target names
+    for (size_t itarget=0; itarget < matPropBlock->targetNames_.size(); ++itarget) {
+      
+      // target need not be subsetted since nothing below will depend on topo
+      const std::string physicsPartName = physics_part_name(matPropBlock->targetNames_[itarget]);
+      stk::mesh::Part *targetPart = metaData_->get_part(physicsPartName);
+      
+      // loop over propertyMap
+      std::map<PropertyIdentifier, ScalarFieldType *>::iterator ii;
+      for ( ii=propertyMap_.begin(); ii!=propertyMap_.end(); ++ii ) {
+        
+        // extract property id and field pointer
+        PropertyIdentifier thePropId = (*ii).first;
+        ScalarFieldType *thePropField = (*ii).second;
+        
+        // find the material property data object
+        MaterialPropertyData *matData = NULL;
+        std::map<PropertyIdentifier, MaterialPropertyData*>::iterator itf =
+          matPropBlock->propertyDataMap_.find(thePropId);
+        if ( itf == matPropBlock->propertyDataMap_.end() ) {
+          // will need to throw
+          NaluEnv::self().naluOutputP0() << "issue with property: " << PropertyIdentifierNames[thePropId] << std::endl;
+          throw std::runtime_error("Please add property specification ");
+        }
+        else {
+          matData = (*itf).second;
+        }
+        
+        switch( matData->type_) {
 
         case CONSTANT_MAT:
         {
-
+          
           // for constant specific heat, proceed in specialty code; create the appropriate enthalpy evaluator
           if (thePropId == SPEC_HEAT_ID && needsEnthalpy_) {
             // extract reference temperature
             double tRef = 300.0;
-            extract_universal_constant("reference_temperature", tRef, true);
-
+            matPropBlock->extract_universal_constant("reference_temperature", tRef, true);
+            
             // set up evaluators required for all cases
             PropertyEvaluator *theCpPropEval = NULL;
             PropertyEvaluator *theEnthPropEval = NULL;
@@ -1218,8 +1224,8 @@ Realm::setup_property()
 
             }
             // push to prop eval
-            materialPropertys_.propertyEvalMap_[SPEC_HEAT_ID] = theCpPropEval;
-            materialPropertys_.propertyEvalMap_[ENTHALPY_ID]  = theEnthPropEval;
+            matPropBlock->propertyEvalMap_[SPEC_HEAT_ID] = theCpPropEval;
+            matPropBlock->propertyEvalMap_[ENTHALPY_ID]  = theEnthPropEval;
           }
           else {
 
@@ -1280,7 +1286,7 @@ Realm::setup_property()
 
                 // all props will use Tref
                 double tRef = 0.0;
-                extract_universal_constant("reference_temperature", tRef, true);
+                matPropBlock->extract_universal_constant("reference_temperature", tRef, true);
 
                 if ( uniformFlow_ ) {
                   // props computed based on YkRef and Tref
@@ -1301,7 +1307,7 @@ Realm::setup_property()
                 if ( uniformFlow_ ) {
                   // props computed based on YkRef and T
                   viscPropEval = new SutherlandsPropertyEvaluator(
-                    materialPropertys_.referencePropertyDataMap_, matData->polynomialCoeffsMap_ );
+                    matPropBlock->referencePropertyDataMap_, matData->polynomialCoeffsMap_ );
                 }
                 else {
                   // props computed based on Yk and T
@@ -1315,7 +1321,7 @@ Realm::setup_property()
               }
 
               // create the property alg and push to evalmap
-              materialPropertys_.propertyEvalMap_[thePropId] = viscPropEval;
+              matPropBlock->propertyEvalMap_[thePropId] = viscPropEval;
 
             }
             break;
@@ -1330,7 +1336,7 @@ Realm::setup_property()
             {
               // R
               double universalR = 8314.4621;
-              extract_universal_constant("universal_gas_constant", universalR, true);
+              matPropBlock->extract_universal_constant("universal_gas_constant", universalR, true);
 
               // create the property alg and push to evalmap
               PropertyEvaluator *theCpPropEval = NULL;
@@ -1338,19 +1344,19 @@ Realm::setup_property()
               if ( uniformFlow_ ) {
                 // props computed based on reference values
                 theCpPropEval = new SpecificHeatPropertyEvaluator(
-                    materialPropertys_.referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
+                    matPropBlock->referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
                     matData->highPolynomialCoeffsMap_, universalR);
                 theEnthPropEval = new EnthalpyPropertyEvaluator(
-                    materialPropertys_.referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
+                    matPropBlock->referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
                     matData->highPolynomialCoeffsMap_, universalR);
               }
               else {
                 // props computed based on transported Yk values
                 theCpPropEval = new SpecificHeatTYkPropertyEvaluator(
-                    materialPropertys_.referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
+                    matPropBlock->referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
                     matData->highPolynomialCoeffsMap_, universalR, *metaData_);
                 theEnthPropEval = new EnthalpyTYkPropertyEvaluator(
-                   materialPropertys_.referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
+                   matPropBlock->referencePropertyDataMap_, matData->lowPolynomialCoeffsMap_,
                    matData->highPolynomialCoeffsMap_, universalR, *metaData_);
               }
 
@@ -1360,8 +1366,8 @@ Realm::setup_property()
               propertyAlg_.push_back(auxAlg);
 
               // set property maps...
-              materialPropertys_.propertyEvalMap_[SPEC_HEAT_ID] = theCpPropEval;
-              materialPropertys_.propertyEvalMap_[ENTHALPY_ID] = theEnthPropEval;
+              matPropBlock->propertyEvalMap_[SPEC_HEAT_ID] = theCpPropEval;
+              matPropBlock->propertyEvalMap_[ENTHALPY_ID] = theEnthPropEval;
             }
             break;
 
@@ -1377,7 +1383,7 @@ Realm::setup_property()
         
             // everyone will require R
             double universalR = 8314.4621;
-            extract_universal_constant("universal_gas_constant", universalR, true);
+            matPropBlock->extract_universal_constant("universal_gas_constant", universalR, true);
             
             // create the property evaluator
             PropertyEvaluator *rhoPropEval = NULL;
@@ -1385,8 +1391,8 @@ Realm::setup_property()
               // load mw and reference species
               std::vector<std::pair<double, double> > mwMassFracVec;
               std::map<std::string, ReferencePropertyData*>::const_iterator itrp;
-              for ( itrp = materialPropertys_.referencePropertyDataMap_.begin();
-                    itrp!= materialPropertys_.referencePropertyDataMap_.end(); ++itrp) {
+              for ( itrp = matPropBlock->referencePropertyDataMap_.begin();
+                    itrp!= matPropBlock->referencePropertyDataMap_.end(); ++itrp) {
                 ReferencePropertyData *propData = (*itrp).second;
                 std::pair<double,double> thePair;
                 thePair = std::make_pair(propData->mw_,propData->massFraction_);
@@ -1394,7 +1400,7 @@ Realm::setup_property()
               }
               if ( IDEAL_GAS_T_MAT == matData->type_ ) {
                 double pRef = 101325.0;
-                extract_universal_constant("reference_pressure", pRef, true);
+                matPropBlock->extract_universal_constant("reference_pressure", pRef, true);
                 rhoPropEval = new IdealGasTPropertyEvaluator(pRef, universalR, mwMassFracVec);
               }
               else {
@@ -1405,14 +1411,14 @@ Realm::setup_property()
               // load mw
               std::vector<double> mwVec;
               std::map<std::string, ReferencePropertyData*>::const_iterator itrp;
-              for ( itrp = materialPropertys_.referencePropertyDataMap_.begin();
-                    itrp!= materialPropertys_.referencePropertyDataMap_.end(); ++itrp) {
+              for ( itrp = matPropBlock->referencePropertyDataMap_.begin();
+                    itrp!= matPropBlock->referencePropertyDataMap_.end(); ++itrp) {
                 ReferencePropertyData *propData = (*itrp).second;
                 mwVec.push_back(propData->mw_);
               }
               if ( IDEAL_GAS_T_MAT == matData->type_ ) {
                 double pRef = 101325.0;
-                extract_universal_constant("reference_pressure", pRef, true);
+                matPropBlock->extract_universal_constant("reference_pressure", pRef, true);
                 rhoPropEval = new IdealGasTYkPropertyEvaluator(pRef, universalR, mwVec, *metaData_);
               }
               else {
@@ -1421,7 +1427,7 @@ Realm::setup_property()
             }
 
             // push back property evaluator to map
-            materialPropertys_.propertyEvalMap_[thePropId] = rhoPropEval;
+            matPropBlock->propertyEvalMap_[thePropId] = rhoPropEval;
 
             // create the property algorithm
             TemperaturePropAlgorithm *auxAlg
@@ -1443,15 +1449,15 @@ Realm::setup_property()
             double pRef = 101325.0;
             double tRef = 300.0;
             double universalR = 8314.4621;
-            extract_universal_constant("reference_pressure", pRef, true);
-            extract_universal_constant("reference_temperature", tRef, true);
-            extract_universal_constant("universal_gas_constant", universalR, true);
+            matPropBlock->extract_universal_constant("reference_pressure", pRef, true);
+            matPropBlock->extract_universal_constant("reference_temperature", tRef, true);
+            matPropBlock->extract_universal_constant("universal_gas_constant", universalR, true);
 
             // load mw
             std::vector<double> mwVec;
             std::map<std::string, ReferencePropertyData*>::const_iterator itrp;
-            for ( itrp = materialPropertys_.referencePropertyDataMap_.begin();
-                  itrp!= materialPropertys_.referencePropertyDataMap_.end(); ++itrp) {
+            for ( itrp = matPropBlock->referencePropertyDataMap_.begin();
+                  itrp!= matPropBlock->referencePropertyDataMap_.end(); ++itrp) {
               ReferencePropertyData *propData = (*itrp).second;
               mwVec.push_back(propData->mw_);
             }
@@ -1460,7 +1466,7 @@ Realm::setup_property()
             PropertyEvaluator *rhoPropEval = new IdealGasYkPropertyEvaluator(pRef, tRef, universalR, mwVec, *metaData_);
 
             // push back property evaluator to map
-            materialPropertys_.propertyEvalMap_[thePropId] = rhoPropEval;
+            matPropBlock->propertyEvalMap_[thePropId] = rhoPropEval;
 
             // create the property algorithm
             GenericPropAlgorithm *auxAlg
@@ -1486,7 +1492,7 @@ Realm::setup_property()
         case HDF5_TABLE_MAT:
         {
 	  if ( HDF5ptr_ == NULL ) {
-	    HDF5ptr_ = new HDF5FilePtr( materialPropertys_.propertyTableName_ );
+	    HDF5ptr_ = new HDF5FilePtr( matPropBlock->propertyTableName_ );
 	  }
 
  	  // create the new TablePropAlgorithm that knows how to read from HDF5 file
@@ -1527,73 +1533,51 @@ Realm::setup_property()
 	break;
 
       case GENERIC: 
-        { 
-          // default property evaluator
-          PropertyEvaluator *propEval = NULL;
-          
-          // extract the property evaluator name
-          std::string propEvalName = matData->genericPropertyEvaluatorName_;
-
-          if ( propEvalName == "water_viscosity_T" ) {
-            propEval = new WaterViscosityTPropertyEvaluator(*metaData_);
-          }
-          else if ( propEvalName == "water_density_T" ) {
-            propEval = new WaterDensityTPropertyEvaluator(*metaData_);
-          }
-          else if ( propEvalName == "water_specific_heat_T" ) {
-            propEval = new WaterSpecHeatTPropertyEvaluator(*metaData_);
-            // create the enthalpy prop evaluator and store
-            WaterEnthalpyTPropertyEvaluator *theEnthPropEval 
-              = new WaterEnthalpyTPropertyEvaluator(*metaData_);
-            materialPropertys_.propertyEvalMap_[ENTHALPY_ID] = theEnthPropEval;
-          }
-          else if ( propEvalName == "water_thermal_conductivity_T" ) {
-            propEval = new WaterThermalCondTPropertyEvaluator(*metaData_);
-          }
-          else {
-            throw std::runtime_error("Realm::setup_property: unknown GENERIC type: " + propEvalName);
-          }
-          
-          // for now, all of the above are TempPropAlgs; push it back
-          TemperaturePropAlgorithm *auxAlg
-            = new TemperaturePropAlgorithm( *this, targetPart, thePropField, propEval);
-          propertyAlg_.push_back(auxAlg);
-
-          // push back property evaluator to map
-          materialPropertys_.propertyEvalMap_[thePropId] = propEval;
+      { 
+        // default property evaluator
+        PropertyEvaluator *propEval = NULL;
+        
+        // extract the property evaluator name
+        std::string propEvalName = matData->genericPropertyEvaluatorName_;
+        
+        if ( propEvalName == "water_viscosity_T" ) {
+          propEval = new WaterViscosityTPropertyEvaluator(*metaData_);
         }
-        break;
-
+        else if ( propEvalName == "water_density_T" ) {
+          propEval = new WaterDensityTPropertyEvaluator(*metaData_);
+        }
+        else if ( propEvalName == "water_specific_heat_T" ) {
+          propEval = new WaterSpecHeatTPropertyEvaluator(*metaData_);
+          // create the enthalpy prop evaluator and store
+          WaterEnthalpyTPropertyEvaluator *theEnthPropEval 
+            = new WaterEnthalpyTPropertyEvaluator(*metaData_);
+          matPropBlock->propertyEvalMap_[ENTHALPY_ID] = theEnthPropEval;
+        }
+        else if ( propEvalName == "water_thermal_conductivity_T" ) {
+          propEval = new WaterThermalCondTPropertyEvaluator(*metaData_);
+        }
+        else {
+          throw std::runtime_error("Realm::setup_property: unknown GENERIC type: " + propEvalName);
+        }
+        
+        // for now, all of the above are TempPropAlgs; push it back
+        TemperaturePropAlgorithm *auxAlg
+          = new TemperaturePropAlgorithm( *this, targetPart, thePropField, propEval);
+        propertyAlg_.push_back(auxAlg);
+        
+        // push back property evaluator to map
+        matPropBlock->propertyEvalMap_[thePropId] = propEval;
+      }
+      break;
+      
         case MaterialPropertyType_END:
           break;
-
+          
         default:
           throw std::runtime_error("Realm::setup_property: unknown type:");
+        }
       }
     }
-  }
-}
-
-//--------------------------------------------------------------------------
-//-------- extract_universal_constant --------------------------------------
-//--------------------------------------------------------------------------
-void
-Realm::extract_universal_constant( 
-  const std::string name, double &value, const bool useDefault)
-{
-  std::map<std::string, double >::iterator it
-    = materialPropertys_.universalConstantMap_.find(name);
-  if ( it == materialPropertys_.universalConstantMap_.end() ) {
-    // not found
-    if ( useDefault ) {
-      NaluEnv::self().naluOutputP0() << "WARNING: Reference value for " << name << " not found " << " using " << value << std::endl;
-    }
-    else {
-      throw std::runtime_error("Realm::setup_property: reference value not found: " + name);
-    }
-  }
-  else {
-    value = (*it).second;
   }
 }
 
@@ -4390,17 +4374,20 @@ Realm::get_nc_alg_current_normal()
 //--------------------------------------------------------------------------
 //-------- get_material_prop_eval ------------------------------------------
 //--------------------------------------------------------------------------
-PropertyEvaluator *
+void
 Realm::get_material_prop_eval(
-  const PropertyIdentifier thePropID)
+  const PropertyIdentifier thePropID,
+  std::vector<PropertyEvaluator*> &propEvalVec)
 {
-  PropertyEvaluator *thePropEval = NULL;
-  std::map<PropertyIdentifier, PropertyEvaluator*>::const_iterator iter
-    = materialPropertys_.propertyEvalMap_.find(thePropID);
-  if (iter != materialPropertys_.propertyEvalMap_.end()) {
-    thePropEval = (*iter).second;
+  for ( size_t i = 0; i < materialPropertys_.materialPropertyVector_.size(); ++i ) {
+    PropertyEvaluator *thePropEval = NULL;
+    std::map<PropertyIdentifier, PropertyEvaluator*>::const_iterator iter
+      = materialPropertys_.materialPropertyVector_[i]->propertyEvalMap_.find(thePropID);
+    if (iter != materialPropertys_.materialPropertyVector_[i]->propertyEvalMap_.end()) {
+      thePropEval = (*iter).second;
+    }
+    propEvalVec.push_back(thePropEval);
   }
-  return thePropEval;
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Use cases for multiphysics requires multi-matrial. This is mostly
due to conjugate heat transfer applications that will use one single
realm.

* Simple restructuring of Material parsing:

******** Newly supported multi-material approach:

```
    material_properties:

      properties:

        - name: mat_one
          target_name: [block_10]

          specifications:

            - name: density
              type: constant
              value: 1.0

            - name: specific_heat
              type: constant
              value: 1.0

            - name: thermal_conductivity
              type: constant
              value: 1.0

        - name: mat_two
          target_name: [block_20]

          specifications:

            - name: density
              type: constant
              value: 1.0

            - name: specific_heat
              type: constant
              value: 1.0

            - name: thermal_conductivity
              type: constant
              value: 1.0

```
******** Routine block is still supported (this work is concentrating on a temperature-form approach)

```
    material_properties:

      target_name: [block_10, block_20]
      specifications:
        - name: density
          type: constant
          value: 1.0

        - name: specific_heat
          type: constant
          value: 1.0

        - name: thermal_conductivity
          type: constant
          value: 1.0
```

* Transition parsing to the new design. For old material_block, create a single
material property object.

* Support backward compatibility. Things get odd when attempting multi-material
enthalpy - something that is not a use case of interest (immediately, at least).
Protect by a throw should enthalpy system have multiple material evaluators found.

* Make sure that the material property algorithms extract the proper promoted
higher-order part.

* add two block use case to DG/HC

Notes:

a) No diffs as expected.
b) May consider moving the material evaluator from nodes to the element..