### PR TITLE
Support exposed face/element FEM-based algorithms

### DIFF
--- a/include/AlgTraits.h
+++ b/include/AlgTraits.h
@@ -45,8 +45,8 @@ struct AlgTraitsTet4 {
 struct AlgTraitsTet10 {
   static constexpr int nDim_ = 3;
   static constexpr int nodesPerElement_ = 10;
-  static constexpr int numScsIp_ = -1; // CVFEM not supported
-  static constexpr int numScvIp_ = -1; // CVFEM not supported
+  static constexpr int numScsIp_ = 16; // CVFEM not supported
+  static constexpr int numScvIp_ = 16; // CVFEM not supported
   static constexpr int numGp_ = 16; 
   static constexpr stk::topology::topology_t topo_ = stk::topology::TET_10;
 };
@@ -140,8 +140,8 @@ struct AlgTraitsTri3
 struct AlgTraitsTri6 {
   static constexpr int nDim_ = 3;
   static constexpr int nodesPerElement_ = 6;
-  static constexpr int nodesPerFace_ = 6;
-  static constexpr int numGp_ = 7;
+  static constexpr int nodesPerFace_ = nodesPerElement_;
+  static constexpr int numFaceIp_ = 7;
   static constexpr stk::topology::topology_t topo_ = stk::topology::TRI_6;
 };
 
@@ -178,12 +178,13 @@ struct AlgTraitsFaceElem
 
   static constexpr int nodesPerElement_ = ElemTraits::nodesPerElement_;
   static constexpr int nodesPerFace_ = FaceTraits::nodesPerElement_;
-
+  
   static constexpr int numScsIp_ = ElemTraits::numScsIp_;
   static constexpr int numScvIp_ = ElemTraits::numScvIp_;
-
-  static constexpr int numFaceIp_ = FaceTraits::numScsIp_;
-
+  static constexpr int numGp_ = ElemTraits::numGp_;
+  
+  static constexpr int numFaceIp_ = FaceTraits::numFaceIp_;
+  
   static constexpr stk::topology::topology_t elemTopo_ = ElemTraits::topo_;
   static constexpr stk::topology::topology_t faceTopo_ = FaceTraits::topo_;
 };
@@ -198,6 +199,8 @@ using AlgTraitsTri3Wed6 = AlgTraitsFaceElem<AlgTraitsTri3, AlgTraitsWed6>;
 using AlgTraitsQuad4Hex8 = AlgTraitsFaceElem<AlgTraitsQuad4, AlgTraitsHex8>;
 using AlgTraitsQuad4Pyr5 = AlgTraitsFaceElem<AlgTraitsQuad4, AlgTraitsPyr5>;
 using AlgTraitsQuad4Wed6 = AlgTraitsFaceElem<AlgTraitsQuad4, AlgTraitsWed6>;
+
+using AlgTraitsTri6Tet10 = AlgTraitsFaceElem<AlgTraitsTri6, AlgTraitsTet10>;
 
 using AlgTraitsEdge32DQuad92D = AlgTraitsFaceElem<AlgTraitsEdge3_2D, AlgTraitsQuad9_2D>;
 using AlgTraitsQuad9Hex27 = AlgTraitsFaceElem<AlgTraitsQuad9, AlgTraitsHex27>;

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -49,14 +49,18 @@ public:
       sierra::nalu::MasterElement* meFC = faceDataNeeded_.get_cvfem_face_me();
       sierra::nalu::MasterElement* meSCS = faceDataNeeded_.get_cvfem_surface_me();
       sierra::nalu::MasterElement* meSCV = faceDataNeeded_.get_cvfem_volume_me();
-
+      sierra::nalu::MasterElement* meFEM = faceDataNeeded_.get_fem_volume_me();
+      sierra::nalu::MasterElement* meFCFEM = faceDataNeeded_.get_fem_face_me();
+      
       sierra::nalu::ScratchMeInfo meElemInfo;
       meElemInfo.nodalGatherSize_ = nodesPerElem_;
       meElemInfo.nodesPerFace_ = nodesPerFace_;
       meElemInfo.nodesPerElement_ = nodesPerElem_;
