### PR TITLE
Add dissipation rate post processing

### DIFF
--- a/include/AveragingInfo.h
+++ b/include/AveragingInfo.h
@@ -40,17 +40,18 @@ public:
   bool computeTke_;
   bool computeFavreStress_;
   bool computeFavreTke_;
-  bool computeResolvedStress_{false};
-  bool computeSFSStress_{false};
+  bool computeResolvedStress_;
+  bool computeSFSStress_;
   bool computeVorticity_;
   bool computeQcriterion_;
   bool computeLambdaCI_;
   bool computeMeanResolvedKe_;
   bool computeMeanErrorIndictor_;
+  bool computeDissipationRate_;
 
   // Temperature stresses
-  bool computeTemperatureSFS_{false};
-  bool computeTemperatureResolved_{false};
+  bool computeTemperatureSFS_;
+  bool computeTemperatureResolved_;
   
   // vector of part names, e.g., block_1, surface_2
   std::vector<std::string> targetNames_;

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -141,25 +141,32 @@ public:
 
   void compute_vorticity(
     const std::string &averageBlockName,
-	stk::mesh::Selector s_all_nodes);
+    stk::mesh::Selector s_all_nodes);
 
   void compute_q_criterion(
-	const std::string &averageBlockName,
-	stk::mesh::Selector s_all_nodes);
+    const std::string &averageBlockName,
+    stk::mesh::Selector s_all_nodes);
 
   void compute_lambda_ci(
-	const std::string &averageBlockName,
-	stk::mesh::Selector s_all_nodes);
+    const std::string &averageBlockName,
+    stk::mesh::Selector s_all_nodes);
 
   void compute_mean_resolved_ke(
-	const std::string &averageBlockName,
-	stk::mesh::Selector s_all_nodes);
+    const std::string &averageBlockName,
+    stk::mesh::Selector s_all_nodes);
 
   void compute_mean_error_indicator(
-        stk::mesh::Selector s_all_nodes,
-        const double dt,
-        const double oldTimeFilter,
-        const double zeroCurrent);
+    stk::mesh::Selector s_all_nodes,
+    const double dt,
+    const double oldTimeFilter,
+    const double zeroCurrent);
+  
+  void compute_dissipation_rate(
+    const AveragingInfo *avInfo,
+    const double &oldTimeFilter,
+    const double &zeroCurrent,
+    const double &dt,
+    stk::mesh::Selector s_all_nodes);
 
   // hold the realm
   Realm &realm_;

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -60,6 +60,14 @@ public:
     SharedMemView<DoubleType***>& gradop,
     SharedMemView<DoubleType***>& deriv);
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
   void determinant(
     const int nelem,
     const double *coords,
@@ -129,16 +137,6 @@ public:
     double *deriv,
     double *det_j,
     double * error );
-
-  void pyr_derivative(
-    const int npts,
-    const double *intLoc,
-    double *deriv);
-
-  void shifted_pyr_derivative(
-    const int npts,
-    const double *intLoc,
-    double *deriv);
 
   void gij( 
     SharedMemView<DoubleType**>& coords,

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -56,6 +56,14 @@ public:
     double *areav,
     double * error );
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
   void shape_fcn(
     double *shpfc);
 

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -38,6 +38,14 @@ public:
     SharedMemView<DoubleType***>&gradop,
     SharedMemView<DoubleType***>&deriv);
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
   void determinant(
     const int nelem,
     const double *coords,

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -49,6 +49,14 @@ public:
     SharedMemView<DoubleType***>&gradop,
     SharedMemView<DoubleType***>&deriv);
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
   void determinant(
     const int nelem,
     const double *coords,

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -36,6 +36,14 @@ public:
     SharedMemView<DoubleType***>& gradop,
     SharedMemView<DoubleType***>& deriv);
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
   void determinant(
     const int nelem,
     const double *coords,
@@ -98,11 +106,6 @@ public:
     double *deriv,
     double *det_j,
     double * error );
