### PR TITLE
Support VOF transport with SUCV/NSO-based stabilization

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -64,12 +64,13 @@ enum EquationType {
   EQ_SPEC_DISS_RATE = 8,
   EQ_TURBULENT_DISS = 9,
   EQ_MASS_FRACTION = 10,
-  EQ_PNG   = 11,
-  EQ_PNG_P = 12,
-  EQ_PNG_Z = 13,
-  EQ_PNG_H = 14,
-  EQ_PNG_U = 15,
-  EQ_PNG_TKE = 16, // FIXME... Last PNG managed like this..
+  EQ_VOLUME_OF_FLUID = 11,
+  EQ_PNG   = 12,
+  EQ_PNG_P = 13,
+  EQ_PNG_Z = 14,
+  EQ_PNG_H = 15,
+  EQ_PNG_U = 16,
+  EQ_PNG_TKE = 17, // FIXME... Last PNG managed like this..
   EquationSystemType_END
 };
 
@@ -85,6 +86,7 @@ static const std::string EquationTypeMap[] = {
   "Specific_Dissipation_Rate",
   "Turbulent_Dissipation",
   "Mass_Fraction",
+  "Volume_of_Fluid",
   "PNG",
   "PNG_P",
   "PNG_Z",
@@ -134,6 +136,7 @@ enum  MaterialPropertyType {
   GEOMETRIC_MAT = 4,
   HDF5_TABLE_MAT = 5,
   GENERIC = 6,
+  VOF_MAT = 7,
   MaterialPropertyType_END
 };
 

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -90,6 +90,13 @@ struct MassFraction {
   {}
 };
 
+struct VolumeOfFluid {
+  double vof_;
+  VolumeOfFluid()
+    : vof_(0.0)
+  {}
+};
+
 struct Emissivity {
   double emissivity_;
   Emissivity()
@@ -231,16 +238,17 @@ struct InflowUserData : public UserData {
   TurbDiss eps_;
   MixtureFraction mixFrac_;
   MassFraction massFraction_;
- 
+  VolumeOfFluid vof_;
   bool uSpec_;
   bool tkeSpec_;
   bool sdrSpec_;
   bool epsSpec_;
   bool mixFracSpec_;
   bool massFractionSpec_;
+  bool vofSpec_;
   InflowUserData()
     : UserData(),
-    uSpec_(false), tkeSpec_(false), sdrSpec_(false), epsSpec_(false), mixFracSpec_(false), massFractionSpec_(false)
+    uSpec_(false), tkeSpec_(false), sdrSpec_(false), epsSpec_(false), mixFracSpec_(false), massFractionSpec_(false), vofSpec_(false)
   {}
 };
 
@@ -551,6 +559,10 @@ template<> struct convert<sierra::nalu::MixtureFraction> {
 
 template<> struct convert<sierra::nalu::MassFraction> {
   static bool decode(const Node& node, sierra::nalu::MassFraction& rhs) ;
+};
+
+template<> struct convert<sierra::nalu::VolumeOfFluid> {
+  static bool decode(const Node& node, sierra::nalu::VolumeOfFluid& rhs) ;
 };
 
 template<> struct convert<sierra::nalu::Emissivity> {

--- a/include/VolumeOfFluidEquationSystem.h
+++ b/include/VolumeOfFluidEquationSystem.h
@@ -1,0 +1,112 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef VolumeOfFluidEquationSystem_h
+#define VolumeOfFluidEquationSystem_h
+
+#include <EquationSystem.h>
+#include <FieldTypeDef.h>
+#include <NaluParsing.h>
+
+namespace stk{
+struct topology;
+}
+
+namespace sierra{
+namespace nalu{
+
+class AlgorithmDriver;
+class Realm;
+class AssembleNodalGradAlgorithmDriver;
+class LinearSystem;
+class EquationSystems;
+class ProjectedNodalGradientEquationSystem;
+
+class VolumeOfFluidEquationSystem : public EquationSystem {
+
+public:
+
+  VolumeOfFluidEquationSystem(
+    EquationSystems& equationSystems,
+    const bool outputClippingDiag,
+    const double deltaZClip);
+  virtual ~VolumeOfFluidEquationSystem();
+
+  void populate_derived_quantities();
+  
+  virtual void register_nodal_fields(
+    stk::mesh::Part *part);
+
+  void register_interior_algorithm(
+    stk::mesh::Part *part);
+  
+  void register_inflow_bc(
+    stk::mesh::Part *part,
+    const stk::topology &theTopo,
+    const InflowBoundaryConditionData &inflowBCData);
+  
+  void register_open_bc(
+    stk::mesh::Part *part,
+    const stk::topology &partTopo,
+    const OpenBoundaryConditionData &openBCData);
+
+  void register_wall_bc(
+    stk::mesh::Part *part,
+    const stk::topology &theTopo,
+    const WallBoundaryConditionData &wallBCData);
+
+  virtual void register_symmetry_bc(
+    stk::mesh::Part *part,
+    const stk::topology &theTopo,
+    const SymmetryBoundaryConditionData &symmetryBCData);
+
+  virtual void register_overset_bc();
+
+  virtual void register_initial_condition_fcn(
+      stk::mesh::Part *part,
+      const std::map<std::string, std::string> &theNames,
+      const std::map<std::string, std::vector<double> > &theParams);
+
+  void initialize();
+  void reinitialize_linear_system();
+  
+  void predict_state();
+  
+  void solve_and_update();
+  void update_and_clip();
+
+  void manage_projected_nodal_gradient(
+    EquationSystems& eqSystems);
+  void compute_projected_nodal_gradient();
+  
+  void sharpen_interface_explicit();
+  void smooth_vof();
+  void compute_interface_normal();
+
+  const bool managePNG_;
+  const bool outputClippingDiag_;
+  const double deltaVofClip_;
+
+  ScalarFieldType *vof_;
+  ScalarFieldType *vofSmoothed_;
+  ScalarFieldType *interfaceNormal_;
+  VectorFieldType *dvofdx_;
+  ScalarFieldType *vofTmp_;
+  
+  AssembleNodalGradAlgorithmDriver *assembleNodalGradAlgDriver_;
+  
+  ProjectedNodalGradientEquationSystem *projectedNodalGradEqs_;
+  
+  bool isInit_;
+};
+
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/kernel/VolumeOfFluidElemKernel.h
+++ b/include/kernel/VolumeOfFluidElemKernel.h
@@ -1,0 +1,79 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef VolumeOfFluidElemKernel_H
+#define VolumeOfFluidElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class TimeIntegrator;
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** CMM (BDF2/BE) for scalar equation
+ */
+template<typename AlgTraits>
+class VolumeOfFluidElemKernel: public Kernel
+{
+public:
+  VolumeOfFluidElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ScalarFieldType*,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~VolumeOfFluidElemKernel();
+
+  /** Perform pre-timestep work for the computational kernel
+   */
+  virtual void setup(const TimeIntegrator&);
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  VolumeOfFluidElemKernel() = delete;
+
+  ScalarFieldType *vofNm1_{nullptr};
+  ScalarFieldType *vofN_{nullptr};
+  ScalarFieldType *vofNp1_{nullptr};
+  VectorFieldType *velocityRTM_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  double dt_{0.0};
+  double gamma1_{0.0};
+  double gamma2_{0.0};
+  double gamma3_{0.0};
+  const bool lumpedMass_;
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* VolumeOfFluidElemKernel_H */

--- a/include/kernel/VolumeOfFluidSucvNsoElemKernel.h
+++ b/include/kernel/VolumeOfFluidSucvNsoElemKernel.h
@@ -1,0 +1,90 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef VolumeOfFluidSucvNsoElemKernel_H
+#define VolumeOfFluidSucvNsoElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class TimeIntegrator;
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** CMM (BDF2/BE) for scalar equation
+ */
+template<typename AlgTraits>
+class VolumeOfFluidSucvNsoElemKernel: public Kernel
+{
+public:
+  VolumeOfFluidSucvNsoElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ScalarFieldType*,
+    const double,
+    const double,
+    ElemDataRequests&);
+
+  virtual ~VolumeOfFluidSucvNsoElemKernel();
+
+  /** Perform pre-timestep work for the computational kernel
+   */
+  virtual void setup(const TimeIntegrator&);
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  VolumeOfFluidSucvNsoElemKernel() = delete;
+
+  ScalarFieldType *vofNm1_{nullptr};
+  ScalarFieldType *vofN_{nullptr};
+  ScalarFieldType *vofNp1_{nullptr};
+  VectorFieldType *velocityRTM_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  const double sucvFac_;
+  const double nsoFac_;
+
+  const int* lrscv_;
+
+  double dt_{0.0};
+  double gamma1_{0.0};
+  double gamma2_{0.0};
+  double gamma3_{0.0};
+
+  const double Cupw_{0.1};
+  const double small_{1.0e-16};
+
+  // correction for gij for elements that do not span -1:1
+  double gijFac_{1.0};
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* VolumeOfFluidSucvNsoElemKernel_H */

--- a/include/property_evaluator/MaterialPropertyData.h
+++ b/include/property_evaluator/MaterialPropertyData.h
@@ -30,7 +30,11 @@ public:
   // mixture fraction specifics
   double primary_;
   double secondary_;
- 
+
+  // vof specifics
+  double phaseOne_;
+  double phaseTwo_;
+
   // table specifics, all single in size, all possibly required to be more general
   std::vector<std::string> indVarName_;
   std::vector<std::string> indVarTableName_;

--- a/include/user_functions/RayleighTaylorMixFracAuxFunction.h
+++ b/include/user_functions/RayleighTaylorMixFracAuxFunction.h
@@ -19,7 +19,8 @@ class RayleighTaylorMixFracAuxFunction : public AuxFunction
 {
 public:
 
-  RayleighTaylorMixFracAuxFunction();
+  RayleighTaylorMixFracAuxFunction(
+    const std::vector<double> &theParams);
 
   virtual ~RayleighTaylorMixFracAuxFunction() {}
   
@@ -34,10 +35,10 @@ public:
     const unsigned endPos) const;
   
 private:
-  const double aX_;
-  const double tX_;
-  const double yTr_;
-  const double dTr_;
+  double aX_;
+  double tX_;
+  double yTr_;
+  double dTr_;
   const double pi_;
 };
 

--- a/src/ComputeGeometryInteriorAlgorithm.C
+++ b/src/ComputeGeometryInteriorAlgorithm.C
@@ -116,7 +116,7 @@ ComputeGeometryInteriorAlgorithm::execute()
       double scv_error = 0.0;
       meSCV->determinant(1, &ws_coordinates[0], &ws_scv_volume[0], &scv_error);
 
-      // assemble dual volume while scattering ip volume
+      // assemble dual volume
       for ( int ip = 0; ip < numScvIp; ++ip ) {
         // nearest node for this ip
         const int nn = ipNodeMap[ip];

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -31,6 +31,7 @@
 #include <TurbKineticEnergyEquationSystem.h>
 #include <pmr/RadiativeTransportEquationSystem.h>
 #include <mesh_motion/MeshDisplacementEquationSystem.h>
+#include <VolumeOfFluidEquationSystem.h>
 
 #include <vector>
 
@@ -96,7 +97,16 @@ void EquationSystems::load(const YAML::Node & y_node)
         const YAML::Node y_system = y_systems[isystem] ;
         EquationSystem *eqSys = 0;
 	YAML::Node y_eqsys ;
-        if ( expect_map(y_system, "LowMachEOM", true) ) {
+        if ( expect_map(y_system, "VolumeOfFluid", true) ) {
+	  y_eqsys =  expect_map(y_system, "VolumeOfFluid", true);
+          if (root()->debug()) NaluEnv::self().naluOutputP0() << "eqSys = VolumeOfFluid" << std::endl;
+          bool outputClipDiag = false;
+          get_if_present_no_default(y_eqsys, "output_clipping_diagnostic", outputClipDiag);
+          double deltaVofClip = 0.0;
+          get_if_present_no_default(y_eqsys, "clipping_delta", deltaVofClip);
+          eqSys = new VolumeOfFluidEquationSystem(*this, outputClipDiag, deltaVofClip);
+        }
+        else if ( expect_map(y_system, "LowMachEOM", true) ) {
 	  y_eqsys =  expect_map(y_system, "LowMachEOM", true);
           if (root()->debug()) NaluEnv::self().naluOutputP0() << "eqSys = LowMachEOM " << std::endl;
           bool elemCont = (realm_.realmUsesEdges_) ? false : true;

--- a/src/MaterialProperty.C
+++ b/src/MaterialProperty.C
@@ -210,6 +210,19 @@ MaterialProperty::load(const YAML::Node &y_prop)
                                        << primaryVal << " "
                                        << secondaryVal << std::endl;
       }
+      else if ( thePropType == "volume_of_fluid") {
+        double phaseOne;
+        double phaseTwo;
+        get_required(y_spec, "phase_one", phaseOne);
+        get_required(y_spec, "phase_two", phaseTwo);
+        matData->type_ = VOF_MAT;
+        matData->phaseOne_ = phaseOne;
+        matData->phaseTwo_ = phaseTwo;
+        NaluEnv::self().naluOutputP0() << thePropName
+                                       << " is a vof prop: "
+                                       << phaseOne << " "
+                                       << phaseTwo << std::endl;
+      }
       else if ( thePropType == "polynomial" ) {
         matData->type_ = POLYNOMIAL_MAT;
         

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -1,4 +1,3 @@
-
 /*------------------------------------------------------------------------*/
 /*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
@@ -905,7 +904,7 @@ void
 MixtureFractionEquationSystem::register_initial_condition_fcn(
   stk::mesh::Part *part,
   const std::map<std::string, std::string> &theNames,
-  const std::map<std::string, std::vector<double> > &/*theParams*/)
+  const std::map<std::string, std::vector<double> > &theParams)
 {
   // iterate map and check for name
   const std::string dofName = "mixture_fraction";
@@ -913,14 +912,24 @@ MixtureFractionEquationSystem::register_initial_condition_fcn(
     = theNames.find(dofName);
   if (iterName != theNames.end()) {
     std::string fcnName = (*iterName).second;
+
     AuxFunction *theAuxFunc = NULL;
+    std::vector<double> fcnParams;
+    
+    // extract the params
+    std::map<std::string, std::vector<double> >::const_iterator iterParams
+      = theParams.find(dofName);
+    if (iterParams != theParams.end()) {
+      fcnParams = (*iterParams).second;	
+    }
+
     if ( fcnName == "VariableDensity" ) {
       // create the function
       theAuxFunc = new VariableDensityMixFracAuxFunction();      
     }
     else if ( fcnName == "RayleighTaylor" ) {
       // create the function
-      theAuxFunc = new RayleighTaylorMixFracAuxFunction();      
+      theAuxFunc = new RayleighTaylorMixFracAuxFunction(fcnParams);      
     }
     else {
       throw std::runtime_error("MixtureFractionEquationSystem::register_initial_condition_fcn: VariableDensity only supported");

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -642,6 +642,19 @@ namespace YAML
     return true;
   }
 
+  bool convert<sierra::nalu::VolumeOfFluid>::decode(const Node& node,
+    sierra::nalu::VolumeOfFluid& vof)
+  {
+    if (!node.IsScalar())
+    {
+      return false;
+    }
+
+    vof.vof_ = node.as<double>();
+
+    return true;
+  }
+
   bool convert<sierra::nalu::Emissivity>::decode(const Node& node,
     sierra::nalu::Emissivity& emiss)
   {
@@ -991,6 +1004,12 @@ namespace YAML
       inflowData.massFraction_ = node["mass_fraction"].as<
           sierra::nalu::MassFraction>();
       inflowData.massFractionSpec_ = true;
+    }
+    if (node["volume_of_fluid"])
+    {
+      inflowData.vof_ = node["volume_of_fluid"].as<
+          sierra::nalu::VolumeOfFluid>();
+      inflowData.vofSpec_ = true;
     }
     if (node["temperature"])
     {

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1176,6 +1176,22 @@ Realm::setup_property()
         }
         break;
 
+        case VOF_MAT:
+        {
+          // extract the volume of fluiod field
+          ScalarFieldType *vof = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
+
+          // primary and secondary
+          const double phaseOne = matData->phaseOne_;
+          const double phaseTwo = matData->phaseTwo_;
+
+          // everything is linear weighting
+          LinearPropAlgorithm *auxAlg
+            = new LinearPropAlgorithm( *this, targetPart, thePropField, vof, phaseOne, phaseTwo);
+          propertyAlg_.push_back(auxAlg);
+        }
+        break;
+
         case POLYNOMIAL_MAT:
         {
 

--- a/src/VolumeOfFluidEquationSystem.C
+++ b/src/VolumeOfFluidEquationSystem.C
@@ -1,0 +1,880 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include "VolumeOfFluidEquationSystem.h"
+#include "AlgorithmDriver.h"
+#include "AssembleNodalGradAlgorithmDriver.h"
+#include "AssembleNodalGradElemAlgorithm.h"
+#include "AssembleNodalGradBoundaryAlgorithm.h"
+#include "AuxFunctionAlgorithm.h"
+#include "ConstantAuxFunction.h"
+#include "CopyFieldAlgorithm.h"
+#include "DirichletBC.h"
+#include "EquationSystem.h"
+#include "EquationSystems.h"
+#include "Enums.h"
+#include "FieldFunctions.h"
+#include "LinearSolvers.h"
+#include "LinearSolver.h"
+#include "LinearSystem.h"
+#include "NaluEnv.h"
+#include "NaluParsing.h"
+#include "ProjectedNodalGradientEquationSystem.h"
+#include "Realm.h"
+#include "Realms.h"
+#include "Simulation.h"
+#include "SolutionOptions.h"
+#include "TimeIntegrator.h"
+#include "SolverAlgorithmDriver.h"
+
+// template for kernels
+#include "AlgTraits.h"
+#include "kernel/KernelBuilder.h"
+#include "kernel/KernelBuilderLog.h"
+
+// kernels
+#include "AssembleElemSolverAlgorithm.h"
+#include "kernel/VolumeOfFluidElemKernel.h"
+#include "kernel/VolumeOfFluidSucvNsoElemKernel.h"
+
+// user function
+#include "user_functions/RayleighTaylorMixFracAuxFunction.h"
+
+#include "overset/UpdateOversetFringeAlgorithmDriver.h"
+
+// stk_util
+#include <stk_util/parallel/Parallel.hpp>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+
+// stk_io
+#include <stk_io/IossBridge.hpp>
+
+// stk_topo
+#include <stk_topology/topology.hpp>
+
+// stk_util
+#include <stk_util/parallel/ParallelReduce.hpp>
+
+// nalu utility
+#include <utils/StkHelpers.h>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// VolumeOfFluidEquationSystem - manages vof pde system
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+VolumeOfFluidEquationSystem::VolumeOfFluidEquationSystem(
+  EquationSystems& eqSystems,
+  const bool outputClippingDiag,
+  const double deltaVofClip)
+  : EquationSystem(eqSystems, "VolumeOfFluidEQS", "volume_of_fluid"),
+    managePNG_(realm_.get_consistent_mass_matrix_png("volume_of_fluid")),
+    outputClippingDiag_(outputClippingDiag),
+    deltaVofClip_(deltaVofClip),
+    vof_(NULL),
+    vofSmoothed_(NULL),
+    interfaceNormal_(NULL),
+    dvofdx_(NULL),
+    vofTmp_(NULL),
+    assembleNodalGradAlgDriver_(new AssembleNodalGradAlgorithmDriver(realm_, "volume_of_fluid", "dvofdx")),
+    projectedNodalGradEqs_(NULL),
+    isInit_(true)
+{
+  // extract solver name and solver object
+  std::string solverName = realm_.equationSystems_.get_solver_block_name("volume_of_fluid");
+  LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_VOLUME_OF_FLUID);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
+
+  // determine nodal gradient form
+  set_nodal_gradient("volume_of_fluid");
+  if ( realm_.realmUsesEdges_ )
+    NaluEnv::self().naluOutputP0() << "VolumeOfFluidEquationSystem will use CVFEM" << std::endl;
+      
+  // push back EQ to manager
+  realm_.push_equation_to_systems(this);
+
+  // advertise as non uniform
+  realm_.uniform_ = false;
+
+  // create projected nodal gradient equation system
+  if ( managePNG_ ) {
+    manage_projected_nodal_gradient(eqSystems);
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+VolumeOfFluidEquationSystem::~VolumeOfFluidEquationSystem()
+{
+  delete assembleNodalGradAlgDriver_;
+}
+
+//--------------------------------------------------------------------------
+//-------- populate_derived_quantities -------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::populate_derived_quantities()
+{
+  // placeholder
+}
+
+//--------------------------------------------------------------------------
+//-------- register_nodal_fields -------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_nodal_fields(
+  stk::mesh::Part *part)
+{
+
+  stk::mesh::MetaData &meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+  const int numStates = realm_.number_of_states();
+
+  // register dof; set it as a restart variable
+  vof_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid", numStates));
+  stk::mesh::put_field_on_mesh(*vof_, *part, nullptr);
+  realm_.augment_restart_variable_list("volume_of_fluid");
+
+  // smoothed
+  vofSmoothed_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid_smoothed"));
+  stk::mesh::put_field_on_mesh(*vofSmoothed_, *part, nullptr);
+
+  // normal
+  interfaceNormal_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_normal"));
+  stk::mesh::put_field_on_mesh(*interfaceNormal_, *part, nullptr);
+
+  // projected nodal gradient
+  dvofdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dvofdx"));
+  stk::mesh::put_field_on_mesh(*dvofdx_, *part, nDim, nullptr);
+
+  // delta solution for linear solver; share delta since this is a split system
+  vofTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pTmp"));
+  stk::mesh::put_field_on_mesh(*vofTmp_, *part, nullptr);
+
+  // make sure all states are properly populated (restart can handle this)
+  if ( numStates > 2 && (!realm_.restarted_simulation() || realm_.support_inconsistent_restart()) ) {
+    ScalarFieldType &vofN = vof_->field_of_state(stk::mesh::StateN);
+    ScalarFieldType &vofNp1 = vof_->field_of_state(stk::mesh::StateNP1);
+
+    CopyFieldAlgorithm *theCopyAlg
+      = new CopyFieldAlgorithm(realm_, part,
+                               &vofNp1, &vofN,
+                               0, 1,
+                               stk::topology::NODE_RANK);
+    copyStateAlg_.push_back(theCopyAlg);
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_interior_algorithm -------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_interior_algorithm(
+  stk::mesh::Part *part)
+{
+
+  // types of algorithms
+  const AlgorithmType algType = INTERIOR;
+
+  ScalarFieldType &vofNp1 = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  VectorFieldType &dvofdxNone = dvofdx_->field_of_state(stk::mesh::StateNone);
+
+  // non-solver; contribution to projected nodal gradient; allow for element-based shifted
+  if ( !managePNG_ ) {
+    std::map<AlgorithmType, Algorithm *>::iterator it
+      = assembleNodalGradAlgDriver_->algMap_.find(algType);
+    if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
+      Algorithm *theAlg = new AssembleNodalGradElemAlgorithm(realm_, part, &vofNp1, &dvofdxNone, edgeNodalGradient_);
+      assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+    }
+    else {
+      it->second->partVec_.push_back(part);
+    } 
+  }
+
+  // Homogeneous kernel implementation
+  stk::topology partTopo = part->topology();
+  auto& solverAlgMap = solverAlgDriver_->solverAlgorithmMap_;
+  
+  AssembleElemSolverAlgorithm* solverAlg = nullptr;
+  bool solverAlgWasBuilt = false;
+  
+  std::tie(solverAlg, solverAlgWasBuilt) = build_or_add_part_to_solver_alg(*this, *part, solverAlgMap);
+  
+  ElemDataRequests& dataPreReqs = solverAlg->dataNeededByKernels_;
+  auto& activeKernels = solverAlg->activeKernels_;
+  
+  if (solverAlgWasBuilt) {
+    build_topo_kernel_if_requested<VolumeOfFluidElemKernel>
+      (partTopo, *this, activeKernels, "vof",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, dataPreReqs, false);
+    
+    build_topo_kernel_if_requested<VolumeOfFluidElemKernel>
+      (partTopo, *this, activeKernels, "lumped_vof",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, dataPreReqs, true);
+
+    build_topo_kernel_if_requested<VolumeOfFluidSucvNsoElemKernel>
+      (partTopo, *this, activeKernels, "sucv_nso",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, 1.0, 1.0, dataPreReqs);
+
+    build_topo_kernel_if_requested<VolumeOfFluidSucvNsoElemKernel>
+      (partTopo, *this, activeKernels, "sucv",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, 1.0, 0.0, dataPreReqs);
+
+    build_topo_kernel_if_requested<VolumeOfFluidSucvNsoElemKernel>
+      (partTopo, *this, activeKernels, "nso",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, 0.0, 1.0, dataPreReqs);
+      
+    report_invalid_supp_alg_names();
+    report_built_supp_alg_names();
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_inflow_bc ----------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_inflow_bc(
+  stk::mesh::Part *part,
+  const stk::topology &/*theTopo*/,
+  const InflowBoundaryConditionData &inflowBCData)
+{
+
+  // algorithm type
+  const AlgorithmType algType = INFLOW;
+
+  ScalarFieldType &vofNp1 = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  VectorFieldType &dvofdxNone = dvofdx_->field_of_state(stk::mesh::StateNone);
+
+  stk::mesh::MetaData &meta_data = realm_.meta_data();
+
+  // register boundary data; vof_bc
+  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid_bc"));
+  stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
+
+  // extract the value for user specified vof and save off the AuxFunction
+  InflowUserData userData = inflowBCData.userData_;
+  std::string vofName = "volume_of_fluid";
+  UserDataType theDataType = get_bc_data_type(userData, vofName);
+
+  AuxFunction *theAuxFunc = NULL;
+  if ( CONSTANT_UD == theDataType ) {
+    VolumeOfFluid vof = userData.vof_;
+    std::vector<double> userSpec(1);
+    userSpec[0] = vof.vof_;
+
+    // new it
+    theAuxFunc = new ConstantAuxFunction(0, 1, userSpec);
+  }
+  else {
+    throw std::runtime_error("VolumeOfFluidEquationSystem::register_inflow_bc: only constant supported");
+  }
+
+  // bc data alg
+  AuxFunctionAlgorithm *auxAlg
+    = new AuxFunctionAlgorithm(realm_, part,
+                               theBcField, theAuxFunc,
+                               stk::topology::NODE_RANK);
+
+  // how to populate the field?
+  if ( userData.externalData_ ) {
+    // xfer will handle population; only need to populate the initial value
+    realm_.initCondAlg_.push_back(auxAlg);
+  }
+  else {
+    // put it on bcData
+    bcDataAlg_.push_back(auxAlg);
+  }
+
+  // copy vof_bc to volume_of_fluid np1...
+  CopyFieldAlgorithm *theCopyAlg
+    = new CopyFieldAlgorithm(realm_, part,
+                             theBcField, &vofNp1,
+                             0, 1,
+                             stk::topology::NODE_RANK);
+  bcDataMapAlg_.push_back(theCopyAlg);
+
+  // non-solver; dvofdx; allow for element-based shifted
+  if ( !managePNG_ ) {
+    std::map<AlgorithmType, Algorithm *>::iterator it
+      = assembleNodalGradAlgDriver_->algMap_.find(algType);
+    if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
+      Algorithm *theAlg 
+        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, &vofNp1, &dvofdxNone, edgeNodalGradient_);
+      assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+    }
+    else {
+      it->second->partVec_.push_back(part);
+    }
+  }
+
+  // Dirichlet bc
+  std::map<AlgorithmType, SolverAlgorithm *>::iterator itd =
+    solverAlgDriver_->solverDirichAlgMap_.find(algType);
+  if ( itd == solverAlgDriver_->solverDirichAlgMap_.end() ) {
+    DirichletBC *theAlg
+      = new DirichletBC(realm_, this, part, &vofNp1, theBcField, 0, 1);
+    solverAlgDriver_->solverDirichAlgMap_[algType] = theAlg;
+  }
+  else {
+    itd->second->partVec_.push_back(part);
+  }
+
+}
+
+//--------------------------------------------------------------------------
+//-------- register_open_bc ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_open_bc(
+  stk::mesh::Part *part,
+  const stk::topology &partTopo,
+  const OpenBoundaryConditionData &openBCData)
+{
+
+  // algorithm type
+  const AlgorithmType algType = OPEN;
+
+  ScalarFieldType &vofNp1 = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  VectorFieldType &dvofdxNone = dvofdx_->field_of_state(stk::mesh::StateNone);
+
+  // non-solver; dvofdx; allow for element-based shifted
+  if ( !managePNG_ ) {
+    std::map<AlgorithmType, Algorithm *>::iterator it
+      = assembleNodalGradAlgDriver_->algMap_.find(algType);
+    if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
+      Algorithm *theAlg 
+        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, &vofNp1, &dvofdxNone, edgeNodalGradient_);
+      assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+    }
+    else {
+      it->second->partVec_.push_back(part);
+    }
+  }
+
+}
+
+//--------------------------------------------------------------------------
+//-------- register_wall_bc ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_wall_bc(
+  stk::mesh::Part *part,
+  const stk::topology &/*theTopo*/,
+  const WallBoundaryConditionData &wallBCData)
+{
+
+  // algorithm type
+  const AlgorithmType algType = WALL;
+
+  // np1
+  ScalarFieldType &vofNp1 = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  VectorFieldType &dvofdxNone = dvofdx_->field_of_state(stk::mesh::StateNone);
+
+  // non-solver; dvofdx; allow for element-based shifted
+  if ( !managePNG_ ) {
+    std::map<AlgorithmType, Algorithm *>::iterator it
+      = assembleNodalGradAlgDriver_->algMap_.find(algType);
+    if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
+      Algorithm *theAlg 
+        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, &vofNp1, &dvofdxNone, edgeNodalGradient_);
+      assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+    }
+    else {
+      it->second->partVec_.push_back(part);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_symmetry_bc --------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_symmetry_bc(
+  stk::mesh::Part *part,
+  const stk::topology &/*theTopo*/,
+  const SymmetryBoundaryConditionData &/*wallBCData*/)
+{
+
+  // algorithm type
+  const AlgorithmType algType = SYMMETRY;
+
+  // np1
+  ScalarFieldType &vofNp1 = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  VectorFieldType &dvofdxNone = dvofdx_->field_of_state(stk::mesh::StateNone);
+
+  // non-solver; dvofdx; allow for element-based shifted
+  if ( !managePNG_ ) {
+    std::map<AlgorithmType, Algorithm *>::iterator it
+      = assembleNodalGradAlgDriver_->algMap_.find(algType);
+    if ( it == assembleNodalGradAlgDriver_->algMap_.end() ) {
+      Algorithm *theAlg 
+        = new AssembleNodalGradBoundaryAlgorithm(realm_, part, &vofNp1, &dvofdxNone, edgeNodalGradient_);
+      assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+    }
+    else {
+      it->second->partVec_.push_back(part);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_overset_bc ---------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_overset_bc()
+{
+  create_constraint_algorithm(vof_);
+
+  UpdateOversetFringeAlgorithmDriver* theAlg = new UpdateOversetFringeAlgorithmDriver(realm_);
+  // Perform fringe updates before all equation system solves
+  equationSystems_.preIterAlgDriver_.push_back(theAlg);
+
+  theAlg->fields_.push_back(
+    std::unique_ptr<OversetFieldData>(new OversetFieldData(vof_,1,1)));
+
+  if ( realm_.has_mesh_motion() ) {
+    UpdateOversetFringeAlgorithmDriver* theAlgPost = new UpdateOversetFringeAlgorithmDriver(realm_,false);
+    // Perform fringe updates after all equation system solves (ideally on the post_time_step)
+    equationSystems_.postIterAlgDriver_.push_back(theAlgPost);
+    theAlgPost->fields_.push_back(std::unique_ptr<OversetFieldData>(new OversetFieldData(vof_,1,1)));
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize ------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::initialize()
+{
+  solverAlgDriver_->initialize_connectivity();
+  linsys_->finalizeLinearSystem();
+}
+
+//--------------------------------------------------------------------------
+//-------- reinitialize_linear_system --------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::reinitialize_linear_system()
+{
+
+  // delete linsys
+  delete linsys_;
+
+  // delete old solver
+  const EquationType theEqID = EQ_VOLUME_OF_FLUID;
+  LinearSolver *theSolver = NULL;
+  std::map<EquationType, LinearSolver *>::const_iterator iter
+    = realm_.root()->linearSolvers_->solvers_.find(theEqID);
+  if (iter != realm_.root()->linearSolvers_->solvers_.end()) {
+    theSolver = (*iter).second;
+    delete theSolver;
+  }
+
+  // create new solver
+  std::string solverName = realm_.equationSystems_.get_solver_block_name("volume_of_fluid");
+  LinearSolver *solver = realm_.root()->linearSolvers_->create_solver(solverName, EQ_VOLUME_OF_FLUID);
+  linsys_ = LinearSystem::create(realm_, 1, this, solver);
+
+  // initialize
+  solverAlgDriver_->initialize_connectivity();
+  linsys_->finalizeLinearSystem();
+}
+
+//--------------------------------------------------------------------------
+//-------- register_initial_condition_fcn ----------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::register_initial_condition_fcn(
+  stk::mesh::Part *part,
+  const std::map<std::string, std::string> &theNames,
+  const std::map<std::string, std::vector<double> > &theParams)
+{
+  // iterate map and check for name
+  const std::string dofName = "volume_of_fluid";
+  std::map<std::string, std::string>::const_iterator iterName
+    = theNames.find(dofName);
+  if (iterName != theNames.end()) {
+    std::string fcnName = (*iterName).second;
+
+    AuxFunction *theAuxFunc = NULL;
+    std::vector<double> fcnParams;
+    
+    // extract the params
+    std::map<std::string, std::vector<double> >::const_iterator iterParams
+      = theParams.find(dofName);
+    if (iterParams != theParams.end()) {
+      fcnParams = (*iterParams).second;	
+    }
+
+    if ( fcnName == "RayleighTaylor" ) {
+      // create the function
+      theAuxFunc = new RayleighTaylorMixFracAuxFunction(fcnParams);      
+    }
+    else {
+      throw std::runtime_error("VolumeOfFluidEquationSystem::register_initial_condition_fcn: limited functions supported");
+    }
+    
+    // create the algorithm
+    AuxFunctionAlgorithm *auxAlg
+      = new AuxFunctionAlgorithm(realm_, part,
+				 vof_, theAuxFunc,
+				 stk::topology::NODE_RANK);
+    
+    // push to ic
+    realm_.initCondAlg_.push_back(auxAlg);
+    
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- solve_and_update ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::solve_and_update()
+{
+
+  // compute dvof/dx
+  if ( isInit_ ) {
+    sharpen_interface_explicit();
+    smooth_vof();
+    compute_interface_normal();
+    compute_projected_nodal_gradient();
+    isInit_ = false;
+  }
+
+  for ( int k = 0; k < maxIterations_; ++k ) {
+
+    NaluEnv::self().naluOutputP0() << " " << k+1 << "/" << maxIterations_
+                    << std::setw(15) << std::right << userSuppliedName_ << std::endl;
+    
+    // vof assemble, load_complete and solve
+    assemble_and_solve(vofTmp_);
+
+    // update
+    double timeA = NaluEnv::self().nalu_time();
+    update_and_clip();
+    double timeB = NaluEnv::self().nalu_time();
+    timerAssemble_ += (timeB-timeA);
+    
+    // sharpen/smoothing
+    sharpen_interface_explicit();
+    smooth_vof();
+    compute_interface_normal();
+    
+    // projected nodal gradient
+    compute_projected_nodal_gradient();
+
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- update_and_clip -------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::update_and_clip()
+{
+  const double deltaVof = deltaVofClip_;
+  const double lowBound = 0.0-deltaVof;
+  const double highBound = 1.0+deltaVof;
+  size_t numClip[2] = {0,0};
+  double minVof = +1.0e16;
+  double maxVof = -1.0e16;
+
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+
+  // define some common selectors
+  stk::mesh::Selector s_all_nodes
+    = (meta_data.locally_owned_part() | meta_data.globally_shared_part())
+    &stk::mesh::selectField(*vof_);
+
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin();
+        ib != node_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    double *vof = stk::mesh::field_data(*vof_, b);
+    double *vofTmp    = stk::mesh::field_data(*vofTmp_, b);
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      double vofNp1 = vof[k] + vofTmp[k];
+      // clip now
+      if ( vofNp1 < lowBound ) {
+        minVof = std::min(vofNp1, minVof);
+        vofNp1 = lowBound;
+        numClip[0]++;
+      }
+      else if ( vofNp1 > highBound ) {
+        maxVof = std::max(vofNp1, maxVof);
+        vofNp1 = highBound;
+        numClip[1]++;
+      }
+      vof[k] = vofNp1;
+    }
+  }
+
+  // parallel assemble clipped value
+  if ( outputClippingDiag_ ) {
+    size_t g_numClip[2] = {};
+    stk::ParallelMachine comm = NaluEnv::self().parallel_comm();
+    stk::all_reduce_sum(comm, numClip, g_numClip, 2);
+
+    if ( g_numClip[0] > 0 ) {
+      double g_minVof = 0;
+      stk::all_reduce_min(comm, &minVof, &g_minVof, 1);
+      NaluEnv::self().naluOutputP0() << "vof clipped (-) " << g_numClip[0] << " times; min: " << g_minVof << std::endl;
+    }
+    else {
+      NaluEnv::self().naluOutputP0() << "vof clipped (-) zero times" << std::endl;
+    }
+
+    if ( g_numClip[1] > 0 ) {
+      double g_maxVof = 0;
+      stk::all_reduce_max(comm, &maxVof, &g_maxVof, 1);
+      NaluEnv::self().naluOutputP0() << "vof clipped (+) " << g_numClip[1] << " times; max: " << g_maxVof << std::endl;
+    }
+    else {
+      NaluEnv::self().naluOutputP0() << "vof clipped (+) zero times" << std::endl;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_interface_normal ----------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::compute_interface_normal()
+{
+  // interface normal is generally compiuted based on vofSmoothed_
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
+  
+  const int nDim = meta_data.spatial_dimension();
+  const double small = 1.0e-16;
+
+  // extract nodal fields
+  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+
+  // zero assembled normal
+  field_fill( meta_data, bulk_data, 0.0, *interfaceNormal_, realm_.get_activate_aura());
+
+  // integration point data that is fixed
+  std::vector<double> dvofdxIp(nDim);
+  double *p_dvofdxIp = &dvofdxIp[0];
+
+  // fields to gather
+  std::vector<double> ws_coordinates;
+  std::vector<double> ws_vofSmoothed;
+  std::vector<double> ws_dual_volume;
+  std::vector<double> ws_scv_volume;
+  std::vector<double> ws_dndx;
+  std::vector<double> ws_deriv;
+  std::vector<double> ws_det_j;
+
+  // select locally owned where vof is defined; exclude inactive block
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
+    & stk::mesh::selectField(*vofSmoothed_)  
+    & !(realm_.get_inactive_selector());
+
+  stk::mesh::BucketVector const& elem_buckets =
+    realm_.get_buckets( stk::topology::ELEMENT_RANK, s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = elem_buckets.begin();
+        ib != elem_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    // extract master element
+    MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(b.topology());
+
+    // extract master element specifics
+    const int nodesPerElement = meSCV->nodesPerElement_;
+    const int numScvIp = meSCV->numIntPoints_;
+    const int *ipNodeMap = meSCV->ipNodeMap();
+
+    // algorithm related
+    ws_coordinates.resize(nodesPerElement*nDim);
+    ws_vofSmoothed.resize(nodesPerElement);
+    ws_dual_volume.resize(nodesPerElement);
+    ws_scv_volume.resize(numScvIp);
+    ws_dndx.resize(nDim*numScvIp*nodesPerElement);
+    ws_deriv.resize(nDim*numScvIp*nodesPerElement);
+    ws_det_j.resize(numScvIp);
+
+    // pointers
+    double *p_coordinates = &ws_coordinates[0];
+    double *p_vofSmoothed = &ws_vofSmoothed[0];
+    double *p_dual_volume = &ws_dual_volume[0];
+    double *p_scv_volume = &ws_scv_volume[0];
+    double *p_dndx = &ws_dndx[0];
+    
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      //===============================================
+      // gather nodal data; this is how we do it now..
+      //===============================================
+      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
+
+      // sanity check on num nodes
+      ThrowAssert( num_nodes == nodesPerElement );
+
+      for ( int ni = 0; ni < num_nodes; ++ni ) {
+        stk::mesh::Entity node = node_rels[ni];
+
+        // pointers to real data
+        const double * coords = stk::mesh::field_data(*coordinates, node);
+
+        // gather scalars
+        p_vofSmoothed[ni] = *stk::mesh::field_data(*vofSmoothed_, node);
+        p_dual_volume[ni] = *stk::mesh::field_data(*dualNodalVolume, node);
+
+        // gather vectors
+        const int offSet = ni*nDim;
+        for ( int j=0; j < nDim; ++j ) {
+          p_coordinates[offSet+j] = coords[j];
+        }
+      }
+      
+      // compute geometry
+      double scv_error = 0.0;
+      meSCV->determinant(1, &p_coordinates[0], &p_scv_volume[0], &scv_error);
+
+      // compute dndx
+      meSCV->grad_op(1, &p_coordinates[0], &p_dndx[0], &ws_deriv[0], &ws_det_j[0], &scv_error);
+      
+      for ( int ip = 0; ip < numScvIp; ++ip ) {
+        
+        // zero local ip gradient
+        for ( int j = 0; j < nDim; ++j ) {
+          p_dvofdxIp[j] = 0.0;
+        }
+        
+        // compute gradient
+        for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+          const int offSetDnDx = nDim*nodesPerElement*ip + ic*nDim;
+          const double nodalVofSmoothed = p_vofSmoothed[ic];
+          for ( int j = 0; j < nDim; ++j ) {
+            p_dvofdxIp[j] += p_dndx[offSetDnDx+j]*nodalVofSmoothed;
+          }
+        }
+        
+        // magnitude
+        double dvofMag = small;
+        for ( int j = 0; j < nDim; ++j ) {
+          dvofMag += p_dvofdxIp[j]*p_dvofdxIp[j];
+        }
+        dvofMag = std::sqrt(dvofMag);
+
+        // nearest node for this ip
+        const int nn = ipNodeMap[ip];
+        stk::mesh::Entity node = node_rels[nn];
+
+        // pointers to real data
+        double * interfaceNormal = stk::mesh::field_data(*interfaceNormal_, node);
+
+        const double volumeFac = p_scv_volume[ip]/p_dual_volume[nn];
+        for ( int j = 0; j < nDim; ++j )
+          interfaceNormal[j] += p_dvofdxIp[j]/dvofMag*volumeFac;
+      }
+    }
+  }
+  
+  // parallel sum
+  stk::mesh::parallel_sum(bulk_data, {interfaceNormal_});
+  
+  // periodic assemble
+  if ( realm_.hasPeriodic_) {
+    const unsigned fieldSize = 1;
+    realm_.periodic_field_update(interfaceNormal_, fieldSize);
+  }
+
+}
+
+//--------------------------------------------------------------------------
+//-------- smooth_vof ------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::smooth_vof()
+{
+  // for now, just copy vof to vofSmoothed
+  NaluEnv::self().naluOutputP0() << "VOF::smooth_interface() TBD" << std::endl;
+  ScalarFieldType &vofNp1 = vof_->field_of_state(stk::mesh::StateN);
+  ScalarFieldType &vofSmoothed = vofSmoothed_->field_of_state(stk::mesh::StateNone);
+  field_copy(realm_.meta_data(), realm_.bulk_data(), vofNp1, vofSmoothed, realm_.get_activate_aura());
+}
+
+//--------------------------------------------------------------------------
+//-------- sharpen_interface_explicit --------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::sharpen_interface_explicit()
+{
+  NaluEnv::self().naluOutputP0() << "VOF::sharpen_interface() currently in situ via the linear system" << std::endl;
+}
+
+//--------------------------------------------------------------------------
+//-------- predict_state ---------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::predict_state()
+{
+  // copy state n to state np1
+  ScalarFieldType &vofN = vof_->field_of_state(stk::mesh::StateN);
+  ScalarFieldType &vofNp1 = vof_->field_of_state(stk::mesh::StateNP1);
+  field_copy(realm_.meta_data(), realm_.bulk_data(), vofN, vofNp1, realm_.get_activate_aura());
+}
+
+//--------------------------------------------------------------------------
+//-------- manage_projected_nodal_gradient ---------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::manage_projected_nodal_gradient(
+  EquationSystems& eqSystems)
+{
+  throw std::runtime_error("VofEquationSystem::manage_projected_nodal_gradient: Not yet supported");
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_projected_nodal_gradient---------------------------------
+//--------------------------------------------------------------------------
+void
+VolumeOfFluidEquationSystem::compute_projected_nodal_gradient()
+{
+  // projected nodal gradient is generally using vofSmoothed_
+  if ( !managePNG_ ) {
+    const double timeA = -NaluEnv::self().nalu_time();
+    assembleNodalGradAlgDriver_->execute();
+    timerMisc_ += (NaluEnv::self().nalu_time() + timeA);
+  }
+  else {
+    projectedNodalGradEqs_->solve_and_update_external();
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/kernel/VolumeOfFluidElemKernel.C
+++ b/src/kernel/VolumeOfFluidElemKernel.C
@@ -1,0 +1,159 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/VolumeOfFluidElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "TimeIntegrator.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+VolumeOfFluidElemKernel<AlgTraits>::VolumeOfFluidElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ScalarFieldType* vof,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  
+  vofN_ = &(vof->field_of_state(stk::mesh::StateN));
+  vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
+  if (vof->number_of_states() == 2)
+    vofNm1_ = vofN_;
+  else
+    vofNm1_ = &(vof->field_of_state(stk::mesh::StateNM1));
+
+  std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
+  velocityRTM_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  if ( lumpedMass_ )
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*vofNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*vofN_, 1);
+  dataPreReqs.add_gathered_nodal_field(*vofNp1_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+VolumeOfFluidElemKernel<AlgTraits>::~VolumeOfFluidElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+VolumeOfFluidElemKernel<AlgTraits>::setup(const TimeIntegrator& timeIntegrator)
+{
+  dt_ = timeIntegrator.get_time_step();
+  gamma1_ = timeIntegrator.get_gamma1();
+  gamma2_ = timeIntegrator.get_gamma2();
+  gamma3_ = timeIntegrator.get_gamma3(); // gamma3 may be zero
+}
+
+template<typename AlgTraits>
+void
+VolumeOfFluidElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>& lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  NALU_ALIGNED DoubleType w_uIp[AlgTraits::nDim_];
+
+  SharedMemView<DoubleType*>& v_vofNm1 = scratchViews.get_scratch_view_1D(
+    *vofNm1_);
+  SharedMemView<DoubleType*>& v_vofN = scratchViews.get_scratch_view_1D(
+    *vofN_);
+  SharedMemView<DoubleType*>& v_vofNp1 = scratchViews.get_scratch_view_1D(
+    *vofNp1_);
+  SharedMemView<DoubleType**>& v_vrtm = scratchViews.get_scratch_view_2D(*velocityRTM_);
+  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+  SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+
+  for ( int ip = 0; ip < AlgTraits::numScvIp_; ++ip ) {
+
+    // nearest node to ip
+    const int nearestNode = ipNodeMap_[ip];
+    
+    // zero out; scalar
+    DoubleType vofNm1Ip = 0.0;
+    DoubleType vofNIp = 0.0;
+    DoubleType vofNp1Ip = 0.0;
+    
+    // zero out; vector
+    for (int j = 0; j < AlgTraits::nDim_; ++j) {
+      w_uIp[j] = 0.0;
+    }
+
+    for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
+      // save off shape function
+      const DoubleType r = v_shape_function_(ip,ic);
+      vofNm1Ip += r*v_vofNm1(ic);
+      vofNIp += r*v_vofN(ic);
+      vofNp1Ip += r*v_vofNp1(ic);
+      for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+        w_uIp[j] += r*v_vrtm(ic,j);
+      }
+    }
+
+    const DoubleType scV = v_scv_volume(ip);
+    
+    // Galerkin first
+    DoubleType uidVofdxi = 0.0;
+    for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
+      const DoubleType lhsMass = v_shape_function_(ip,ic)*gamma1_/dt_;
+      DoubleType lhsAdv = 0.0;
+      for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+        lhsAdv += w_uIp[j]*v_dndx(ip,ic,j);
+      }
+      uidVofdxi += lhsAdv*v_vofNp1(ic);
+      lhs(nearestNode,ic) += (lhsMass+lhsAdv)*scV;
+    }
+
+    // form residual
+    const DoubleType mass = (gamma1_*vofNp1Ip + gamma2_*vofNIp + gamma3_*vofNm1Ip)/dt_;
+    
+    // assemble rhs
+    rhs(nearestNode) -= (mass+uidVofdxi)*scV;
+  }
+}
+
+INSTANTIATE_KERNEL(VolumeOfFluidElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/kernel/VolumeOfFluidSucvNsoElemKernel.C
+++ b/src/kernel/VolumeOfFluidSucvNsoElemKernel.C
@@ -1,0 +1,239 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/VolumeOfFluidSucvNsoElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "TimeIntegrator.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+VolumeOfFluidSucvNsoElemKernel<AlgTraits>::VolumeOfFluidSucvNsoElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ScalarFieldType* vof,
+  const double sucvFac,
+  const double nsoFac,
+  ElemDataRequests& dataPreReqs)
+  : Kernel(),
+    sucvFac_(sucvFac),
+    nsoFac_(nsoFac),
+    lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  
+  vofN_ = &(vof->field_of_state(stk::mesh::StateN));
+  vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
+  if (vof->number_of_states() == 2)
+    vofNm1_ = vofN_;
+  else
+    vofNm1_ = &(vof->field_of_state(stk::mesh::StateNM1));
+  
+  std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
+  velocityRTM_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_surface_me(meSCS);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*vofNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*vofN_, 1);
+  dataPreReqs.add_gathered_nodal_field(*vofNp1_, 1);
+
+  // master element data
+  dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GRAD_OP, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCS_GIJ, CURRENT_COORDINATES);
+  
+  // correction to gij
+  gijFac_ = (AlgTraits::nodesPerElement_ == 4 || AlgTraits::nodesPerElement_ == 8) ? 4.0 : 1.0;
+}
+
+template<typename AlgTraits>
+VolumeOfFluidSucvNsoElemKernel<AlgTraits>::~VolumeOfFluidSucvNsoElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+VolumeOfFluidSucvNsoElemKernel<AlgTraits>::setup(const TimeIntegrator& timeIntegrator)
+{
+  dt_ = timeIntegrator.get_time_step();
+  gamma1_ = timeIntegrator.get_gamma1();
+  gamma2_ = timeIntegrator.get_gamma2();
+  gamma3_ = timeIntegrator.get_gamma3(); // gamma3 may be zero
+}
+
+template<typename AlgTraits>
+void
+VolumeOfFluidSucvNsoElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>& lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  NALU_ALIGNED DoubleType w_uIp[AlgTraits::nDim_];
+  NALU_ALIGNED DoubleType w_dvofdxIp[AlgTraits::nDim_];
+
+  SharedMemView<DoubleType*>& v_vofNm1 = scratchViews.get_scratch_view_1D(
+    *vofNm1_);
+  SharedMemView<DoubleType*>& v_vofN = scratchViews.get_scratch_view_1D(
+    *vofN_);
+  SharedMemView<DoubleType*>& v_vofNp1 = scratchViews.get_scratch_view_1D(
+    *vofNp1_);
+  SharedMemView<DoubleType**>& v_vrtm = scratchViews.get_scratch_view_2D(*velocityRTM_);
+
+  SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
+  SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx;
+  SharedMemView<DoubleType***>& v_gijUpper = scratchViews.get_me_views(CURRENT_COORDINATES).gijUpper;
+  SharedMemView<DoubleType***>& v_gijLower = scratchViews.get_me_views(CURRENT_COORDINATES).gijLower;
+
+  for ( int ip = 0; ip < AlgTraits::numScsIp_; ++ip ) {
+
+    // left and right nodes for this ip
+    const int il = lrscv_[2*ip];
+    const int ir = lrscv_[2*ip+1];
+    
+    // zero out; scalar
+    DoubleType vofNm1Ip = 0.0;
+    DoubleType vofNIp = 0.0;
+    DoubleType vofNp1Ip = 0.0;
+    
+    // zero out; vector
+    for (int j = 0; j < AlgTraits::nDim_; ++j) {
+      w_uIp[j] = 0.0;
+      w_dvofdxIp[j] = 0.0;
+    }
+
+    for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
+      // save off shape function
+      const DoubleType r = v_shape_function_(ip,ic);
+      vofNm1Ip += r*v_vofNm1(ic);
+      vofNIp += r*v_vofN(ic);
+      vofNp1Ip += r*v_vofNp1(ic);
+      const DoubleType vofIc = v_vofNp1(ic);
+      for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+        w_uIp[j] += r*v_vrtm(ic,j);
+        w_dvofdxIp[j] += vofIc*v_dndx(ip,ic,j);
+      }
+    }
+
+    // form uj*nj; fold in uigijuj
+    DoubleType ujaj = 0.0;
+    DoubleType uigijuj = 0.0;
+    DoubleType gUpperMagGradQ = 0.0;
+    DoubleType uigLijuj = 0.0;
+    for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
+      const DoubleType ai = v_scs_areav(ip,i);
+      const DoubleType ui = w_uIp[i];
+      const DoubleType dvofdxIpi = w_dvofdxIp[i];
+
+      ujaj += ui*ai;
+      for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+        uigijuj += ui*v_gijLower(ip,i,j)*w_uIp[j];
+        uigLijuj += ui*v_gijLower(ip,i,j)*w_uIp[j];
+        gUpperMagGradQ += dvofdxIpi*v_gijUpper(ip,i,j)*w_dvofdxIp[j];
+      }
+    }
+
+    // construct tau (from flow-aligned time scale) and nu (from residual)
+    const DoubleType tau = 1.0/(stk::math::sqrt((2.0/dt_)*(2.0/dt_) + gijFac_*uigijuj));
+    
+    // form mass term residual
+    const DoubleType mass = (gamma1_*vofNp1Ip + gamma2_*vofNIp + gamma3_*vofNm1Ip)/dt_;
+
+    DoubleType uidVofdxi = 0.0;
+    for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
+      // save of some variables
+      const DoubleType vofIc = v_vofNp1(ic);
+      
+      // SUCV diffusion-like term; -tau*uidvof/dxi*ujnj (residual below)
+      DoubleType lhsfac = 0.0;
+      for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+        const DoubleType ujdNj = w_uIp[j]*v_dndx(ip,ic,j);
+        uidVofdxi += ujdNj*vofIc;
+        lhsfac += -ujdNj;
+      }
+      lhs(il,ic) += tau*ujaj*lhsfac*sucvFac_;
+      lhs(ir,ic) -= tau*ujaj*lhsfac*sucvFac_;	  
+    }
+    
+    // form residual
+    const DoubleType residual = mass+uidVofdxi;
+
+    // full sucv residual
+    const DoubleType residualSucv = -tau*ujaj*residual*sucvFac_;
+    
+    // residual; left and right
+    rhs(il) -= residualSucv;
+    rhs(ir) += residualSucv; 
+
+    // construct and nu (from residual)
+    const DoubleType nuResidual = stk::math::sqrt((residual*residual)/(gUpperMagGradQ/gijFac_+small_));
+
+    // construct nu from first-order-like approach; SNL-internal write-up (eq 209)
+    const DoubleType nuFirstOrder = stk::math::sqrt(uigLijuj);
+
+    // limit based on first order; Cupw_ is a fudge factor similar to Guermond's approach
+    const DoubleType nu = stk::math::min(Cupw_*nuFirstOrder, nuResidual);
+
+    DoubleType gijFac = 0.0;
+    for ( int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic ) {
+
+      // save of some variables
+      const DoubleType vofIc = v_vofNp1(ic);
+
+      // NSO diffusion-like term; -nu*gUpper*dvof/dxj*ai (residual below)
+      DoubleType lhsfac = 0.0;
+      for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
+        const DoubleType axi = v_scs_areav(ip,i);
+        for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+          const DoubleType dnxj = v_dndx(ip,ic,j);
+          const DoubleType fac = v_gijUpper(ip,i,j)*dnxj*axi;
+          gijFac += fac*vofIc;
+          lhsfac += -fac;
+        }
+      }
+      
+      lhs(il,ic) += nu*lhsfac;
+      lhs(ir,ic) -= nu*lhsfac;
+    }
+
+    // residual; left and right
+    const DoubleType residualNSO = -nu*gijFac;
+    rhs(il) -= residualNSO;
+    rhs(ir) += residualNSO;   
+  }
+  
+}
+
+INSTANTIATE_KERNEL(VolumeOfFluidSucvNsoElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/user_functions/RayleighTaylorMixFracAuxFunction.C
+++ b/src/user_functions/RayleighTaylorMixFracAuxFunction.C
@@ -17,7 +17,8 @@
 namespace sierra{
 namespace nalu{
 
-RayleighTaylorMixFracAuxFunction::RayleighTaylorMixFracAuxFunction() :
+RayleighTaylorMixFracAuxFunction::RayleighTaylorMixFracAuxFunction(
+    const std::vector<double> &theParams) :
   AuxFunction(0,1),
   aX_(0.1),
   tX_(1.0),
@@ -25,7 +26,15 @@ RayleighTaylorMixFracAuxFunction::RayleighTaylorMixFracAuxFunction() :
   dTr_(0.20),
   pi_(acos(-1.0))
 {
-  // does nothing
+  // extract the params - if they are supplied (optional)
+  if ( theParams.size() > 0 )
+    aX_ = theParams[0];
+  if ( theParams.size() > 1 )
+    tX_ = theParams[1];
+  if ( theParams.size() > 2 )
+    yTr_ = theParams[2];
+  if ( theParams.size() > 3 )
+    dTr_ = theParams[3];
 }
 
 void


### PR DESCRIPTION
* VOF EquationSystem

* mass and advection kernel

* SUCV kernel

* connect VOF in EqSystems and kernels

* allow for VOF-based material model

* modify RayleighTaylor to support a driven cavity test; params optional

    initial_conditions:

      - user_function: ic_2
        target_name: block_1
        user_function_name:
         mixture_fraction: RayleighTaylor
        user_function_parameters:
         mixture_fraction: [0.1, 1.0, 0.5, 0.05]

* liner system sharpening evaluation... Not so great without smoothing of
  vof and, therefore, interface_normal. Remove for now..

    // sharpen; d(alpha)/dtau = -d/dxj(sj); sj = [alpha*(1-alpha) + D*d(alpha)/dxk*nk]nj

* Add NSO

* dial SUCV and NSO via: [vof, sucv, nso, sucv_nso]