-      meElemInfo.numFaceIp_ = meFC != nullptr ? meFC->numIntPoints_ : 0;
+      meElemInfo.numFaceIp_ = meFC != nullptr ? meFC->numIntPoints_  
+        : meFCFEM != nullptr ? meFCFEM->numIntPoints_: 0;
       meElemInfo.numScsIp_ = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
       meElemInfo.numScvIp_ = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
+      meElemInfo.numFemIp_ = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
 
       int rhsSize = meElemInfo.nodalGatherSize_*numDof_, lhsSize = rhsSize*rhsSize, scratchIdsSize = rhsSize;
 

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -35,7 +35,10 @@ enum ELEM_DATA_NEEDED {
   FEM_GRAD_OP,
   FEM_SHIFTED_GRAD_OP,
   FEM_DET_J,
-  FEM_NORMAL
+  FEM_NORMAL,
+  FEM_FACE_NORMAL,
+  FEM_FACE_GRAD_OP,
+  FEM_FACE_DET_J,
 };
 
 enum COORDS_TYPES {
@@ -76,7 +79,7 @@ public:
   ElemDataRequests()
     : dataEnums(),
       coordsFields_(),
-    fields(), meFC_(nullptr), meSCS_(nullptr), meSCV_(nullptr), meFEM_(nullptr)
+    fields(), meFC_(nullptr), meSCS_(nullptr), meSCV_(nullptr), meFCFEM_(nullptr), meFEM_(nullptr)
   {
   }
 
@@ -126,6 +129,11 @@ public:
     meSCS_ = meSCS;
   }
 
+  void add_fem_face_me(MasterElement *meFCFEM)
+  {
+    meFCFEM_ = meFCFEM;
+  }
+
   void add_fem_volume_me(MasterElement *meFEM)
   {
     meFEM_ = meFEM;
@@ -156,6 +164,7 @@ public:
   MasterElement *get_cvfem_volume_me() const {return meSCV_;}
   MasterElement *get_cvfem_surface_me() const {return meSCS_;}
   MasterElement *get_fem_volume_me() const {return meFEM_;}
+  MasterElement *get_fem_face_me() const {return meFCFEM_;}
 
 private:
   std::array<std::set<ELEM_DATA_NEEDED>, MAX_COORDS_TYPES> dataEnums;
@@ -164,6 +173,7 @@ private:
   MasterElement *meFC_;
   MasterElement *meSCS_;
   MasterElement *meSCV_;
+  MasterElement *meFCFEM_;
   MasterElement *meFEM_;
 };
 

--- a/include/kernel/ScalarPngBcFemKernel.h
+++ b/include/kernel/ScalarPngBcFemKernel.h
@@ -51,8 +51,8 @@ private:
   ScalarFieldType *scalarQ_{nullptr};
   
   // fixed scratch space
-  AlignedViewType<DoubleType[BcAlgTraits::numGp_]> v_ip_weight_{ "v_ip_weight" };
-  AlignedViewType<DoubleType[BcAlgTraits::numGp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_]> v_ip_weight_{ "v_ip_weight" };
+  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_{"vf_shape_function"};
 };
 
 }  // nalu

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -97,6 +97,13 @@ public:
     SharedMemView<DoubleType*>&det_j) {
     throw std::runtime_error("shifted_grad_op using SharedMemView is not implemented");}
 
+  virtual void face_grad_op_fem(
+    int face_ordinal,
+    SharedMemView<DoubleType**>& coords,
+    SharedMemView<DoubleType***>& gradop,
+    SharedMemView<DoubleType*>&det_j) {
+    throw std::runtime_error("face_grad_op_fem using SharedMemView is not implemented");}
+
   virtual void determinant(
     SharedMemView<DoubleType**>&coords,
     SharedMemView<DoubleType**>&areav) {
@@ -286,6 +293,7 @@ public:
 
   // FEM
   std::vector<double>weights_;
+  std::vector<double>sideWeights_;
 };
 
 class QuadrilateralP2Element : public MasterElement

