### PR TITLE
Allow for inoput output region to post process

### DIFF
--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -655,9 +655,16 @@ DataProbePostProcessing::register_field(
   stk::mesh::MetaData &metaData,
   stk::mesh::Part *part)
 {
-  stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *toField 
-    = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
-  stk::mesh::put_field_on_mesh(*toField, *part, fieldSize, nullptr);
+  // check for velocity as this is the only current vector supported
+  if ( fieldName.find("velocity") != std::string::npos ) { //FIXME: require FieldType as in InputOutpu and TurbAverga
+    VectorFieldType *someVelocity = &(metaData.declare_field<VectorFieldType>(stk::topology::NODE_RANK, fieldName));
+    stk::mesh::put_field_on_mesh(*someVelocity, *part, fieldSize, nullptr);
+  }
+  else {
+    stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *toField 
+      = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
+    stk::mesh::put_field_on_mesh(*toField, *part, fieldSize, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/InputOutputRealm.C
+++ b/src/InputOutputRealm.C
@@ -58,12 +58,14 @@ InputOutputRealm::~InputOutputRealm()
 void 
 InputOutputRealm::initialize()
 {
-  // bar minimum to register fields and to extract from possible mesh file
+  // bare minimum to register fields and to extract from possible mesh file
+  setup_post_processing_algorithms();
   register_io_fields();
   ioBroker_->populate_mesh();
   ioBroker_->populate_field_data();
   create_output_mesh();
   input_variables_from_mesh();
+  initialize_post_processing_algorithms();
 }
 
 //--------------------------------------------------------------------------

--- a/src/TimeIntegrator.C
+++ b/src/TimeIntegrator.C
@@ -347,17 +347,18 @@ TimeIntegrator::provide_mean_norm()
   // provide integrated norm
   std::vector<Realm *>::iterator ii;
   double sumNorm = 0.0;
-  double realmIncrement = 0.0;
+  int realmIncrement = 0;
   for ( ii = realmVec_.begin(); ii!=realmVec_.end(); ++ii) {
     if ( (*ii)->type_ == "multi_physics" ) { 
       // only increment for a "real" realm
       sumNorm += (*ii)->provide_mean_norm();
-      realmIncrement += 1.0;
+      realmIncrement += 1;
     }
   }
+  realmIncrement = std::max(1,realmIncrement);
   NaluEnv::self().naluOutputP0() << "Mean System Norm: "
-      << std::setprecision(16) << sumNorm/realmIncrement << " "
-      << std::setprecision(6) << timeStepCount_ << " " << currentTime_ << std::endl;
+                                 << std::setprecision(16) << sumNorm/double(realmIncrement) << " "
+                                 << std::setprecision(6) << timeStepCount_ << " " << currentTime_ << std::endl;
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
* Activate DataProbes in InputOutput realm. This allows
  for decoupling of data probes in DNS runs with super-probed
  specifications..

* Changed DataProbes to register a vector for velocity_probe. This
  follows inputOutput realm registration and turb averaging.

Sample input:

```
Simulations:
  - name: sim1
    time_integrator: ti_1
    optimizer: opt1

realms:

  - name: ioRealm
    mesh: output/elem100C_wale_Rm1.e
    type: initialization

    field_registration:
      specifications:

        - field_name: velocity
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 3
          field_type: node_rank

        - field_name: velocity_ra_one
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 3
          field_type: node_rank

        - field_name: density
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 1
          field_type: node_rank

        - field_name: density_ra_one
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 1
          field_type: node_rank

        - field_name: dudx_ra_one
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 9
          field_type: node_rank

        - field_name: reynolds_stress
          target_name: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified-6-HE
X, Unspecified-7-HEX]
          field_size: 6
          field_type: node_rank

        - field_name: tau_wall_ra_two
          target_name: BottomWall
          field_size: 1
          field_type: node_rank

#    now all of the probes

        - field_name: velocity_probe
          target_name: [100C_wale_probeCenterImpinge_IOR, probeRingImpingeRdHalf_IOR]
          field_size: 3
          field_type: node_rank

        - field_name: velocity_ra_one_probe
          target_name: [100C_wale_probeCenterImpinge_IOR, probeRingImpingeRdHalf_IOR]
          field_size: 3
          field_type: node_rank

        - field_name: density_ra_one_probe
          target_name: [100C_wale_probeCenterImpinge_IOR, probeRingImpingeRdHalf_IOR]
          field_size: 1
          field_type: node_rank

        - field_name: dudx_ra_one_probe
          target_name: [100C_wale_probeCenterImpinge_IOR, probeRingImpingeRdHalf_IOR]
          field_size: 9
          field_type: node_rank

        - field_name: reynolds_stress_probe
          target_name: [100C_wale_probeCenterImpinge_IOR, probeRingImpingeRdHalf_IOR]
          field_size: 6
          field_type: node_rank

        - field_name: tau_wall_probe
          target_name: probeRingSurface_IOR
          field_size: 1
          field_type: node_rank

        - field_name: tau_wall
          target_name: BottomWall
          field_size: 1
          field_type: node_rank

        - field_name: tau_wall_ra_two_probe
          target_name: probeRingSurface_IOR
          field_size: 1
          field_type: node_rank

    data_probes:

      output_frequency: 1

      search_tolerance: 1.0e-6
      search_expansion_factor: 2.0

      specifications:

        - name: probe_volume 
          from_target_part: [Unspecified-2-HEX, Unspecified-3-HEX, Unspecified-4-HEX, Unspecified-5-HEX, Unspecified
-6-HEX, Unspecified-7-HEX]

          line_of_site_specifications:

            - name: 100C_wale_probeCenterImpinge_IOR
              number_of_points: 48
              tip_coordinates:  [0.0, 0.0, -0.03]
              tail_coordinates: [0.0, 0.0, 0.0]

          ring_specifications:

            - name: probeRingImpingeRdHalf_IOR
              number_of_points: 4
              number_of_line_points: 3
              unit_normal: [0.0, 0.0, 1.0]
              origin_coordinates: [0.0, 0.0, -0.03]
              tip_coordinates: [0.005, 0.0, 0.0]
              tail_coordinates: [0.005, 0.0, -0.03]

          output_variables:

            - field_name: velocity
              field_size: 3

            - field_name: velocity_ra_one
              field_size: 3

            - field_name: density
              field_size: 1

            - field_name: density_ra_one
              field_size: 1

            - field_name: dudx_ra_one
              field_size: 9

            - field_name: reynolds_stress
              field_size: 6

        - name: probe_surface
          from_target_part: BottomWall

          ring_specifications:

            - name: probeRingSurface_IOR
              number_of_points: 4
              number_of_line_points: 3
              unit_normal: [0.0, 0.0, 1.0]
              origin_coordinates: [0.0, 0.0, -0.03]
              tip_coordinates: [0.12, 0.0, -0.03]
              tail_coordinates: [0.0, 0.0, -0.03]

          output_variables:

            - field_name: tau_wall
              field_size: 1

            - field_name: tau_wall_ra_two
              field_size: 1

    solution_options:
      name: myOptions
      input_variables_from_file_restoration_time: 10.0
      input_variables_interpolate_in_time: no

      options:    
        - input_variables_from_file:
            velocity: velocity 
            velocity_ra_one: velocity_ra_one 
            dudx_ra_one: dudx_ra_one 
            density: density 
            density_ra_one: density_ra_one 
            reynolds_stress: reynolds_stress 
            tau_wall: tau_wall
            tau_wall_ra_two: tau_wall_ra_two

    output:
      output_data_base_name: output/inputoutputrealm.e
      output_frequency: 1
      output_node_set: no
      output_variables:
       - velocity
       - velocity_ra_one
       - dudx_ra_one
       - density
       - density_ra_one
       - reynolds_stress
       - tau_wall
       - tau_wall_ra_two
       - velocity_ra_one_probe
       - dudx_ra_one_probe
       - density_ra_one_probe
       - tau_wall_ra_two_probe

Time_Integrators:
  - StandardTimeIntegrator:
      name: ti_1
      start_time: 0
      termination_step_count: 1
      time_step: 0.00001
      time_stepping_type: adaptive
      time_step_count: 0
      second_order_accuracy: yes

      realms:
        - ioRealm

```