### PR TITLE
Towards full BF algorithm

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -113,6 +113,7 @@ enum PropertyIdentifier {
   LAME_MU_ID = 6,
   LAME_LAMBDA_ID = 7,
   SCATTERING_COEFF_ID = 8,
+  SURFACE_TENSION_ID = 9,
   PropertyIdentifier_END
 };
 
@@ -125,7 +126,8 @@ static const std::string PropertyIdentifierNames[] = {
   "enthalpy",
   "lame_mu",
   "lame_lambda",
-  "scattering_coefficient"};
+  "scattering_coefficient",
+  "surface_tension"};
 
 // prop enum and name below
 enum  MaterialPropertyType {

--- a/include/VolumeOfFluidEquationSystem.h
+++ b/include/VolumeOfFluidEquationSystem.h
@@ -92,6 +92,7 @@ public:
   void smooth_vof();
   void smooth_vof_execute();
   void compute_interface_normal();
+  void compute_interface_curvature();
 
   const bool managePNG_;
 
@@ -99,6 +100,8 @@ public:
   ScalarFieldType *vofSmoothed_;
   ScalarFieldType *smoothedRhs_;
   VectorFieldType *interfaceNormal_;
+  ScalarFieldType *interfaceCurvature_;
+  ScalarFieldType *surfaceTension_;
   VectorFieldType *dvofdx_;
   ScalarFieldType *vofTmp_;
   

--- a/reg_tests/test_files/vofSlosh/vofSlosh.i
+++ b/reg_tests/test_files/vofSlosh/vofSlosh.i
@@ -86,6 +86,10 @@ realms:
           phase_one: 8.9e-4
           phase_two: 1.8e-5
 
+        - name: surface_tension
+          type: constant
+          value: 0.01
+
     boundary_conditions:
 
     - wall_boundary_condition: bc_left
@@ -137,6 +141,8 @@ realms:
        - volume_of_fluid
        - volume_of_fluid_smoothed
        - interface_normal
+       - interface_curvature
+       - surface_tension
        - dvofdx
        - density
        - viscosity

--- a/reg_tests/test_files/vofSphereDrop/vofSphereDrop.i
+++ b/reg_tests/test_files/vofSphereDrop/vofSphereDrop.i
@@ -82,6 +82,10 @@ realms:
           phase_one: 0.001
           phase_two: 0.001
 
+        - name: surface_tension
+          type: constant
+          value: 0.01
+
     boundary_conditions:
 
     - inflow_boundary_condition: top_bot

--- a/reg_tests/test_files/vofWaveGenerator/vofWaveGenerator.i
+++ b/reg_tests/test_files/vofWaveGenerator/vofWaveGenerator.i
@@ -193,6 +193,10 @@ realms:
           type: volume_of_fluid
           phase_one: 8.9e-4
           phase_two: 1.8e-5
+
+        - name: surface_tension
+          type: constant
+          value: 0.02
   
     boundary_conditions:
 
@@ -257,6 +261,8 @@ realms:
        - volume_of_fluid
        - volume_of_fluid_smoothed
        - interface_normal
+       - interface_curvature
+       - surface_tension
        - dvofdx
        - density
        - viscosity


### PR DESCRIPTION
* Allow for property specification of surface_tension;

	field name; surface_tension

    material_properties:
      target_name: [block_1, block_2]

      specifications:

        - name: surface_tension
          type: constant
          value: 0.01

* Added calculation of interface curvature;

	field name; interface_curvature

Notes:

a) Need kappa_surfaceTension_ip*d(alpha)/dxj_ip*nj*dS to
   vdot and LHS kernel - if d(alpha)/dxj != 0

b) Need the same ip evaluation (normalized by density) in the Gjph algorithm.

c) No need for new momentum source term - everything is hidden in Gjph...