--- a/include/master_element/Tet10FEM.h
+++ b/include/master_element/Tet10FEM.h
@@ -10,6 +10,7 @@
 #define Tet10FEM_h
 
 #include<master_element/MasterElement.h>
+#include<master_element/Tri6FEM.h>
 
 namespace sierra{
 namespace nalu{
@@ -21,10 +22,7 @@ public:
 
   Tet10FEM();
   virtual ~Tet10FEM();
-  
-  // define the quadrature rule
-  const bool fifteenPt_;
-  
+    
   // NGP-ready methods first
   void determinant_fem(
     SharedMemView<DoubleType**>&coords,
@@ -41,6 +39,12 @@ public:
     SharedMemView<DoubleType**>&coords,
     SharedMemView<DoubleType***>&gradop,
     SharedMemView<DoubleType***>&deriv,
+    SharedMemView<DoubleType*>&det_j) final;
+
+  void face_grad_op_fem(
+    int face_ordinal,
+    SharedMemView<DoubleType**>& coords,
+    SharedMemView<DoubleType***>& gradop,
     SharedMemView<DoubleType*>&det_j) final;
 
   void shape_fcn(
@@ -78,6 +82,12 @@ public:
     const double *field,
     double *result);
 
+  void sidePcoords_to_elemPcoords(
+    const int & side_ordinal,
+    const int & npoints,
+    const double *side_pcoords,
+    double *elem_pcoords);
+
   void tet10_fem_shape_fcn(
     const int  &numIp,
     const double *isoParCoord,
@@ -95,6 +105,9 @@ public:
 
   double parametric_distance(
     const double *x);
+
+ private:
+  Tri6FEM *tri6FEM_;
 };
     
 } // namespace nalu

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -94,9 +94,10 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
   MasterElement *meSCS = dataNeededBySuppAlgs.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeededBySuppAlgs.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeededBySuppAlgs.get_fem_volume_me();
+  MasterElement *meFCFEM = dataNeededBySuppAlgs.get_fem_face_me();
   
-  const bool faceDataNeeded = meFC != nullptr
-    && meSCS == nullptr && meSCV == nullptr && meFEM == nullptr;
+  const bool faceDataNeeded = (meFC != nullptr || meFCFEM != nullptr)
+    && (meSCS == nullptr && meSCV == nullptr && meFEM == nullptr);
   const bool elemDataNeeded = meFC == nullptr
     && (meSCS != nullptr || meSCV != nullptr || meFEM != nullptr);
 
@@ -107,9 +108,11 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     : meSCV != nullptr ? meSCV->nodesPerElement_ 
     : meFEM != nullptr ? meFEM->nodesPerElement_
     : meFC  != nullptr ? meFC->nodesPerElement_
+    : meFCFEM != nullptr ? meFCFEM->nodesPerElement_
     : 0;
 
-  const int numFaceIp = meFC != nullptr ? meFC->numIntPoints_ : 0;
+  const int numFaceIp = meFC != nullptr ? meFC->numIntPoints_ 
+    : meFCFEM != nullptr ? meFCFEM->numIntPoints_ : 0;
   const int numScsIp = meSCS != nullptr ? meSCS->numIntPoints_ : 0;
   const int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
   const int numFemIp = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
@@ -140,7 +143,7 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     // Updated logic for data sharing of deriv and det_j
     bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
     bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
-
+   
     for(ELEM_DATA_NEEDED data : dataEnums) {
       switch(data)
       {
@@ -193,7 +196,22 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
           break;
         case FEM_NORMAL:
           needDerivFem = true;
+          needDetjFem = true;
           numScalars += nDim * numFemIp;
+          break;
+        case FEM_FACE_GRAD_OP:
+          needDerivFC = true;
+          needDetjFC = true;
+          numScalars += nodesPerEntity*numFaceIp*nDim;
+          break;
+        case FEM_FACE_DET_J:
+          needDerivFC = true;
+          needDetjFC = true;
+          break;
+        case FEM_FACE_NORMAL:
+          needDerivFC = true;
+          needDetjFC = true;
+          numScalars += nDim * numFaceIp;
           break;
         default: 
           ThrowRequireMsg(false, "get_num_scalars_pre_req_data: enum not coded " << data);
@@ -209,10 +227,7 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
 
     if (needDerivScv)
       numScalars += nodesPerEntity*numScvIp*nDim;
-    
-    if (needDerivFem)
-      numScalars += nodesPerEntity*numFemIp*nDim;
-    
+        
     if (needDetjFC)
       numScalars += numFaceIp;
 
@@ -222,6 +237,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     if (needDetjScv)
       numScalars += numScvIp;
     
+    if (needDerivFem)
+      numScalars += nodesPerEntity*numFemIp*nDim;
+
     if (needDetjFem)
       numScalars += numFemIp;
   }
@@ -319,6 +337,20 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
           needDerivFem = true;
           numScalars += nDim * numFemIp;
           break;
+        case FEM_FACE_GRAD_OP:
+          needDerivFC = true;
+          needDetjFC = true;
+          numScalars += nodesPerEntity*numFaceIp*nDim;
+          break;
+        case FEM_FACE_DET_J:
+          needDerivFC = true;
+          needDetjFC = true;
+          break;
+        case FEM_FACE_NORMAL:
+          needDerivFC = true;
+          needDetjFC = true;
+          numScalars += nDim * numFaceIp;
+          break;
         default: 
           ThrowRequireMsg(false, "get_num_scalars_pre_req_data: enum not coded " << data);
           break;
@@ -334,9 +366,6 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     if (needDerivScv)
       numScalars += nodesPerEntity*numScvIp*nDim;
 
-    if (needDerivFem)
-      numScalars += nodesPerEntity*numFemIp*nDim;
-
     if (needDetjFC)
       numScalars += numFaceIp;
 
@@ -346,6 +375,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     if (needDetjScv)
       numScalars += numScvIp;
 
+    if (needDerivFem)
+      numScalars += nodesPerEntity*numFemIp*nDim;
+    
     if (needDetjFem)
       numScalars += numFemIp;
   }
@@ -367,6 +399,7 @@ void fill_pre_req_data(
   MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
+  MasterElement *meFCFEM = dataNeeded.get_fem_face_me();
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
   prereqData.elemNodes = bulkData.begin_nodes(elem);
 
@@ -427,7 +460,7 @@ void fill_pre_req_data(
       SharedMemView<double**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
       auto& meData = prereqData.get_me_views(cType);
   
-      meData.fill_master_element_views(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM);
+      meData.fill_master_element_views(dataEnums, coordsView, meFC, meSCS, meSCV, meFCFEM, meFEM);
     }
   }
 }
