### PR TITLE
Port GCL to kernel

### DIFF
--- a/include/kernel/ContinuityGclElemKernel.h
+++ b/include/kernel/ContinuityGclElemKernel.h
@@ -1,0 +1,78 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef ContinuityGclElemKernel_H
+#define ContinuityGclElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class TimeIntegrator;
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** GCL for continuity equation (pressure DOF)
+ */
+template<typename AlgTraits>
+class ContinuityGclElemKernel: public Kernel
+{
+public:
+  ContinuityGclElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~ContinuityGclElemKernel();
+
+  /** Perform pre-timestep work for the computational kernel
+   */
+  virtual void setup(const TimeIntegrator&);
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  ContinuityGclElemKernel() = delete;
+
+  ScalarFieldType *densityNp1_{nullptr};
+  ScalarFieldType *divV_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  double dt_{0.0};
+  double gamma1_{0.0};
+  const bool lumpedMass_;
+
+  // inverse density scaling tied to balancedForce_
+  const double densFac_;
+  const double om_densFac_;
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* ContinuityGclElemKernel_H */

--- a/include/kernel/MomentumGclElemKernel.h
+++ b/include/kernel/MomentumGclElemKernel.h
@@ -1,0 +1,68 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef MomentumGclElemKernel_H
+#define MomentumGclElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** GCL for momentum equation (velocity DOF)
+ */
+template<typename AlgTraits>
+class MomentumGclElemKernel: public Kernel
+{
+public:
+  MomentumGclElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~MomentumGclElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  MomentumGclElemKernel() = delete;
+
+  VectorFieldType *velocityNp1_{nullptr};
+  ScalarFieldType *densityNp1_{nullptr};
+  ScalarFieldType *divV_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  const bool lumpedMass_;
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* MomentumGclElemKernel_H */

--- a/include/kernel/ScalarGclElemKernel.h
+++ b/include/kernel/ScalarGclElemKernel.h
@@ -1,0 +1,69 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef ScalarGclElemKernel_H
+#define ScalarGclElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** GCL for scalar equation (Z, h, Yk, etc., DOF)
+ */
+template<typename AlgTraits>
+class ScalarGclElemKernel: public Kernel
+{
+public:
+  ScalarGclElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ScalarFieldType*,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~ScalarGclElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  ScalarGclElemKernel() = delete;
+
+  ScalarFieldType *densityNp1_{nullptr};
+  ScalarFieldType *divV_{nullptr};
+  ScalarFieldType *scalarQ_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  const bool lumpedMass_;
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* ScalarGclElemKernel_H */

--- a/include/kernel/VolumeOfFluidGclElemKernel.h
+++ b/include/kernel/VolumeOfFluidGclElemKernel.h
@@ -1,0 +1,68 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef VolumeOfFluidGclElemKernel_H
+#define VolumeOfFluidGclElemKernel_H
+
+#include "kernel/Kernel.h"
+#include "FieldTypeDef.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class MasterElement;
+class ElemDataRequests;
+
+/** GCL for VOF equation (VOF DOF)
+ */
+template<typename AlgTraits>
+class VolumeOfFluidGclElemKernel: public Kernel
+{
+public:
+  VolumeOfFluidGclElemKernel(
+    const stk::mesh::BulkData&,
+    const SolutionOptions&,
+    ScalarFieldType*,
+    ElemDataRequests&,
+    const bool);
+
+  virtual ~VolumeOfFluidGclElemKernel();
+
+  /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
+   *  the linear solve
+   */
+  virtual void execute(
+    SharedMemView<DoubleType**>&,
+    SharedMemView<DoubleType*>&,
+    ScratchViews<DoubleType>&);
+
+private:
+  VolumeOfFluidGclElemKernel() = delete;
+
+  ScalarFieldType *divV_{nullptr};
+  ScalarFieldType *vofNp1_{nullptr};
+  VectorFieldType *coordinates_{nullptr};
+
+  const bool lumpedMass_;
+
+  /// Integration point to node mapping
+  const int* ipNodeMap_;
+
+  /// Shape functions
+  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};
+};
+
+}  // nalu
+}  // sierra
+
+#endif /* VolumeOfFluidGclElemKernel_H */

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -112,11 +112,13 @@
 // kernels
 #include "kernel/ContinuityAdvElemKernel.h"
 #include "kernel/ContinuityVofAdvElemKernel.h"
