### PR TITLE
Support HO PMR solves and concentric sphere verification case

### DIFF
--- a/include/SolutionNormPostProcessing.h
+++ b/include/SolutionNormPostProcessing.h
@@ -78,6 +78,9 @@ public:
   // percision
   int percision_;
 
+  // target names
+  std::vector<std::string> targets_;
+
   // hold the dofName, functionName in a vector 
   std::vector<std::pair<std::string, std::string> > dofFunctionVec_;
 

--- a/include/user_functions/ConcentricAuxFunction.h
+++ b/include/user_functions/ConcentricAuxFunction.h
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef ConcentricAuxFunction_h
+#define ConcentricAuxFunction_h
+
+#include <AuxFunction.h>
+
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class ConcentricAuxFunction : public AuxFunction
+{
+public:
+
+  ConcentricAuxFunction();
+
+  virtual ~ConcentricAuxFunction() {}
+  
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+private:
+  const double ti_;
+  const double t1_;
+  const double ri_;
+  const double r1_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/AssembleHeatCondIrradWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondIrradWallSolverAlgorithm.C
@@ -105,6 +105,7 @@ AssembleHeatCondIrradWallSolverAlgorithm::execute()
     MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsIp = meFC->numIntPoints_;
+    const int *ipNodeMap = meFC->ipNodeMap();
 
     // resize some things; matrix related
     const int lhsSize = nodesPerFace*nodesPerFace;
@@ -171,7 +172,7 @@ AssembleHeatCondIrradWallSolverAlgorithm::execute()
         }
         magA = std::sqrt(magA);
 	
-        const int nn = ip;
+        const int nn = ipNodeMap[ip];
         const int offSet = ip*nodesPerFace;
 	
         // form boundary ip values

--- a/src/AssembleHeatCondWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondWallSolverAlgorithm.C
@@ -104,6 +104,7 @@ AssembleHeatCondWallSolverAlgorithm::execute()
     MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsIp = meFC->numIntPoints_;
+    const int *ipNodeMap = meFC->ipNodeMap();
 
     // resize some things; matrix related
     const int lhsSize = nodesPerFace*nodesPerFace;
@@ -173,7 +174,7 @@ AssembleHeatCondWallSolverAlgorithm::execute()
         }
         magA = std::sqrt(magA);
 	
-        const int nn = ip;
+        const int nn = ipNodeMap[ip];
         const int offSet = ip*nodesPerFace;
 	
         // form boundary ip values

--- a/src/pmr/RadTransWallElemKernel.C
+++ b/src/pmr/RadTransWallElemKernel.C
@@ -37,7 +37,7 @@ RadTransWallElemKernel<BcAlgTraits>::RadTransWallElemKernel(
   bcIntensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity_bc");
   intensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity");
   exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-
+  
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
  
   // compute and save shape function
@@ -68,7 +68,7 @@ RadTransWallElemKernel<BcAlgTraits>::setup(const TimeIntegrator& /*timeIntegrato
   for ( int j = 0; j < BcAlgTraits::nDim_; ++j )
     v_Sk_(j) = Sk[j];
 }
-
+  
 template<typename BcAlgTraits>
 void
 RadTransWallElemKernel<BcAlgTraits>::execute(

--- a/src/user_functions/ConcentricAuxFunction.C
+++ b/src/user_functions/ConcentricAuxFunction.C
@@ -1,0 +1,59 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/ConcentricAuxFunction.h>
+#include <algorithm>
+#include <NaluEnv.h>
+
+// basic c++
+#include <cmath>
+#include <vector>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+ConcentricAuxFunction::ConcentricAuxFunction() :
+  AuxFunction(0,1),
+  ti_(300.0),
+  //t1_(302.834),
+  t1_(302.83443018241820254843332804739),
+  ri_(0.03),
+  r1_(0.05)
+{
+  // nothing
+}
+
+void
+ConcentricAuxFunction::do_evaluate(
+  const double *coords,
+  const double /*time*/,
+  const unsigned spatialDimension,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+  for(unsigned p=0; p < numPoints; ++p) {
+
+    const double x = coords[0];
+    const double y = coords[1];
+    const double z = coords[2];
+    
+    const double R = std::sqrt(x*x + y*y + z*z);
+    const double temp = ti_ + (t1_-ti_)*(1/ri_ - 1/R)/(1.0/ri_ - 1/r1_);
+    fieldPtr[0] = temp;
+    
+    fieldPtr += fieldSize;
+    coords += spatialDimension;
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
* add "concentric" for norms. Allow specification of norm targets rather
  than blind physics targets. All rtests already where using the target
  interface. As such, it was silently neglected before.

* clean up higher-order for heat cond and pmr. Code was using nn = ip rather
  than ipNodeMap.