@@ -442,6 +475,7 @@ void fill_master_element_views(
     MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
     MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
     MasterElement *meFEM = dataNeeded.get_fem_volume_me();
+    MasterElement *meFCFEM = dataNeeded.get_fem_face_me();
 
     for (auto it = dataNeeded.get_coordinates_map().begin();
          it != dataNeeded.get_coordinates_map().end(); ++it) {
@@ -452,7 +486,7 @@ void fill_master_element_views(
       SharedMemView<DoubleType**>* coordsView = &prereqData.get_scratch_view_2D(*coordField);
       auto& meData = prereqData.get_me_views(cType);
   
-      meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM, faceOrdinal);
+      meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFCFEM, meFEM, faceOrdinal);
     }
 }
 

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -117,11 +117,11 @@ ContinuityOpenElemKernel<BcAlgTraits>::execute(
  
   // dndx for both rhs and lhs
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
   SharedMemView<DoubleType***>& v_dndx_lhs = (shiftedGradOp_ || reducedSensitivities_)
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -143,8 +143,8 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType*>& v_viscosity = elemScratchViews.get_scratch_view_1D(*viscosity_);
   SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(*density_);
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -85,8 +85,8 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   // element
   SharedMemView<DoubleType**>& v_uNp1 = elemScratchViews.get_scratch_view_2D(*velocityNp1_);
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -94,8 +94,8 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
 
   // dndx for both rhs and lhs
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/ScalarPngBcFemKernel.C
+++ b/src/kernel/ScalarPngBcFemKernel.C
@@ -39,14 +39,14 @@ ScalarPngBcFemKernel<BcAlgTraits>::ScalarPngBcFemKernel(
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(BcAlgTraits::topo_);
 
   // copy ip weights into our 1-d view
-  for ( int k = 0; k < BcAlgTraits::numGp_; ++k )
+  for ( int k = 0; k < BcAlgTraits::numFaceIp_; ++k )
     v_ip_weight_[k] = meFEM->weights_[k];
   
   // compute and save shape function
   if ( solnOpts.get_shifted_grad_op(fieldName) )
-    get_fem_shape_fn_data<BcAlgTraits>([&](double* ptr){meFEM->shifted_shape_fcn(ptr);}, vf_shape_function_);
+    get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFEM->shifted_shape_fcn(ptr);}, vf_shape_function_);
   else
