### PR TITLE
Wall function params re-design

### DIFF
--- a/include/ComputeWallFrictionVelocityAlgorithm.h
+++ b/include/ComputeWallFrictionVelocityAlgorithm.h
@@ -32,14 +32,10 @@ public:
 
   void execute();
 
-  void zero_nodal_fields();
-
   void compute_utau(
       const double &up, const double &yp,
       const double &density, const double &viscosity,
       double &utau);
-  
-  void normalize_nodal_fields();
 
   const bool useShifted_;
   const double yplusCrit_;

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -30,6 +30,7 @@ class ComputeMdotAlgorithmDriver;
 class LinearSystem;
 class ProjectedNodalGradientEquationSystem;
 class SurfaceForceAndMomentAlgorithmDriver;
+class WallFunctionParamsAlgorithmDriver;
 
 /** Low-Mach formulation of the Navier-Stokes Equations
  *
@@ -182,7 +183,7 @@ public:
   AlgorithmDriver *diffFluxCoeffAlgDriver_;
   AlgorithmDriver *tviscAlgDriver_;
   AlgorithmDriver *cflReyAlgDriver_;
-  AlgorithmDriver *wallFunctionParamsAlgDriver_;
+  WallFunctionParamsAlgorithmDriver *wallFunctionParamsAlgDriver_;
 
   ProjectedNodalGradientEquationSystem *projectedNodalGradEqs_;
 

--- a/include/WallFunctionParamsAlgorithmDriver.h
+++ b/include/WallFunctionParamsAlgorithmDriver.h
@@ -1,0 +1,39 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef WallFunctionParamsAlgorithmDriver_h
+#define WallFunctionParamsAlgorithmDriver_h
+
+#include <AlgorithmDriver.h>
+#include<FieldTypeDef.h>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class WallFunctionParamsAlgorithmDriver : public AlgorithmDriver
+{
+public:
+
+  WallFunctionParamsAlgorithmDriver(
+    Realm &realm);
+  ~WallFunctionParamsAlgorithmDriver();
+
+  void pre_work();
+  void post_work();
+
+  ScalarFieldType *assembledWallArea_;
+  ScalarFieldType *assembledWallNormalDistance_;
+};
+  
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -91,6 +91,7 @@
 #include "TurbViscWaleAlgorithm.h"
 #include "FixPressureAtNodeAlgorithm.h"
 #include "FixPressureAtNodeInfo.h"
+#include "WallFunctionParamsAlgorithmDriver.h"
 
 // template for kernels
 #include "AlgTraits.h"
@@ -1769,8 +1770,8 @@ MomentumEquationSystem::register_wall_bc(
 
     // create wallFunctionParamsAlgDriver
     if ( NULL == wallFunctionParamsAlgDriver_) 
-      wallFunctionParamsAlgDriver_ = new AlgorithmDriver(realm_);
-   
+      wallFunctionParamsAlgDriver_ = new WallFunctionParamsAlgorithmDriver(realm_);
+    
     const AlgorithmType wfAlgType = WALL_FCN;
     
     // create algorithm for utau, yp and assembled nodal wall area (_WallFunction)

--- a/src/WallFunctionParamsAlgorithmDriver.C
+++ b/src/WallFunctionParamsAlgorithmDriver.C
@@ -1,0 +1,132 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <WallFunctionParamsAlgorithmDriver.h>
+#include <Algorithm.h>
+#include <AlgorithmDriver.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// WallFunctionParamsAlgorithmDriver - Drives nodal grad algorithms
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+WallFunctionParamsAlgorithmDriver::WallFunctionParamsAlgorithmDriver(
+  Realm &realm)
+  : AlgorithmDriver(realm),
+    assembledWallArea_(NULL),
+    assembledWallNormalDistance_(NULL)
+{
+  // register the fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
+  assembledWallNormalDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+WallFunctionParamsAlgorithmDriver::~WallFunctionParamsAlgorithmDriver()
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- pre_work --------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+WallFunctionParamsAlgorithmDriver::pre_work()
+{
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  // define some common selectors; select all nodes (locally and shared)
+  // where assembledWallArea is defined
+  stk::mesh::Selector s_all_nodes
+    = (meta_data.locally_owned_part() | meta_data.globally_shared_part())
+    &stk::mesh::selectField(*assembledWallArea_);
+
+  //===========================================================
+  // zero out nodal fields
+  //===========================================================
+
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin() ;
+        ib != node_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+    double * assembledWallArea = stk::mesh::field_data(*assembledWallArea_, b);
+    double * assembledWallNormalDistance = stk::mesh::field_data(*assembledWallNormalDistance_, b);
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      assembledWallArea[k] = 0.0;
+      assembledWallNormalDistance[k] = 0.0;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- post_work -------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+WallFunctionParamsAlgorithmDriver::post_work()
+{
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  // parallel assemble
+  stk::mesh::parallel_sum(bulk_data, {assembledWallArea_, assembledWallNormalDistance_});
+  
+  // periodic assemble
+  if ( realm_.hasPeriodic_) {
+    const unsigned fieldSize = 1;
+    const bool bypassFieldCheck = false; // fields are not defined at all slave/master node pairs
+    realm_.periodic_field_update(assembledWallArea_, fieldSize, bypassFieldCheck);
+    realm_.periodic_field_update(assembledWallNormalDistance_, fieldSize, bypassFieldCheck);
+  }
+
+  // normalize
+  stk::mesh::Selector s_all_nodes
+    = (meta_data.locally_owned_part() | meta_data.globally_shared_part())
+    &stk::mesh::selectField(*assembledWallArea_);
+  
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin() ;
+        ib != node_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+    const double * assembledWallArea = stk::mesh::field_data(*assembledWallArea_, b);
+    double * assembledWallNormalDistance = stk::mesh::field_data(*assembledWallNormalDistance_, b);
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      assembledWallNormalDistance[k] /= assembledWallArea[k];
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
* Create a new wall function parameters alg driver. This is due to
  the new set of wall function use-cases including machine-learned
  approaches.

  The issue with the current design is that zeroing of fields and
  parallel assembly was being conducted in the ComputeUtauAlg. This assumed
  that the single algorithm would be called once with the "symbolic" pre-
  and post- completed in the alg. However, if we have multiple types of
  algs, we need to have this elevated so that WallFuncParamsAlgDriver
  can hanlde pre and post with arbitrary types completed in the Alg.

  The SurfacePostProcessingAlgDriver is the analogous use case.