-
-  void wedge_derivative(
-    const int npts,
-    const double *intLoc,
-    double *deriv);
 
   void face_grad_op(
     const int nelem,

--- a/reg_tests/test_files/heatedWaterChannelElem/heatedWaterChannelElem.i
+++ b/reg_tests/test_files/heatedWaterChannelElem/heatedWaterChannelElem.i
@@ -173,6 +173,7 @@ realms:
 
           compute_tke: yes 
           compute_reynolds_stress: yes
+          compute_dissipation_rate: yes
 
         - name: two
           target_name: surface_5
@@ -203,6 +204,7 @@ realms:
        - resolved_turbulent_ke_ra_one
        - resolved_turbulent_ke_fa_one
        - reynolds_stress
+       - dissipation_rate
 
     restart:
       restart_data_base_name: heatedWaterChannelElem.rst

--- a/src/AveragingInfo.C
+++ b/src/AveragingInfo.C
@@ -28,11 +28,16 @@ AveragingInfo::AveragingInfo()
   computeTke_(false),
   computeFavreStress_(false),
   computeFavreTke_(false),
+  computeResolvedStress_(false),
+  computeSFSStress_(false),
   computeVorticity_(false),
   computeQcriterion_(false),
   computeLambdaCI_(false),
   computeMeanResolvedKe_(false),
-  computeMeanErrorIndictor_(false)
+  computeMeanErrorIndictor_(false),
+  computeDissipationRate_(false),
+  computeTemperatureSFS_(false),
+  computeTemperatureResolved_(false)
 {
   // does nothing
 }

--- a/src/master_element/Quad42DCVFEM.C
+++ b/src/master_element/Quad42DCVFEM.C
@@ -256,6 +256,33 @@ void Quad42DSCV::shifted_grad_op(
 }
 
 //--------------------------------------------------------------------------
+//-------- grad_op ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void Quad42DSCV::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  int lerr = 0;
+
+  SIERRA_FORTRAN(quad_derivative)
+    ( &numIntPoints_, &intgLoc_[0], deriv );
+  
+  SIERRA_FORTRAN(quad_gradient_operator)
+    ( &nelem,
+      &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gradop, det_j, error, &lerr );
+  
+  if ( lerr )
+    NaluEnv::self().naluOutput() << "sorry, negative Quad42DSCV volume.." << std::endl;
+}
+
+//--------------------------------------------------------------------------
 //-------- shape_fcn -------------------------------------------------------
 //--------------------------------------------------------------------------
 void
@@ -527,6 +554,9 @@ void Quad42DSCS::grad_op(
   quad_gradient_operator<Traits::numScsIp_, Traits::nodesPerElement_>(deriv, coords, gradop);
 }
 
+//--------------------------------------------------------------------------
+//-------- grad_op ---------------------------------------------------------
+//--------------------------------------------------------------------------
 void Quad42DSCS::grad_op(
   const int nelem,
   const double *coords,

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -232,6 +232,36 @@ void TetSCV::shifted_grad_op(
   generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
 }
 
+//--------------------------------------------------------------------------
+//-------- grad_op ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void TetSCV::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  int lerr = 0;
+
+  SIERRA_FORTRAN(tet_derivative)
+    ( &numIntPoints_, deriv );
+  
+  SIERRA_FORTRAN(tet_gradient_operator)
+    ( &nelem,
+      &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gradop, det_j, error, &lerr );
+
+  if ( lerr )
+    NaluEnv::self().naluOutput() << "sorry, negative TetSCV volume.." << std::endl;
+}
+
+//--------------------------------------------------------------------------
+//-------- determinant -------------------------------------------------
+//--------------------------------------------------------------------------
 void TetSCV::determinant(
   const int nelem,
   const double *coords,

--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -306,6 +306,33 @@ void Tri32DSCV::shifted_grad_op(
   tri_gradient_operator(coords, gradop, deriv);
 }
 
+//--------------------------------------------------------------------------
+//-------- grad_op ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void Tri32DSCV::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  int lerr = 0;
+
+  SIERRA_FORTRAN(tri_derivative)
+    ( &numIntPoints_, deriv );
+  
+  SIERRA_FORTRAN(tri_gradient_operator)
+    ( &nelem,
+      &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gradop, det_j, error, &lerr );
+  
+  if ( lerr )
+    NaluEnv::self().naluOutput() << "sorry, negative Tri32DSCV volume.." << std::endl;
+}
+
 void Tri32DSCV::determinant(
   const int nelem,
   const double *coords,


### PR DESCRIPTION
Activate via: compute_dissipation_rate: yes

* compute CVFEM-based eps at the element. Integrate over the SCV ips
  field name is "dissipation_rate"

* add grad_op for all SCV elements

* moved around a few member functions for derivatives and grad_ops to
  be able to share between SCS and SCV

* add postP for eta to rtest