### PR TITLE
New ring data probe infrastructure

### DIFF
--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -51,19 +51,43 @@ public:
   std::vector<std::string> partName_;
   std::vector<int> processorId_;
   std::vector<int> numPoints_;
+  std::vector<int> numLinePoints_;
+  std::vector<int> numTotalPoints_;
   std::vector<int> generateNewIds_;
 
-  // line of site type
+  // line of nodes
   std::vector<Coordinates> tipCoordinates_;
   std::vector<Coordinates> tailCoordinates_;
 
-  // ring type (vector or vectors to allow for 3D and 2D rotations)
+  // ring unit normal and origin (vector or vectors to allow for 3D and 2D rotations)
   std::vector<std::array<double, 3> > unitNormal_;
   std::vector<std::array<double, 3> > originCoordinates_;
   std::vector<std::array<double, 3> > seedCoordinates_;
   
   std::vector<std::vector<stk::mesh::Entity> > nodeVector_;
   std::vector<stk::mesh::Part *> part_;
+};
+
+class ProbeType {
+public:
+ ProbeType() : dataProbeInfo_(new DataProbeInfo()) {}
+  ~ProbeType() {delete dataProbeInfo_;} 
+  DataProbeInfo *dataProbeInfo_;
+
+  void setup();
+  void increment();
+};
+
+class LineOfSiteProbeType : public ProbeType {
+public:
+ LineOfSiteProbeType() {}
+ ~LineOfSiteProbeType() {}
+};
+
+class RingProbeType : public ProbeType {
+public:
+ RingProbeType() {}
+ ~RingProbeType() {}
 };
 
 class DataProbeSpecInfo {
@@ -80,6 +104,9 @@ public:
   // homegeneous collection of fields over each specification
   std::vector<std::pair<std::string, std::string> > fromToName_;
   std::vector<std::pair<std::string, int> > fieldInfo_;
+
+  // vector of probe types
+  std::vector<ProbeType *> probeTypeVec_;
 };
 
 class DataProbePostProcessing

--- a/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
+++ b/reg_tests/test_files/heatedWaterChannelEdge/heatedWaterChannelEdge_rst.i
@@ -204,9 +204,11 @@ realms:
           ring_specifications:
             - name: probeRingOne
               number_of_points: 32
+              number_of_line_points: 2
               unit_normal: [0.0, 0.0, 1.0]
               origin_coordinates: [0.42, 0.014269, 0.0]
-              seed_coordinates: [0.4116, 0.014269, 0.0]
+              tip_coordinates: [0.4116, 0.014269, 0.0]
+              tail_coordinates: [0.429, 0.014269, 0.0]
 
           output_variables:
             - field_name: velocity


### PR DESCRIPTION
Goal: Allow for easy averaging for radially symmetric flows.

* re-arrange design to allow for a set of circular/ring data probes

* input file changes for ring case

Rule:

a) One part per ring name. Other attempts were too clunky with explosion of parts.

b) Each ring starts at the tail coordinates and rotates about the origin and
   axis for each of the specified number of points. Then, dx is added based
   on the line specification (can be one) and repeats. The log file respects
   this ordering.

Complete Example:

    data_probes:

      output_frequency: 1

      search_tolerance: 1.0e-6
      search_expansion_factor: 2.0

      specifications:

        - name: probe_volume
          from_target_part: [Unspecified-2-HEX]

          line_of_site_specifications:

            - name: 25C_wale_probeCenterImpinge
              number_of_points: 20
              tip_coordinates:  [0.0, 0.0, -0.03]
              tail_coordinates: [0.0, 0.0, 0.0]

          ring_specifications:

            - name: probeRingOffImpingeRdHalf
              number_of_points: 32
              number_of_line_points: 20
              unit_normal: [0.0, 0.0, 1.0]
              origin_coordinates: [0.0, 0.0, -0.03]
              tip_coordinates: [-0.005, 0.0, 0.0]
              tail_coordinates: [-0.005, 0.0, -0.03]

          output_variables:

            - field_name: pressure
              field_size: 1

        - name: probe_surface
          from_target_part: BottomWall

          line_of_site_specifications:

            - name: 25C_wale_probePlate
              number_of_points: 200
              tip_coordinates:  [0.00, 0.0, -0.03]
              tail_coordinates: [0.15, 0.0, -0.03]

          ring_specifications:

            - name: probeRingSurface0p125
              number_of_points: 64
              number_of_line_points: 1
              unit_normal: [0.0, 0.0, 1.0]
              origin_coordinates: [0.0, 0.0, -0.03]
              tip_coordinates: [0.125, 0.0, -0.03]
              tail_coordinates: [0.125, 0.0, -0.03]

          output_variables:
            - field_name: tau_wall
              field_size: 1
            - field_name: tau_wall_ra_two
              field_size: 1