-    get_fem_shape_fn_data<BcAlgTraits>([&](double* ptr){meFEM->shape_fcn(ptr);}, vf_shape_function_);
+    get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFEM->shape_fcn(ptr);}, vf_shape_function_);
   
   // add master elements
   dataPreReqs.add_fem_volume_me(meFEM);
@@ -73,7 +73,7 @@ ScalarPngBcFemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType*>& v_det_j = scratchViews.get_me_views(CURRENT_COORDINATES).det_j_fem;
   SharedMemView<DoubleType**>& v_normal = scratchViews.get_me_views(CURRENT_COORDINATES).normal_fem;
   
-  for ( int ip = 0; ip < BcAlgTraits::numGp_; ++ip ) {
+  for ( int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip ) {
     
     // interpolate to bip
     DoubleType qBip = 0.0;

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -77,10 +77,10 @@ void test_MEBC_views(int faceOrdinal, const std::vector<sierra::nalu::ELEM_DATA_
 
     for(sierra::nalu::ELEM_DATA_NEEDED request : elem_requests) {
       if (request == sierra::nalu::SCS_FACE_GRAD_OP) {
-        compare_old_face_grad_op(faceOrdinal, false, v_coords, meViews.dndx_fc_scs, driver.meSCS_);
+        compare_old_face_grad_op(faceOrdinal, false, v_coords, meViews.dndx_fc, driver.meSCS_);
       }
       if (request == sierra::nalu::SCS_SHIFTED_FACE_GRAD_OP) {
-        compare_old_face_grad_op(faceOrdinal, true, v_coords, meViews.dndx_shifted_fc_scs, driver.meSCS_);
+        compare_old_face_grad_op(faceOrdinal, true, v_coords, meViews.dndx_shifted_fc, driver.meSCS_);
       }
     }
   });


### PR DESCRIPTION
* Add face_grad_op for FEM

* Modify Scratch and ElemData interface. In reality, we do not
  need things like dndx_fc_scs and dndx_fc_fem as they
  both operate on numIps. dndx_scs and dndx_scv are useful
  while dndx_fem starts looking more like dndx_scs... For another day..

* Simplified the logic to fold support dndx_fc for FEM. This means that we are
  likely never going to support mixed methods, e.g., dndx_fc_scs and
  dndx_fc_fem in the same PDE solve. This seems safe as I have only ever
  done this for DOM NSO stabilization.

* Added Tri6Tet10 AlgTraits.

* Share face shape function extraction for CVFEM and FEM

* modify unit test to remove fc_scs