+#include "kernel/ContinuityGclElemKernel.h"
 #include "kernel/ContinuityMassElemKernel.h"
 #include "kernel/MomentumAdvDiffElemKernel.h"
 #include "kernel/MomentumActuatorSrcElemKernel.h"
 #include "kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h"
 #include "kernel/MomentumBuoyancySrcElemKernel.h"
+#include "kernel/MomentumGclElemKernel.h"
 #include "kernel/MomentumMassElemKernel.h"
 #include "kernel/MomentumUpwAdvDiffElemKernel.h"
 
@@ -1359,6 +1361,14 @@ MomentumEquationSystem::register_interior_algorithm(
         (partTopo, *this, activeKernels, "NSO_4TH_KE",
          realm_.bulk_data(), *realm_.solutionOptions_, velocity_, dudx_, 1.0, dataPreReqs);
 
+      build_topo_kernel_if_requested<MomentumGclElemKernel>
+        (partTopo, *this, activeKernels, "gcl",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, false);
+      
+      build_topo_kernel_if_requested<MomentumGclElemKernel>
+        (partTopo, *this, activeKernels, "lumped_gcl",
+         realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
+
       report_invalid_supp_alg_names();
       report_built_supp_alg_names();
     }
@@ -2582,6 +2592,14 @@ ContinuityEquationSystem::register_interior_algorithm(
 
         build_topo_kernel_if_requested<ContinuityMassElemKernel>
           (partTopo, *this, activeKernels, "lumped_density_time_derivative",
+           realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
+
+        build_topo_kernel_if_requested<ContinuityGclElemKernel>
+          (partTopo, *this, activeKernels, "gcl",
+           realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, false);
+
+        build_topo_kernel_if_requested<ContinuityGclElemKernel>
+          (partTopo, *this, activeKernels, "lumped_gcl",
            realm_.bulk_data(), *realm_.solutionOptions_, dataPreReqs, true);
 
         build_topo_kernel_if_requested<ContinuityAdvElemKernel>

--- a/src/VolumeOfFluidEquationSystem.C
+++ b/src/VolumeOfFluidEquationSystem.C
@@ -46,6 +46,7 @@
 #include "kernel/VolumeOfFluidSucvNsoElemKernel.h"
 #include "kernel/VolumeOfFluidSharpenElemKernel.h"
 #include "kernel/VolumeOfFluidOpenAdvElemKernel.h"
+#include "kernel/VolumeOfFluidGclElemKernel.h"
 
 // user function
 #include "user_functions/RayleighTaylorMixFracAuxFunction.h"
@@ -308,6 +309,14 @@ VolumeOfFluidEquationSystem::register_interior_algorithm(
     build_topo_kernel_if_requested<VolumeOfFluidSharpenElemKernel>
       (partTopo, *this, activeKernels, "sharpen",
        realm_.bulk_data(), *realm_.solutionOptions_, vof_, cAlpha_, dataPreReqs);
+
+    build_topo_kernel_if_requested<VolumeOfFluidGclElemKernel>
+      (partTopo, *this, activeKernels, "lumped_gcl",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, dataPreReqs, true);
+
+    build_topo_kernel_if_requested<VolumeOfFluidGclElemKernel>
+      (partTopo, *this, activeKernels, "gcl",
+       realm_.bulk_data(), *realm_.solutionOptions_, vof_, dataPreReqs, false);
       
     report_invalid_supp_alg_names();
     report_built_supp_alg_names();

--- a/src/kernel/ContinuityGclElemKernel.C
+++ b/src/kernel/ContinuityGclElemKernel.C
@@ -1,0 +1,116 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/ContinuityGclElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "TimeIntegrator.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+ContinuityGclElemKernel<AlgTraits>::ContinuityGclElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    densFac_(solnOpts.balancedForce_ ? 0.0 : 1.0),
+    om_densFac_(solnOpts.balancedForce_ ? 1.0 : 0.0),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+
+  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "density");
+  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  divV_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  if ( lumpedMass_ )
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*divV_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+ContinuityGclElemKernel<AlgTraits>::~ContinuityGclElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+ContinuityGclElemKernel<AlgTraits>::setup(const TimeIntegrator& timeIntegrator)
+{
+  dt_ = timeIntegrator.get_time_step();
+  gamma1_ = timeIntegrator.get_gamma1();
+}
+
+template<typename AlgTraits>
+void
+ContinuityGclElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>&/*lhs*/,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  const DoubleType projTimeScale = dt_/gamma1_;
+
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
+    *densityNp1_);
+  SharedMemView<DoubleType*>& v_divV = scratchViews.get_scratch_view_1D(
+    *divV_);
+  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+    const int nearestNode = ipNodeMap_[ip];
+
+    DoubleType rhoIp = 0.0;
+    DoubleType divVIp = 0.0;
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const DoubleType r = v_shape_function_(ip, ic);
+      rhoIp += r*v_densityNp1(ic);
+      divVIp += r*v_divV(ic);
+    }
+
+    const DoubleType rhoScale = densFac_*rhoIp + om_densFac_;
+    rhs(nearestNode) -= rhoScale*divVIp*v_scv_volume(ip)/projTimeScale;
+
+    // manage LHS : N/A
+  }
+}
+
+INSTANTIATE_KERNEL(ContinuityGclElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/kernel/ContinuityVofOpenElemKernel.C
+++ b/src/kernel/ContinuityVofOpenElemKernel.C
@@ -161,7 +161,6 @@ ContinuityVofOpenElemKernel<BcAlgTraits>::execute(
       pBip += r*vf_pressure(ic);
       pbcBip += r*vf_pressureBc(ic);
       rhoBip += r*vf_density(ic);
-      const DoubleType rhoIC = vf_density(ic);
       for ( int j = 0; j < BcAlgTraits::nDim_; ++j ) {
         w_uBip[j] += r*vf_vrtm(ic,j);
         w_GpdxBip[j] += r*vf_Gpdx(ic,j);

--- a/src/kernel/MomentumGclElemKernel.C
+++ b/src/kernel/MomentumGclElemKernel.C
@@ -1,0 +1,134 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/MomentumGclElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+MomentumGclElemKernel<AlgTraits>::MomentumGclElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+
+  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "velocity");
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+
+  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "density");
+  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+
+  divV_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity");
+  velocityNp1_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  if ( lumpedMass_ )
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*divV_, 1);
+  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+MomentumGclElemKernel<AlgTraits>::~MomentumGclElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+MomentumGclElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>&lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  NALU_ALIGNED DoubleType w_uIp [AlgTraits::nDim_];
+
+  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
+    *densityNp1_);
+  SharedMemView<DoubleType*>& v_divV = scratchViews.get_scratch_view_1D(
+    *divV_);
+  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+    const int nearestNode = ipNodeMap_[ip];
+
+    DoubleType rhoIp = 0.0;
+    DoubleType divVIp = 0.0;
+    for (int j=0; j < AlgTraits::nDim_; j++) {
+      w_uIp[j] = 0.0;
+    }
+
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const DoubleType r = v_shape_function_(ip, ic);
+      rhoIp += r*v_densityNp1(ic);
+      divVIp += r*v_divV(ic);
+      for (int j=0; j < AlgTraits::nDim_; j++) {
+        w_uIp[j] += r*v_velocityNp1(ic, j);
+      }
+    }
+    
+    const DoubleType scV = v_scv_volume(ip);
+    const int nnNdim = nearestNode*AlgTraits::nDim_;
+    for (int i=0; i < AlgTraits::nDim_; ++i) {
+      rhs(nnNdim+i) -= rhoIp*w_uIp[i]*divVIp*scV;
+    }
+
+    // Compute LHS
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const int icNdim = ic*AlgTraits::nDim_;
+      const DoubleType r = v_shape_function_(ip, ic);
+      const DoubleType lhsfac = r*rhoIp*divVIp*scV;
+
+      for (int j=0; j<AlgTraits::nDim_; ++j) {
+        const int indexNN = nnNdim + j;
+        lhs(indexNN,icNdim+j) += lhsfac;
+      }
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(MomentumGclElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/kernel/ScalarGclElemKernel.C
+++ b/src/kernel/ScalarGclElemKernel.C
@@ -1,0 +1,115 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/ScalarGclElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+ScalarGclElemKernel<AlgTraits>::ScalarGclElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ScalarFieldType* scalarQ,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+
+  ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "density");
+  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  divV_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  if ( lumpedMass_ )
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(*divV_, 1);
+  dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+ScalarGclElemKernel<AlgTraits>::~ScalarGclElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+ScalarGclElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>&lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(
+    *scalarQ_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
+    *densityNp1_);
+  SharedMemView<DoubleType*>& v_divV = scratchViews.get_scratch_view_1D(
+    *divV_);
+  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+    const int nearestNode = ipNodeMap_[ip];
+
+    DoubleType rhoIp = 0.0;
+    DoubleType divVIp = 0.0;
+    DoubleType scalarQIp = 0.0;
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const DoubleType r = v_shape_function_(ip, ic);
+      rhoIp += r*v_densityNp1(ic);
+      divVIp += r*v_divV(ic);
+      scalarQIp += r*v_scalarQ(ic);
+    }
+
+    const DoubleType scV = v_scv_volume(ip);
+
+    rhs(nearestNode) -= rhoIp*scalarQIp*divVIp*scV;
+
+    // Compute LHS
+    const DoubleType lhsFac = rhoIp*divVIp*scV;
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const DoubleType r = v_shape_function_(ip, ic);
+      lhs(nearestNode,ic) += r*lhsFac;
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(ScalarGclElemKernel);
+
+}  // nalu
+}  // sierra

