### PR TITLE
Minor clean-up to DataProbes and the inactiveSelector interface

### DIFF
--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -137,9 +137,6 @@ public:
   void review( 
     const DataProbeInfo *probeInfo);
 
-  // we want these nodes to be excluded from anything of importance
-  void create_inactive_selector();
-
   // create the transfer and hold the vector in the DataProbePostProcessing class
   void create_transfer();
 
@@ -154,9 +151,6 @@ public:
   
   // provide a 3x3 * 3x1 multiply
   void mat_vec(const std::vector<double> &coord, const std::vector<double> &R, std::vector<double> &newCoord); 
-
-  // provide the inactive selector
-  stk::mesh::Selector &get_inactive_selector();
 
   // hold the realm
   Realm &realm_;
@@ -174,11 +168,7 @@ public:
 
   // vector of specifications
   std::vector<DataProbeSpecInfo *> dataProbeSpecInfo_;
-
-  // hold all the parts; provide a selector
-  stk::mesh::PartVector allTheParts_;
-  stk::mesh::Selector inactiveSelector_;
-
+ 
   // hold the transfers
   Transfers *transfers_;
 };

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -626,8 +626,6 @@ DataProbePostProcessing::initialize()
     }
   }
 
-  create_inactive_selector();
-  
   create_transfer();
 }
   
@@ -644,30 +642,6 @@ DataProbePostProcessing::register_field(
   stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *toField 
     = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
   stk::mesh::put_field_on_mesh(*toField, *part, fieldSize, nullptr);
-}
-
-//--------------------------------------------------------------------------
-//-------- create_inactive_selector ----------------------------------------
-//--------------------------------------------------------------------------
-void
-DataProbePostProcessing::create_inactive_selector()
-{
-  for ( size_t idps = 0; idps < dataProbeSpecInfo_.size(); ++idps ) {
-
-    DataProbeSpecInfo *probeSpec = dataProbeSpecInfo_[idps];
-
-    for ( size_t k = 0; k < probeSpec->dataProbeInfo_.size(); ++k ) {
-    
-      DataProbeInfo *probeInfo = probeSpec->dataProbeInfo_[k];
-          
-      // loop over probes... one part per probe
-      for ( int j = 0; j < probeInfo->numProbes_; ++j ) {
-        allTheParts_.push_back(probeInfo->part_[j]);
-      }
-    }
-  }
-
-  inactiveSelector_ = stk::mesh::selectUnion(allTheParts_);
 }
 
 //--------------------------------------------------------------------------
@@ -852,15 +826,6 @@ DataProbePostProcessing::provide_output(
       }
     }
   }
-}
-
-//--------------------------------------------------------------------------
-//-------- get_inactive_selector -------------------------------------------
-//--------------------------------------------------------------------------
-stk::mesh::Selector &
-DataProbePostProcessing::get_inactive_selector()
-{
-  return inactiveSelector_;
 }
 
 void 


### PR DESCRIPTION
* No longer require inactive node from data probes given Real::get_inactive_selector():

  stk::mesh::Selector otherInactiveSelector = (
    metaData_->universal_part()
    & !(stk::mesh::selectUnion(interiorPartVec_))
    & !(stk::mesh::selectUnion(bcPartVec_)));

The above filters all nodes that are not of interest. The Overset aspect is not shown above..

Notes:

a) Data probes created in previous simulations prevail in subsequent
   even if the data probe in the new run is not created.

For example, in a previous run, a data probe was created:

For probe name: los_one Node Identifiers:
      562       563       564       565

In the subsequent run, these nodes still show up in the universal part:

BEGIN universal selector output:
  562 563 564 565 etc...
END   universal selector output:

However, are selected out:

BEGIN inactive selector output:
  562 563 564 565
END inactive selector output:

All is well with these extra nodes not killing the linear system setup.
See below...

b) I am trying to clean up this in a separate project to allow for clean
   restarts with changing around data probe order/definitons.