### PR TITLE
Design the FEM kernels to be more dynamic for future deployment of FEM

### DIFF
--- a/include/BuildTemplates.h
+++ b/include/BuildTemplates.h
@@ -18,6 +18,9 @@ template class ClassName<AlgTraitsTet4>;                          \
 template class ClassName<AlgTraitsPyr5>;                          \
 template class ClassName<AlgTraitsWed6>;                          \
 
+#define INSTANTIATE_FEM_KERNEL_3D(ClassName)                      \
+template class ClassName<AlgTraitsHex8>;                          \
+
 #define INSTANTIATE_KERNEL_FACE_3D(ClassName)                     \
 template class ClassName<AlgTraitsTri3>;                          \
 template class ClassName<AlgTraitsQuad4>;                         \
@@ -84,6 +87,9 @@ INSTANTIATE_POLY_TEMPLATE(ClassName,AlgTraitsEdgePQuadPGL)        \
   INSTANTIATE_KERNEL_2D(ClassName)                                \
   INSTANTIATE_KERNEL_3D_HO(ClassName)                             \
   INSTANTIATE_KERNEL_2D_HO(ClassName)                             \
+
+#define INSTANTIATE_FEM_KERNEL(ClassName)                         \
+  INSTANTIATE_FEM_KERNEL_3D(ClassName)                            \
 
 #define INSTANTIATE_KERNEL_FACE(ClassName)                        \
   INSTANTIATE_KERNEL_FACE_3D(ClassName)                           \

--- a/include/kernel/ScalarDiffFemKernel.h
+++ b/include/kernel/ScalarDiffFemKernel.h
@@ -57,11 +57,10 @@ private:
   VectorFieldType *coordinates_{nullptr};
 
   // master element
-  Hex8FEM * meFEM_;
-  double *ipWeight_;
   const bool shiftedGradOp_;
   
   /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numGp_]> v_ip_weight_{ "v_ip_weight" };
   AlignedViewType<DoubleType[AlgTraits::numGp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
 };
 

--- a/include/master_element/MasterElementFactory.h
+++ b/include/master_element/MasterElementFactory.h
@@ -33,11 +33,19 @@ namespace nalu{
       int dimension = 0,
       std::string quadType = "GaussLegendre");
 
+    static MasterElement*
+    get_fem_master_element(
+      const stk::topology& theTopo,
+      int dimension = 0,
+      std::string quadType = "GaussLegendre");
+
     static void clear();
   private:
     MasterElementRepo() = default;
+    // allow support of all three types of master elements in a given simulation
     static std::map<stk::topology, std::unique_ptr<MasterElement>> surfaceMeMap_;
     static std::map<stk::topology, std::unique_ptr<MasterElement>> volumeMeMap_;
+    static std::map<stk::topology, std::unique_ptr<MasterElement>> femMeMap_;
   };
 
 } // namespace nalu

--- a/src/kernel/ScalarDiffFemKernel.C
+++ b/src/kernel/ScalarDiffFemKernel.C
@@ -34,24 +34,26 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
     bulkData_(&bulkData),
     scalarQ_(scalarQ),
     diffFluxCoeff_(diffFluxCoeff),
-    meFEM_(new Hex8FEM()),
-    ipWeight_(&meFEM_->weights_[0]),
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ_->name()))
 {
-  ThrowRequireMsg(AlgTraits::topo_ == stk::topology::HEX_8,
-                  "FEM_DIFF only available for hexes currently");
-
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");
 
+  // extract master element
+  MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);
+  
+  // copy ip weights into our 1-d view
+  for ( int k = 0; k < AlgTraits::numGp_; ++k )
+    v_ip_weight_[k] = meFEM->weights_[k];
+  
   // master element, shape function is shifted consistently
   if ( shiftedGradOp_ )
-    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shifted_shape_fcn(ptr);}, v_shape_function_);
+    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM->shifted_shape_fcn(ptr);}, v_shape_function_);
   else
