### PR TITLE
Clean out the ToDo list; boost

### DIFF
--- a/include/ActuatorLinePointDrag.h
+++ b/include/ActuatorLinePointDrag.h
@@ -188,7 +188,7 @@ public:
   Realm &realm_;
 
   // type of stk search
-  stk::search::SearchMethod searchMethod_;
+  const stk::search::SearchMethod searchMethod_;
 
   // custom ghosting
   stk::mesh::Ghosting *actuatorLineGhosting_;

--- a/include/FixPressureAtNodeInfo.h
+++ b/include/FixPressureAtNodeInfo.h
@@ -59,7 +59,7 @@ struct FixPressureAtNodeInfo
   stk::mesh::PartVector partVec_;
 
   //! Search method for determining the nearest node to the prescribed location
-  stk::search::SearchMethod searchMethod_{stk::search::KDTREE};
+  const stk::search::SearchMethod searchMethod_{stk::search::KDTREE};
 
   NodeLookupType lookupType_{SPATIAL_LOCATION};
 

--- a/include/NonConformalInfo.h
+++ b/include/NonConformalInfo.h
@@ -103,7 +103,7 @@ class NonConformalInfo {
   /* expand search box */
   double expandBoxPercentage_;
 
-  stk::search::SearchMethod searchMethod_;
+  const stk::search::SearchMethod searchMethod_;
 
   /* clip isoparametric coordinates if they are out of bounds */
   const bool clipIsoParametricCoords_;

--- a/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.i
+++ b/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.i
@@ -162,7 +162,6 @@ realms:
         node_lookup_type: spatial_location
         location: [100.0, 2500.0, 1.0]
         search_target_part: [fluid_part]
-        search_method: stk_kdtree
 
       options:
 
@@ -248,7 +247,6 @@ realms:
     # 245 degrees (southwest) at 90 m above the surface in a planar 
     # averaged sense.  
     abl_forcing:
-      search_method: stk_kdtree
       search_tolerance: 0.0001
       search_expansion_factor: 1.5
 

--- a/reg_tests/test_files/actuatorLine/actuatorLine.i
+++ b/reg_tests/test_files/actuatorLine/actuatorLine.i
@@ -120,7 +120,6 @@ realms:
 
     actuator:
       type: ActLinePointDrag
-      search_method: boost_rtree
       search_target_part: block_1
 
       specifications:

--- a/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.i
+++ b/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.i
@@ -100,7 +100,6 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - wall_boundary_condition: bc_3
       target_name: surface_3
@@ -229,7 +228,6 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - wall_boundary_condition: bc_inner
       target_name: surface_3
@@ -318,7 +316,6 @@ realms:
       target_name: [surface_3, surface_4]
       periodic_user_data:
         search_tolerance: 1.e-2
-        search_method: boost_rtree
 
     solution_options:
       name: myOptionsHC

--- a/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic_rst.i
+++ b/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic_rst.i
@@ -100,7 +100,6 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - wall_boundary_condition: bc_3
       target_name: surface_3
@@ -230,7 +229,6 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - wall_boundary_condition: bc_inner
       target_name: surface_3
@@ -320,7 +318,6 @@ realms:
       target_name: [surface_3, surface_4]
       periodic_user_data:
         search_tolerance: 1.e-2
-        search_method: boost_rtree
 
     solution_options:
       name: myOptionsHC

--- a/reg_tests/test_files/heatedBackStep/heatedBackStep.i
+++ b/reg_tests/test_files/heatedBackStep/heatedBackStep.i
@@ -153,7 +153,6 @@ realms:
       target_name: [surface_6, surface_7]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - wall_boundary_condition: bc_top
       target_name: surface_8

--- a/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge.i
+++ b/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge.i
@@ -180,7 +180,6 @@ realms:
 
       output_frequency: 5
 
-      search_method: stk_kdtree
       search_tolerance: 1.0e-3
       search_expansion_factor: 2.0
 

--- a/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
+++ b/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
@@ -177,7 +177,6 @@ realms:
 
       output_frequency: 5
 
-      search_method: stk_kdtree
       search_tolerance: 1.0e-3
       search_expansion_factor: 2.0
 

--- a/reg_tests/test_files/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.i
+++ b/reg_tests/test_files/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.i
@@ -104,7 +104,6 @@ realms:
       target_name: [leftWall, rightWall]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
 
     - symmetry_boundary_condition: bc_top
       target_name: topWall

--- a/src/ActuatorLinePointDrag.C
+++ b/src/ActuatorLinePointDrag.C
@@ -245,13 +245,10 @@ ActuatorLinePointDrag::load(
     get_if_present(y_actuatorLine, "search_method", searchMethodName, searchMethodName);
 
     // determine search method for this pair
-    if ( searchMethodName == "boost_rtree" )
-      searchMethod_ = stk::search::BOOST_RTREE;
-    else if ( searchMethodName == "stk_kdtree" )
-      searchMethod_ = stk::search::KDTREE;
-    else
-      NaluEnv::self().naluOutputP0() << "ActuatorLinePointDrag::search method not declared; will use stk_kdtree" << std::endl;
-
+    if ( searchMethodName != "stk_kdtree" )
+      NaluEnv::self().naluOutputP0() << "ActuatorLinePointDrag::search_method only supports stk_kdtree" 
+                                     << std::endl;
+    
     // extract the set of from target names; each spec is homogeneous in this respect
     const YAML::Node searchTargets = y_actuatorLine["search_target_part"];
     if (searchTargets.Type() == YAML::NodeType::Scalar) {

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -85,7 +85,7 @@ NonConformalInfo::NonConformalInfo(
     currentPartVec_(currentPartVec),
     opposingPartVec_(opposingPartVec),
     expandBoxPercentage_(expandBoxPercentage),
-    searchMethod_(stk::search::BOOST_RTREE),
+    searchMethod_(stk::search::KDTREE),
     clipIsoParametricCoords_(clipIsoParametricCoords),
     searchTolerance_(searchTolerance),
     dynamicSearchTolAlg_(dynamicSearchTolAlg),
@@ -93,12 +93,9 @@ NonConformalInfo::NonConformalInfo(
     canReuse_(false)
 {
   // determine search method for this pair
-  if ( searchMethodName == "boost_rtree" )
-    searchMethod_ = stk::search::BOOST_RTREE;
-  else if ( searchMethodName == "stk_kdtree" )
-    searchMethod_ = stk::search::KDTREE;
-  else
-    NaluEnv::self().naluOutputP0() << "NonConformalInfo::search method not declared; will use boost_rtree" << std::endl;
+  if ( searchMethodName != "stk_kdtree" )
+    NaluEnv::self().naluOutputP0() << "NonConformalInfo::search_method only supports stk_kdtree" 
+                                   << std::endl;
 }
 
 //--------------------------------------------------------------------------

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -89,12 +89,9 @@ PeriodicManager::add_periodic_pair(
 
   // determine search method for this pair; default is boost_rtree
   stk::search::SearchMethod searchMethod = stk::search::KDTREE;
-  if ( searchMethodName == "boost_rtree" )
-    searchMethod = stk::search::BOOST_RTREE;
-  else if ( searchMethodName == "stk_kdtree" )
-    searchMethod = stk::search::KDTREE;
-  else
-    NaluEnv::self().naluOutputP0() << "PeriodicManager::search method not declared; will use stk_kdtree" << std::endl;
+  if ( searchMethodName != "stk_kdtree" )
+    NaluEnv::self().naluOutputP0() << "PeriodicManager::search_method only supports stk_kdtree" 
+                                   << std::endl;
   searchMethodVec_.push_back(searchMethod);
 }
 

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -466,12 +466,8 @@ SolutionOptions::load(const YAML::Node & y_node)
           fix_pressure["search_target_part"].as<std::vector<std::string>>();
         if (fix_pressure["search_method"]) {
           std::string searchMethodName = fix_pressure["search_method"].as<std::string>();
-          if (searchMethodName == "boost_rtree")
-            fixPressureInfo_->searchMethod_ = stk::search::BOOST_RTREE;
-          else if (searchMethodName == "stk_kdtree")
-            fixPressureInfo_->searchMethod_ = stk::search::KDTREE;
-          else
-            NaluEnv::self().naluOutputP0() << "ABL Fix Pressure: Search will use stk_kdtree"
+          if (searchMethodName != "stk_kdtree")
+            NaluEnv::self().naluOutputP0() << "ABL::search_method only supports stk_kdtree"
                                            << std::endl;
         }
       }

--- a/src/xfer/Transfer.C
+++ b/src/xfer/Transfer.C
@@ -354,14 +354,11 @@ void Transfer::allocate_stk_transfer() {
 
   typedef stk::transfer::GeometricTransfer< class LinInterp< class FromMesh, class ToMesh > > STKTransfer;
 
-  // extract search type
-  stk::search::SearchMethod searchMethod = stk::search::KDTREE;
-  if ( searchMethodName_ == "boost_rtree" )
-    searchMethod = stk::search::BOOST_RTREE;
-  else if ( searchMethodName_ == "stk_kdtree" )
-    searchMethod = stk::search::KDTREE;
-  else
-    NaluEnv::self().naluOutputP0() << "Transfer::search method not declared; will use stk_kdtree" << std::endl;
+  // extract search type; at present, only one supported
+  const stk::search::SearchMethod searchMethod = stk::search::KDTREE;
+  if ( searchMethodName_ != "stk_kdtree" )
+    NaluEnv::self().naluOutputP0() << "Transfer::search_method only supports stk_kdtree" 
+                                   << std::endl;
   transfer_.reset(new STKTransfer(from_mesh, to_mesh, name_, searchExpansionFactor_, searchMethod));
 }
 


### PR DESCRIPTION
* Deprecate boost search; only stk::kdtree is now supported

* Remove search method line commands from input files. If we move
to a new NGP approach, we can activate in once more. Rather than
strip out all of the code and let the contsructors hard code the search
method, I left the code in place for future seach support.

Notes:

a. As [hopefully] expected, no diffs due to coarse search change