### PR TITLE
Towards support for FEM-based open bc: low-Mach fluid flow

### DIFF
--- a/include/LowMachFemEquationSystem.h
+++ b/include/LowMachFemEquationSystem.h
@@ -51,6 +51,11 @@ public:
     stk::mesh::Part *part,
     const stk::topology &theTopo);
 
+  virtual void register_open_bc(
+    stk::mesh::Part *part,
+    const stk::topology &partTopo,
+    const OpenBoundaryConditionData &openBCData);
+
   virtual void pre_iter_work();
   virtual void solve_and_update();
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -141,9 +141,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     int dndxLength = 0, dndxLengthFC = 0, gUpperLength = 0, gLowerLength = 0;
 
     // Updated logic for data sharing of deriv and det_j
-    bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
-    bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
-   
+    bool needDeriv = false; bool needDerivScv = false; bool needDerivFC = false;  bool needDerivFCElem = false;
+    bool needDetj = false; bool needDetjScv = false; bool needDetjFC = false;
+    bool needDerivFem = false;  bool needDetjFem = false; 
     for(ELEM_DATA_NEEDED data : dataEnums) {
       switch(data)
       {
@@ -156,7 +156,7 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
         case SCS_FACE_GRAD_OP:
         case SCS_SHIFTED_FACE_GRAD_OP:
           dndxLengthFC = nodesPerEntity*numFaceIp*nDim;
-          needDerivFC = true;
+          needDerivFCElem = true;
           needDetjFC = true;
           numScalars += dndxLengthFC;
           break;
@@ -200,7 +200,7 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
           numScalars += nDim * numFemIp;
           break;
         case FEM_FACE_GRAD_OP:
-          needDerivFC = true;
+          needDerivFCElem = true;
           needDetjFC = true;
           numScalars += nodesPerEntity*numFaceIp*nDim;
           break;
@@ -220,6 +220,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     }
 
     if (needDerivFC)
+      numScalars += nodesPerEntity*numFaceIp*nDim;
+
+    if (needDerivFCElem)
       numScalars += nodesPerEntity*numFaceIp*nDim;
 
     if (needDeriv)
@@ -280,9 +283,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     int dndxLength = 0, dndxLengthFC = 0, gUpperLength = 0, gLowerLength = 0;
 
     // Updated logic for data sharing of deriv and det_j
-    bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
-    bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
-
+    bool needDeriv = false; bool needDerivScv = false; bool needDerivFC = false; bool needDerivFCElem = false;
+    bool needDetj = false; bool needDetjScv = false; bool needDetjFC = false;
+    bool needDerivFem = false; bool needDetjFem = false; 
     for(ELEM_DATA_NEEDED data : dataEnums) {
       switch(data)
       {
@@ -295,7 +298,7 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
         case SCS_FACE_GRAD_OP:
         case SCS_SHIFTED_FACE_GRAD_OP:
           dndxLengthFC = nodesPerEntity*numFaceIp*nDim;
-          needDerivFC = true;
+          needDerivFCElem = true;
           needDetjFC = true;
           numScalars += dndxLengthFC;
           break;
@@ -358,6 +361,9 @@ int get_num_scalars_pre_req_data(ElemDataRequests& dataNeededBySuppAlgs, int nDi
     }
 
     if (needDerivFC)
+      numScalars += nodesPerEntity*numFaceIp*nDim;
+
+    if (needDerivFCElem)
       numScalars += nodesPerEntity*numFaceIp*nDim;
 
     if (needDeriv)

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -142,9 +142,9 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(*velocityRTM_);
   SharedMemView<DoubleType*>& v_viscosity = elemScratchViews.get_scratch_view_1D(*viscosity_);
   SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(*density_);
-  SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
+  SharedMemView<DoubleType***>& v_dndx_fc_elem = shiftedGradOp_
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_elem
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_elem;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
@@ -275,7 +275,7 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
         
         const DoubleType axj = vf_exposedAreaVec(ip,j);
-        const DoubleType dndxj = v_dndx(ip,ic,j);
+        const DoubleType dndxj = v_dndx_fc_elem(ip,ic,j);
         const DoubleType uxj = v_velocityNp1(ic,j);
         
         const DoubleType divUstress = 2.0/3.0*viscBip*dndxj*uxj*axj*includeDivU_;
@@ -285,7 +285,7 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
           // matrix entries
           int indexR = nearestNode*BcAlgTraits::nDim_ + i;
           
-          const DoubleType dndxi = v_dndx(ip,ic,i);
+          const DoubleType dndxi = v_dndx_fc_elem(ip,ic,i);
           const DoubleType uxi = v_velocityNp1(ic,i);
           const DoubleType nxi = w_nx[i];
           const DoubleType om_nxinxi = 1.0-nxi*nxi;
@@ -306,7 +306,7 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
             if ( i != l ) {
               const DoubleType nxinxl = nxi*w_nx[l];
               const DoubleType uxl = v_velocityNp1(ic,l);
-              const DoubleType dndxl = v_dndx(ip,ic,l);
+              const DoubleType dndxl = v_dndx_fc_elem(ip,ic,l);
               
               // +ni*nl*mu*dul/dxj*Aj; sneak in divU (explicit)
               lhsfac = viscBip*dndxj*axj*nxinxl;

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -84,9 +84,9 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
  
   // element
   SharedMemView<DoubleType**>& v_uNp1 = elemScratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
+  SharedMemView<DoubleType***>& v_dndx_fc_elem = shiftedGradOp_
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_elem
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_elem;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
@@ -116,7 +116,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
         
         const DoubleType axj = vf_exposedAreaVec(ip,j);
-        const DoubleType dndxj = v_dndx(ip,ic,j);
+        const DoubleType dndxj = v_dndx_fc_elem(ip,ic,j);
         const DoubleType uxj = v_uNp1(ic,j);
         
         const DoubleType divUstress = 2.0/3.0*viscBip*dndxj*uxj*axj*includeDivU_;
@@ -125,7 +125,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
 
           const int indexR = nearestNode*BcAlgTraits::nDim_ +i;
 
-          const DoubleType dndxi = v_dndx(ip,ic,i);
+          const DoubleType dndxi = v_dndx_fc_elem(ip,ic,i);
           const DoubleType uxi = v_uNp1(ic,i);
           const DoubleType nxi = w_nx[i];
           const DoubleType nxinxi = nxi*nxi;
@@ -146,7 +146,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
             if ( i != l ) {
               const DoubleType nxinxl = nxi*w_nx[l];
               const DoubleType uxl = v_uNp1(ic,l);
-              const DoubleType dndxl = v_dndx(ip,ic,l);
+              const DoubleType dndxl = v_dndx_fc_elem(ip,ic,l);
               
               // -ni*nl*mu*dul/dxj*Aj; sneak in divU (explicit)
               lhsfac = -viscBip*dndxj*axj*nxinxl;

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -93,9 +93,9 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType*>& v_scalarQ = elemScratchViews.get_scratch_view_1D(*scalarQ_);
 
   // dndx for both rhs and lhs
-  SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 
-    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc
-    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc;
+  SharedMemView<DoubleType***>& v_dndx_fc_elem = shiftedGradOp_ 
+    ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_elem
+    : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_elem;
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     
@@ -115,7 +115,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
     for ( int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic ) {
       const int faceNodeNumber = face_node_ordinals[ic];
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
-        inverseLengthScale += v_dndx(ip,faceNodeNumber,j)*vf_exposedAreaVec(ip,j);
+        inverseLengthScale += v_dndx_fc_elem(ip,faceNodeNumber,j)*vf_exposedAreaVec(ip,j);
       }
     }        
     inverseLengthScale /= aMag;
@@ -135,7 +135,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
     for ( int ic = 0; ic < BcAlgTraits::nodesPerElement_; ++ic ) {
       const DoubleType qIc = v_scalarQ(ic);
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
-        w_dqdxBip[j] += v_dndx(ip,ic,j)*qIc;
+        w_dqdxBip[j] += v_dndx_fc_elem(ip,ic,j)*qIc;
       }
     }
     
@@ -160,7 +160,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
     for ( int ic = 0; ic < BcAlgTraits::nodesPerElement_; ++ic ) {
       DoubleType lhsFac = 0.0;
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j )
-        lhsFac += -v_dndx(ip,ic,j)*vf_exposedAreaVec(ip,j);
+        lhsFac += -v_dndx_fc_elem(ip,ic,j)*vf_exposedAreaVec(ip,j);
       lhs(nearestNode,ic) += diffFluxCoeffBip*lhsFac;
     }    
   }

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -77,10 +77,10 @@ void test_MEBC_views(int faceOrdinal, const std::vector<sierra::nalu::ELEM_DATA_
 
     for(sierra::nalu::ELEM_DATA_NEEDED request : elem_requests) {
       if (request == sierra::nalu::SCS_FACE_GRAD_OP) {
-        compare_old_face_grad_op(faceOrdinal, false, v_coords, meViews.dndx_fc, driver.meSCS_);
+        compare_old_face_grad_op(faceOrdinal, false, v_coords, meViews.dndx_fc_elem, driver.meSCS_);
       }
       if (request == sierra::nalu::SCS_SHIFTED_FACE_GRAD_OP) {
-        compare_old_face_grad_op(faceOrdinal, true, v_coords, meViews.dndx_shifted_fc, driver.meSCS_);
+        compare_old_face_grad_op(faceOrdinal, true, v_coords, meViews.dndx_shifted_fc_elem, driver.meSCS_);
       }
     }
   });


### PR DESCRIPTION

* fix a numFaceIp error  formaly numFemIp

* add face ME pre-reqs off of faceData not elemData

* missing coordinates registration off of faceData

* another missing coord on faceData

* modify design for derivatives. Only FEM requires deriv_fc for a face:elemnet
  algorithm (purely off of the face for things like face normal and face det_j)
  while deriv_fc_elem is required for face grad ops. This makes things cleaner.

* deploy the consistent usage of the name "dndx_fc_elem" - just to be overly
  specific. At present, there is no need for a dndx_fc usage, however, adding
  the _elem really drives the point.

* wrong ME for face_grad_op_fem

* deal with IR loop - needs to be npf

* mapping between local ir face node and global number on the matrix

Notes:

a) Mess of a design/consistency when we decide we require an dedicated
   derivative. In many cases, we internally (to the master element) create
   a constant expression for derivatives while in other cases, we save off
   something in ScratchViews.

b) 1x2x10 running, however, not converging due to missing PNG open bc contribution.
   Will concentrate on this for the next push.