### PR TITLE
Add parallel and peridoc reductions for SST/DES min-wall field

### DIFF
--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -142,7 +142,7 @@ ComputeSSTMaxLengthScaleElemAlgorithm::execute()
     }
   }  
 
-  // parallel reduce; worry about periodic?
+  // parallel reduce
   std::vector<const stk::mesh::FieldBase *> fieldVec;
   fieldVec.push_back(maxLengthScale_);
   stk::mesh::parallel_max(bulk_data, fieldVec);

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -459,6 +459,16 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
        }
      }
    }
+  
+   // parallel reduce
+   std::vector<const stk::mesh::FieldBase *> fieldVec;
+   fieldVec.push_back(minDistanceToWall_);
+   stk::mesh::parallel_max(bulk_data, fieldVec);
+   
+   // deal with periodicity
+   if ( realm_.hasPeriodic_) {
+     realm_.periodic_field_update(minDistanceToWall_, 1);
+   }
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
* as per RCK's find

No diffs noted (coverage exists in elem backstep case)