-    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM_->shape_fcn(ptr);}, v_shape_function_);
+    get_fem_shape_fn_data<AlgTraits>([&](double* ptr){meFEM->shape_fcn(ptr);}, v_shape_function_);
 
-  dataPreReqs.add_fem_volume_me(meFEM_);
+  dataPreReqs.add_fem_volume_me(meFEM);
 
   // fields and data
   dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
@@ -66,7 +68,7 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
 template<typename AlgTraits>
 ScalarDiffFemKernel<AlgTraits>::~ScalarDiffFemKernel()
 {
-  delete meFEM_;
+  // does nothing
 }
 
 template<typename AlgTraits>
@@ -92,8 +94,8 @@ ScalarDiffFemKernel<AlgTraits>::execute(
     }
 
     // start the assembly
-    const DoubleType ipFactor = v_det_j(ip)*ipWeight_[ip];
-
+    const DoubleType ipFactor = v_det_j(ip)*v_ip_weight_(ip);
+    
     // row ir
     for ( int ir = 0; ir < AlgTraits::nodesPerElement_; ++ir) {
 
@@ -115,7 +117,7 @@ ScalarDiffFemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarDiffFemKernel);
+INSTANTIATE_FEM_KERNEL(ScalarDiffFemKernel);
 
 }  // nalu
 }  // sierra

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -9,6 +9,7 @@
 #include "master_element/MasterElement.h"
 
 #include "master_element/Hex8CVFEM.h"
+#include "master_element/Hex8FEM.h"
 #include "master_element/Hex27CVFEM.h"
 #include "master_element/Tet4CVFEM.h"
 #include "master_element/Pyr5CVFEM.h"
@@ -186,6 +187,27 @@ namespace nalu{
   }
   //--------------------------------------------------------------------------
   std::unique_ptr<MasterElement>
+  create_fem_master_element(stk::topology topo)
+  {
+    if (topo.is_super_topology()) {
+      // super topologies uses different master element type
+      return nullptr;
+    }
+
+    switch ( topo.value() ) {
+
+      case stk::topology::HEX_8:
+        return make_unique<Hex8FEM>();
+
+      default:
+        NaluEnv::self().naluOutputP0() << "sorry, FEM only supports Hex8 elements" << std::endl;
+        NaluEnv::self().naluOutputP0() << "your type is " << topo.value() << std::endl;
+        break;
+    }
+    return nullptr;
+  }
+  //--------------------------------------------------------------------------
+  std::unique_ptr<MasterElement>
   create_volume_master_element(
     stk::topology topo,
     int dimension,
@@ -254,10 +276,31 @@ namespace nalu{
     return theElem;
   }
 
+  std::map<stk::topology, std::unique_ptr<MasterElement>> MasterElementRepo::femMeMap_;
+  
+  MasterElement* MasterElementRepo::get_fem_master_element(
+    const stk::topology& theTopo,
+    int dimension,
+    std::string quadType)
+  {
+    // do not support arbitrary FEM promotion
+    if ( theTopo.is_super_topology() )
+      throw std::runtime_error("higher-order promotion is not valid for FEM-based approaches");  
+    auto it = femMeMap_.find(theTopo);
+    if (it == femMeMap_.end()) {
+      femMeMap_[theTopo] = create_fem_master_element(theTopo);
+    }
+    
+    MasterElement* theElem = femMeMap_.at(theTopo).get();
+    ThrowRequire(theElem != nullptr);
+    return theElem;
+  }
+
   void MasterElementRepo::clear()
   {
     surfaceMeMap_.clear();
     volumeMeMap_.clear();
+    femMeMap_.clear();
   }
 
 }


### PR DESCRIPTION
* No need to new a special FEM master element. We instantiate only
Hex8 currently.

* Wrap ipWeight in a view

* Added femMeMap_ to allow for FEM-based elements and CVFEM in one realm.

* Modified FEM kernel.