### PR TITLE
Allow for initial mesh displacement

### DIFF
--- a/include/MeshMotionInfo.h
+++ b/include/MeshMotionInfo.h
@@ -24,7 +24,8 @@ class MeshMotionInfo
    const double omega, 
    std::vector<double> centroid,
    std::vector<double> unitVec,
-   const bool computeCentroid);
+   const bool computeCentroid,
+   const double theAngle_ = 0.0);
 
   ~MeshMotionInfo();
 
@@ -34,6 +35,7 @@ class MeshMotionInfo
   std::vector<double> unitVec_;
   const double computeCentroid_;
   double computeCentroidCompleted_;
+  const double theAngle_;
 };
 
 } // namespace nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -151,7 +151,7 @@ class Realm {
 
   // overset boundary condition requires elemental field registration
   bool query_for_overset();
-
+  
   void set_omega(
     stk::mesh::Part *targetPart,
     double omega);
@@ -166,6 +166,14 @@ class Realm {
     const std::vector<double> &centroidCoords,
     const std::vector<double> &unitVec);
   void mesh_velocity_cross_product(double *o, double *c, double *u);
+
+  // allow for a single mesh displacement (coords change, however, mesh motion fixed)
+  void process_initial_displacement();
+  void set_initial_displacement(
+    stk::mesh::Part *targetPart,
+    const std::vector<double> &centroidCoords,
+    const std::vector<double> &unitVec,
+    const double theAngle);
 
   // non-conformal-like algorithm suppoer
   void initialize_non_conformal();

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -59,9 +59,10 @@ public:
 
   inline std::string get_coordinates_name() const
   {
-    return does_mesh_move() ? "current_coordinates" : "coordinates";
+    return ( (meshMotion_ | meshDeformation_ | externalMeshDeformation_ | initialMeshDisplacement_) 
+	     ? "current_coordinates" : "coordinates");    
   }
-
+  
   double get_alpha_factor(const std::string&) const;
 
   double get_alpha_upw_factor(const std::string&) const;
@@ -108,6 +109,7 @@ public:
   bool meshMotion_;
   bool meshDeformation_;
   bool externalMeshDeformation_;
+  bool initialMeshDisplacement_;
   bool errorIndicatorActive_;
   ErrorIndicatorType errorIndicatorType_;
   int errorIndicatorFrequency_;
@@ -177,6 +179,9 @@ public:
 
   // mesh motion
   std::map<std::string, MeshMotionInfo *> meshMotionInfoMap_;
+
+  // initial displacement
+  std::map<std::string, MeshMotionInfo *> initialMeshDisplacementInfoMap_;
 
   std::vector<double> gravity_;
 

--- a/src/MeshMotionInfo.C
+++ b/src/MeshMotionInfo.C
@@ -29,13 +29,15 @@ MeshMotionInfo::MeshMotionInfo(
   const double omega, 
   std::vector<double> centroid,
   std::vector<double> unitVec,
-  const bool computeCentroid)
+  const bool computeCentroid,
+  const double theAngle)
   : meshMotionBlock_(meshMotionBlock), 
     omega_(omega), 
     centroid_(centroid),
     unitVec_(unitVec),
     computeCentroid_(computeCentroid),
-    computeCentroidCompleted_(false)
+    computeCentroidCompleted_(false),
+    theAngle_(theAngle)
 {
   // nothing to do
 }


### PR DESCRIPTION
Usage:

    solution_options:

      name: myOptions

      initial_mesh_displacement:

        - name: staticBlock
          target_name: block_1
          unit_vector: [0.0,0.0,1.0]
          compute_centroid: no
          angle: 10.0

        - name: fixedRotBlock
          target_name: block_2
          unit_vector: [0.0,0.0,1.0]
          compute_centroid: no
          angle: 10.0