### PR TITLE
Add KLU as coarse type for all Muelu xml

### DIFF
--- a/reg_tests/xml/matches_ml_default.xml
+++ b/reg_tests/xml/matches_ml_default.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="1000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/milestone-nc.xml
+++ b/reg_tests/xml/milestone-nc.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="100"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/milestone.xml
+++ b/reg_tests/xml/milestone.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="1000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/milestone_ABL.xml
+++ b/reg_tests/xml/milestone_ABL.xml
@@ -1,6 +1,8 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="low"/>
   <Parameter        name="coarse: max size"                 type="int"      value="2000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
+
   <Parameter        name="max levels"                       type="int"      value="6"/>
 
   <Parameter        name="transpose: use implicit"          type="bool"     value="true"/>

--- a/reg_tests/xml/milestone_McAlister.xml
+++ b/reg_tests/xml/milestone_McAlister.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="low"/>
   <Parameter        name="coarse: max size"                 type="int"      value="2000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
   <Parameter        name="max levels"                       type="int"      value="6"/>
 
   <Parameter        name="transpose: use implicit"          type="bool"     value="true"/>

--- a/reg_tests/xml/milestone_aspect_ratio.xml
+++ b/reg_tests/xml/milestone_aspect_ratio.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="1000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/milestone_aspect_ratio_smooth.xml
+++ b/reg_tests/xml/milestone_aspect_ratio_smooth.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="1000"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/muelu_STV_HO.xml
+++ b/reg_tests/xml/muelu_STV_HO.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="500"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">

--- a/reg_tests/xml/muelu_kovasznay_p7.xml
+++ b/reg_tests/xml/muelu_kovasznay_p7.xml
@@ -1,6 +1,7 @@
 <ParameterList name="MueLu">
   <Parameter        name="verbosity"                        type="string"   value="none"/>
   <Parameter        name="coarse: max size"                 type="int"      value="225"/>
+  <Parameter        name="coarse: type"                     type="string"   value="klu2"/>
 
   <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
   <ParameterList    name="smoother: params">


### PR DESCRIPTION
* Make the KLU request explicit in the Muelu XML so that even if someone
builds Trilinos with SuperLU, there are zero diffs (SuperLU is default
when built).