### PR TITLE
Density scaling of the continuity equation when using BF

### DIFF
--- a/include/overset/AssembleOversetSolverConstraintAlgorithm.h
+++ b/include/overset/AssembleOversetSolverConstraintAlgorithm.h
@@ -32,7 +32,8 @@ public:
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
-    stk::mesh::FieldBase *fieldQ);
+    stk::mesh::FieldBase *fieldQ,
+    const bool densityScaling);
   virtual ~AssembleOversetSolverConstraintAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
@@ -40,7 +41,11 @@ public:
 
   // interface assumes that the correct state was provided
   stk::mesh::FieldBase *fieldQ_;
+  ScalarFieldType *density_;
+  ScalarFieldType *dualNodalVolume_;
   
+  const double scaleFac_;
+
   std::vector< const stk::mesh::FieldBase *> ghostFieldVec_;
 };
 

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -404,12 +404,18 @@ EquationSystem::create_constraint_algorithm(
   // create the alg on the new constraint; at present, should only hit this once
   const AlgorithmType algType = OVERSET;
 
+  // check for density scaling
+  bool densityScaling = false;
+  if ( eqnTypeName_ == "continuity" ) {
+    densityScaling = realm_.solutionOptions_->balancedForce_;
+  }
+
   std::map<AlgorithmType, SolverAlgorithm *>::iterator itc =
     solverAlgDriver_->solverConstraintAlgMap_.find(algType);
   if ( itc == solverAlgDriver_->solverConstraintAlgMap_.end() ) {
     // FIXME: should we declare an empty part to push into below Alg?
     AssembleOversetSolverConstraintAlgorithm *theAlg
-      = new AssembleOversetSolverConstraintAlgorithm(realm_, NULL, this, theField);
+      = new AssembleOversetSolverConstraintAlgorithm(realm_, NULL, this, theField, densityScaling);
     solverAlgDriver_->solverConstraintAlgMap_[algType] = theAlg;
   }
   else {


### PR DESCRIPTION
  For the BF alforithm, the system is: 1/rho*dp/dx*Area = 1/dt*v*Area

  In order to have the LHS scaled properly, approximate this scaling
  as (dualVolume^1/nDim)/rho

  Scale the entire row by this scaling factor

* Added scaling factor for constraint alg when BF is active for
  continuity. Approximate this as element averaged-quantities.

Notes:

a) In time, we can elevate thsi scaling per system.
b) Scaling does help linear system convergence substantially when the VoF
   is moving through the overset pathc.