### PR TITLE
Periodic bug fix for SST min NDTW

### DIFF
--- a/include/PeriodicManager.h
+++ b/include/PeriodicManager.h
@@ -60,10 +60,10 @@ class PeriodicManager {
   // holder for master += slave; slave = master
   void apply_constraints(
     stk::mesh::FieldBase *,
-    const unsigned &sizeOfField,
-    const bool &bypassFieldCheck,
-    const bool &addSlaves = true,
-    const bool &setSlaves = true);
+    const unsigned sizeOfField,
+    const bool bypassFieldCheck,
+    const bool addSlaves,
+    const bool setSlaves);
 
   // find the max
   void apply_max_field(

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -230,7 +230,9 @@ class Realm {
   void periodic_field_update(
     stk::mesh::FieldBase *theField,
     const unsigned &sizeOfTheField,
-    const bool &bypassFieldCheck = true) const;
+    const bool bypassFieldCheck = true,
+    const bool addSlaves = true,
+    const bool setSlaves = true) const;
 
   void periodic_delta_solution_update(
      stk::mesh::FieldBase *theField,

--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -149,7 +149,7 @@ ComputeSSTMaxLengthScaleElemAlgorithm::execute()
   
   // deal with periodicity
   if ( realm_.hasPeriodic_) {
-    realm_.periodic_field_update(maxLengthScale_, 1);
+    realm_.periodic_field_update(maxLengthScale_, 1, true, false, true);
   }
  
 }

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -748,12 +748,11 @@ PeriodicManager::update_global_id_field()
 void
 PeriodicManager::apply_constraints(
   stk::mesh::FieldBase *theField,
-  const unsigned &sizeOfField,
-  const bool &bypassFieldCheck,
-  const bool &addSlaves,
-  const bool &setSlaves)
+  const unsigned sizeOfField,
+  const bool bypassFieldCheck,
+  const bool addSlaves,
+  const bool setSlaves)
 {
-
   // update periodically ghosted fields within add_ and set_
   if ( addSlaves )
     add_slave_to_master(theField, sizeOfField, bypassFieldCheck);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -3038,10 +3038,10 @@ void
 Realm::periodic_field_update(
   stk::mesh::FieldBase *theField,
   const unsigned &sizeOfField,
-  const bool &bypassFieldCheck) const
+  const bool bypassFieldCheck,
+  const bool addSlaves,
+  const bool setSlaves) const
 {
-  const bool addSlaves = true;
-  const bool setSlaves = true;
   periodicManager_->apply_constraints(theField, sizeOfField, bypassFieldCheck, addSlaves, setSlaves);
 }
 

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -468,7 +468,7 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
    
    // deal with periodicity
    if ( realm_.hasPeriodic_) {
-     realm_.periodic_field_update(minDistanceToWall_, 1);
+     realm_.periodic_field_update(minDistanceToWall_, 1, true, false, true);
    }
 }
 


### PR DESCRIPTION
 In most periodic field updates, we want a m+=s; s=m;

 However, for SST, the miniumum normal distance to a wall field
 was clipped. To ensure proper consistency of this nodal field between
 m and s, a periodic_update was processed. However, the default behavior
 summed the values rather than a simple setting s=m;

* generalized Realm::periodic_field_update() to allow for addSlaves
  and setSlaves to be explosed to the caller. These are defaulted to
  true if not specified. This approach ensures consistency of m
  prevailing.