### PR TITLE
New type of data probe averaging: Ring

### DIFF
--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -40,18 +40,28 @@ class Transfers;
 
 class DataProbeInfo {
 public:
-  DataProbeInfo() {}
+   DataProbeInfo() : numProbes_(0) {}
   ~DataProbeInfo() {}
-
+  
   // for each type of probe, e.g., line of site, hold some stuff
-  bool isLineOfSite_;
   int numProbes_;
+  // manage the types of probes
+  std::vector<int> isLineOfSite_;
+  std::vector<int> isRing_;
   std::vector<std::string> partName_;
   std::vector<int> processorId_;
   std::vector<int> numPoints_;
   std::vector<int> generateNewIds_;
+
+  // line of site type
   std::vector<Coordinates> tipCoordinates_;
   std::vector<Coordinates> tailCoordinates_;
+
+  // ring type (vector or vectors to allow for 3D and 2D rotations)
+  std::vector<std::array<double, 3> > unitNormal_;
+  std::vector<std::array<double, 3> > originCoordinates_;
+  std::vector<std::array<double, 3> > seedCoordinates_;
+  
   std::vector<std::vector<stk::mesh::Entity> > nodeVector_;
   std::vector<stk::mesh::Part *> part_;
 };
@@ -112,6 +122,12 @@ public:
   // output to a file
   void provide_output(const double currentTime);
   
+  // general rotation matrix about a unit normal centered at origin (0,0,0)
+  void compute_R(const double theta, const std::vector<double> &u, std::vector<double> &R);
+  
+  // provide a 3x3 * 3x1 multiply
+  void mat_vec(const std::vector<double> &coord, const std::vector<double> &R, std::vector<double> &newCoord); 
+
   // provide the inactive selector
   stk::mesh::Selector &get_inactive_selector();
 

--- a/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
+++ b/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
@@ -201,6 +201,13 @@ realms:
               tip_coordinates: [0.459, 6.78e-2]
               tail_coordinates: [0.371, 0.0252]
 
+          ring_specifications:
+            - name: probeRingOne
+              number_of_points: 32
+              unit_normal: [0.0, 0.0, 1.0]
+              origin_coordinates: [0.42, 0.014269, 0.0]
+              seed_coordinates: [0.4116, 0.014269, 0.0]
+
           output_variables:
             - field_name: velocity
               field_size: 2


### PR DESCRIPTION
* re-work the data probes to support line_of_site and ring specifications:

    data_probes:

      output_frequency: 5

      search_tolerance: 1.0e-3
      search_expansion_factor: 2.0

      specifications:

        - name: probe_volume
          from_target_part: block_1

          line_of_site_specifications:
            - name: probeLine_zero
              number_of_points: 100
              tip_coordinates: [-0.005, 0.0, 0.1]
              tail_coordinates: [0.005, 0.0, 0.1]

          ring_specifications:

            - name: probeRingFrontOne_one
              number_of_points: 16
              unit_normal: [0.0, 0.0, -1.0]
              origin_coordinates: [0.0, 0.0, 0.1]
              seed_coordinates: [0.0, 2.5e-3, 0.1]

          output_variables:

            - field_name: velocity
              field_size: 3

            - field_name: reynolds_stress
              field_size: 6

Note:

a) tested in 2D and 3D. 2D drove a need to save a vector of arrays...
b) can lift to Iris now