### PR TITLE
Clang warning fix

### DIFF
--- a/include/overset/OversetManagerSTK.h
+++ b/include/overset/OversetManagerSTK.h
@@ -223,6 +223,7 @@ struct OrientedShape {
     throw std::runtime_error("OversetManagerSTK:OrientedShape error : Attempted to use default, non-overriden overlap calculation!");
     return false;
   }
+  virtual ~OrientedShape() {}
 };
 
 /** Oriented cylinder for fine overlap calculations


### PR DESCRIPTION
New STK overset coupling generates warnings in any Clang build due to the missing line included in this PR. 