--- a/src/kernel/VolumeOfFluidGclElemKernel.C
+++ b/src/kernel/VolumeOfFluidGclElemKernel.C
@@ -1,0 +1,107 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernel/VolumeOfFluidGclElemKernel.h"
+#include "AlgTraits.h"
+#include "master_element/MasterElement.h"
+#include "SolutionOptions.h"
+
+// template and scratch space
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+template<typename AlgTraits>
+VolumeOfFluidGclElemKernel<AlgTraits>::VolumeOfFluidGclElemKernel(
+  const stk::mesh::BulkData& bulkData,
+  const SolutionOptions& solnOpts,
+  ScalarFieldType* vof,
+  ElemDataRequests& dataPreReqs,
+  const bool lumpedMass)
+  : Kernel(),
+    lumpedMass_(lumpedMass),
+    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+{
+  // save off fields
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+
+  vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
+  divV_ = metaData.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+
+  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+
+  // compute shape function
+  if ( lumpedMass_ )
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);
+  else
+    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+
+  // add master elements
+  dataPreReqs.add_cvfem_volume_me(meSCV);
+
+  // fields and data
+  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*divV_, 1);
+  dataPreReqs.add_gathered_nodal_field(*vofNp1_, 1);
+  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+VolumeOfFluidGclElemKernel<AlgTraits>::~VolumeOfFluidGclElemKernel()
+{}
+
+template<typename AlgTraits>
+void
+VolumeOfFluidGclElemKernel<AlgTraits>::execute(
+  SharedMemView<DoubleType **>&lhs,
+  SharedMemView<DoubleType *>&rhs,
+  ScratchViews<DoubleType>& scratchViews)
+{
+  SharedMemView<DoubleType*>& v_vofNp1 = scratchViews.get_scratch_view_1D(
+    *vofNp1_);
+  SharedMemView<DoubleType*>& v_divV = scratchViews.get_scratch_view_1D(
+    *divV_);
+  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+
+  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+    const int nearestNode = ipNodeMap_[ip];
+
+    DoubleType divVIp = 0.0;
+    DoubleType vofIp = 0.0;
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      const DoubleType r = v_shape_function_(ip, ic);
+      divVIp += r*v_divV(ic);
+      vofIp += r*v_vofNp1(ic);
+    }
+
+    const DoubleType scV = v_scv_volume(ip);
+
+    rhs(nearestNode) -= vofIp*divVIp*scV;
+
+    // Compute LHS
+    const DoubleType lhsFac = divVIp*scV;
+    for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
+      lhs(nearestNode,ic) += v_shape_function_(ip, ic)*lhsFac;
+    }
+  }
+}
+
+INSTANTIATE_KERNEL(VolumeOfFluidGclElemKernel);
+
+}  // nalu
+}  // sierra


### PR DESCRIPTION
* Added GCL for continuity and momentum; continuity doubles with and without
  balanced_force scheme; LHS included for momentum.

* Added GCL for scalars; LHS included.

* addded GCL for vof; may later deprecate for div_correction approach; LHS included.

Notes:

a) Possibly time to start deprecating some of the SuppAlgDep Elem source terms..