### PR TITLE
Low-Reynolds correction to k_sgs via Inagaki (2011)

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -156,6 +156,7 @@ enum TurbulenceModel {
   SST_DES = 5,
   DKSGS = 6,
   KEPS = 7,
+  LRKSGS = 8,
   TurbulenceModel_END
 };  
 
@@ -168,7 +169,8 @@ static const std::string TurbulenceModelNames[] = {
   "sst",
   "sst_des",
   "dynamic_ksgs",
-  "k_epsilon"};
+  "k_epsilon",
+  "lr_ksgs"};
 
 enum TurbulenceModelConstant {
   TM_cMu = 0,

--- a/include/TurbKineticEnergyEquationSystem.h
+++ b/include/TurbKineticEnergyEquationSystem.h
@@ -84,6 +84,8 @@ public:
     EquationSystems& eqSystems);
   void compute_projected_nodal_gradient();
   
+  void compute_dsqrtk_dx_sq();
+
   const bool managePNG_;
 
   ScalarFieldType *tke_;

--- a/include/TurbKineticEnergyKsgsNodeSourceSuppAlg.h
+++ b/include/TurbKineticEnergyKsgsNodeSourceSuppAlg.h
@@ -41,9 +41,11 @@ public:
   GenericFieldType *dudx_;
   ScalarFieldType *dualNodalVolume_;
   ScalarFieldType *cEps_;
+  ScalarFieldType *visc_;
+  ScalarFieldType *dsqrtkSq_;
   double tkeProdLimitRatio_;
   int nDim_;
-  
+  double lrksgsfac_;
 };
 
 } // namespace nalu

--- a/include/TurbViscKsgsAlgorithm.h
+++ b/include/TurbViscKsgsAlgorithm.h
@@ -33,7 +33,17 @@ public:
   ScalarFieldType *tvisc_;
   ScalarFieldType *dualNodalVolume_;
   ScalarFieldType *cmuEps_;
-  
+  // low-Re
+  ScalarFieldType *cEps_;
+  ScalarFieldType *visc_;
+  ScalarFieldType *minDistance_;
+  ScalarFieldType *dsqrtkSq_;
+
+  // low-Re factors and constants
+  double lrksgsfac_;
+  const double Cl_;
+  const double Ao_;
+  const double Bo_;
 };
 
 } // namespace nalu

--- a/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
@@ -32,7 +32,8 @@ public:
   TurbKineticEnergyKsgsDesignOrderSrcElemKernel(
     const stk::mesh::BulkData&,
     const SolutionOptions&,
-    ElemDataRequests&);
+    ElemDataRequests&,
+    double lrksgsfac);
 
   virtual ~TurbKineticEnergyKsgsDesignOrderSrcElemKernel();
   
@@ -54,7 +55,9 @@ private:
   ScalarFieldType *tvisc_{nullptr};
   ScalarFieldType *dualNodalVolume_{nullptr};
   ScalarFieldType *cEps_{nullptr};
+  ScalarFieldType *visc_{nullptr};
 
+  const double lrksgsfac_;
   const double tkeProdLimitRatio_;
   
   /// Integration point to node mapping

--- a/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
@@ -32,7 +32,8 @@ public:
   TurbKineticEnergyKsgsSrcElemKernel(
     const stk::mesh::BulkData&,
     const SolutionOptions&,
-    ElemDataRequests&);
+    ElemDataRequests&,
+    double lrksgsfac);
 
   virtual ~TurbKineticEnergyKsgsSrcElemKernel();
 
@@ -54,7 +55,10 @@ private:
   ScalarFieldType *dualNodalVolume_{nullptr};
   ScalarFieldType *cEps_{nullptr};
   GenericFieldType *Gju_{nullptr};
-
+  // low-Re
+  ScalarFieldType *visc_{nullptr};
+  ScalarFieldType *dsqrtkSq_{nullptr};
+  const double lrksgsfac_;
   double tkeProdLimitRatio_{0.0};
   
   /// Integration point to node mapping

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1443,7 +1443,7 @@ MomentumEquationSystem::register_interior_algorithm(
     if ( it_tv == tviscAlgDriver_->algMap_.end() ) {
       Algorithm * theAlg = NULL;
       switch (realm_.solutionOptions_->turbulenceModel_ ) {
-        case KSGS: case DKSGS:
+        case KSGS: case LRKSGS: case DKSGS:
           theAlg = new TurbViscKsgsAlgorithm(realm_, part);
           break;
         case SMAGORINSKY:

--- a/src/TurbViscKsgsAlgorithm.C
+++ b/src/TurbViscKsgsAlgorithm.C
@@ -11,6 +11,7 @@
 #include <Algorithm.h>
 #include <FieldTypeDef.h>
 #include <Realm.h>
+#include <SolutionOptions.h>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
@@ -18,6 +19,9 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Field.hpp>
+
+// stk_util
+#include <stk_util/parallel/ParallelReduce.hpp>
 
 namespace sierra{
 namespace nalu{
@@ -38,7 +42,15 @@ TurbViscKsgsAlgorithm::TurbViscKsgsAlgorithm(
     density_(NULL),
     tvisc_(NULL),
     dualNodalVolume_(NULL),
-    cmuEps_(NULL)
+    cmuEps_(NULL),
+    cEps_(NULL),
+    visc_(NULL),
+    minDistance_(NULL),
+    dsqrtkSq_(NULL),
+    lrksgsfac_(0.0),
+    Cl_(4.0),
+    Ao_(20.0),
+    Bo_(2.0)
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
@@ -47,7 +59,19 @@ TurbViscKsgsAlgorithm::TurbViscKsgsAlgorithm(
   density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
   dualNodalVolume_ =meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  cmuEps_ =meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_mu_epsilon");
+  cmuEps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_mu_epsilon");
+
+  // low-Re form
+  cEps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
+  visc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  // assign required variables that may not be registered to an arbitrary field
+  minDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  if (realm_.solutionOptions_->turbulenceModel_ == LRKSGS ) {
+    minDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "minimum_distance_to_wall");
+    dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
+    lrksgsfac_ = 1.0;
+  }
 }
 
 //--------------------------------------------------------------------------
@@ -77,14 +101,28 @@ TurbViscKsgsAlgorithm::execute()
     const double *density = stk::mesh::field_data(*density_, *b.begin() );
     const double *dualNodalVolume = stk::mesh::field_data(*dualNodalVolume_, *b.begin() );
     const double *cmuEps = stk::mesh::field_data(*cmuEps_, *b.begin() );
+    // low-Re
+    const double *cEps = stk::mesh::field_data(*cEps_, *b.begin() );
+    const double *visc = stk::mesh::field_data(*visc_, *b.begin() );
+    const double *minDistance = stk::mesh::field_data(*minDistance_, *b.begin() );
+    const double *dsqrtkSq = stk::mesh::field_data(*dsqrtkSq_, *b.begin() );
     double *tvisc = stk::mesh::field_data(*tvisc_, *b.begin() );
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
       const double filter = std::pow(dualNodalVolume[k], invNdim);
-      tvisc[k] = cmuEps[k]*density[k]*std::sqrt(tke[k])*filter;
+      // low-Re corrections
+      const double dsq = lrksgsfac_*dsqrtkSq[k] + 0.0;
+      const double md = lrksgsfac_*minDistance[k] + 0.0;
+      const double nu = visc[k]/density[k];
+      const double epsKsgs = lrksgsfac_*(cEps[k]*std::pow(tke[k], 1.5)/filter + 2.0*nu*dsq) + 0.0;
+      const double upeps = std::pow(nu*epsKsgs, 0.25)*std::sqrt(Cl_*md/filter);
+      const double ypeps = md*upeps/nu;
+      const double fmu = lrksgsfac_*(1.0 - std::exp(-std::pow(std::pow(ypeps/Ao_, 2.0/3.0),Bo_))) 
+        + (1.0-lrksgsfac_);
+      tvisc[k] = fmu*cmuEps[k]*density[k]*std::sqrt(tke[k])*filter;
     }
   }
 }
-
+  
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -9,108 +9,121 @@
 #include "AlgTraits.h"
 #include "Enums.h"
 #include "SolutionOptions.h"
-#include "master_element/MasterElement.h"
+ #include "master_element/MasterElement.h"
 
-// template and scratch space
-#include "BuildTemplates.h"
-#include "ScratchViews.h"
+ // template and scratch space
+ #include "BuildTemplates.h"
+ #include "ScratchViews.h"
 
-// stk_mesh/base/fem
-#include <stk_mesh/base/Entity.hpp>
-#include <stk_mesh/base/MetaData.hpp>
-#include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/Field.hpp>
+ // stk_mesh/base/fem
+ #include <stk_mesh/base/Entity.hpp>
+ #include <stk_mesh/base/MetaData.hpp>
+ #include <stk_mesh/base/BulkData.hpp>
+ #include <stk_mesh/base/Field.hpp>
 
-namespace sierra {
-namespace nalu {
+ namespace sierra {
+ namespace nalu {
 
-template<typename AlgTraits>
-TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsDesignOrderSrcElemKernel(
-  const stk::mesh::BulkData& bulkData,
-  const SolutionOptions& solnOpts,
-  ElemDataRequests& dataPreReqs)
-  : Kernel(),
-    tkeProdLimitRatio_(solnOpts.get_turb_model_constant(TM_tkeProdLimitRatio)),
-    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
-{
-  // save off fields
-  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "dual_nodal_volume");
-  cEps_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
+ template<typename AlgTraits>
+ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsDesignOrderSrcElemKernel(
+   const stk::mesh::BulkData& bulkData,
+   const SolutionOptions& solnOpts,
+   ElemDataRequests& dataPreReqs,
+   double lrksgsfac)
+   : Kernel(),
+     lrksgsfac_(lrksgsfac),
+     tkeProdLimitRatio_(solnOpts.get_turb_model_constant(TM_tkeProdLimitRatio)),
+     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+ {
+   // save off fields
+   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+   coordinates_ = metaData.get_field<VectorFieldType>(
+     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+   VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
+     stk::topology::NODE_RANK, "velocity");
+   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+   tkeNp1_ = metaData.get_field<ScalarFieldType>(
+     stk::topology::NODE_RANK, "turbulent_ke");
+   densityNp1_ = metaData.get_field<ScalarFieldType>(
+     stk::topology::NODE_RANK, "density");
+   tvisc_ = metaData.get_field<ScalarFieldType>(
+     stk::topology::NODE_RANK, "turbulent_viscosity");
+   dualNodalVolume_ = metaData.get_field<ScalarFieldType>(
+     stk::topology::NODE_RANK, "dual_nodal_volume");
+   cEps_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
 
-  MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
-  get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+   // low-Re form
+   visc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
 
-  // add master elements
-  dataPreReqs.add_cvfem_volume_me(meSCV);
+   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
+   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
 
-  // required fields
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
-  dataPreReqs.add_gathered_nodal_field(*dualNodalVolume_, 1);
-  dataPreReqs.add_gathered_nodal_field(*cEps_, 1);
-  dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
-  dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
-}
+   // add master elements
+   dataPreReqs.add_cvfem_volume_me(meSCV);
 
-template<typename AlgTraits>
-TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::~TurbKineticEnergyKsgsDesignOrderSrcElemKernel()
-{}
+   // required fields
+   dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+   dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
+   dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
+   dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+   dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
+   dataPreReqs.add_gathered_nodal_field(*dualNodalVolume_, 1);
+   dataPreReqs.add_gathered_nodal_field(*cEps_, 1);
+   dataPreReqs.add_gathered_nodal_field(*visc_, 1);
+   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+   dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
+ }
 
-template<typename AlgTraits>
-void
-TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
-  SharedMemView<DoubleType **>&lhs,
-  SharedMemView<DoubleType *>&rhs,
-  ScratchViews<DoubleType>& scratchViews)
-{
-  NALU_ALIGNED DoubleType w_dudx [AlgTraits::nDim_][AlgTraits::nDim_];
- 
-  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType*>& v_tkeNp1 = scratchViews.get_scratch_view_1D(
-    *tkeNp1_);
-  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
-    *densityNp1_);
-  SharedMemView<DoubleType*>& v_tvisc = scratchViews.get_scratch_view_1D(
-    *tvisc_);
-  SharedMemView<DoubleType*>& v_dualNodalVolume = scratchViews.get_scratch_view_1D(
-    *dualNodalVolume_);
-  SharedMemView<DoubleType*>& v_cEps = scratchViews.get_scratch_view_1D(
-    *cEps_);
-  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
-  SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+ template<typename AlgTraits>
+ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::~TurbKineticEnergyKsgsDesignOrderSrcElemKernel()
+ {}
 
-  for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
-    
-    const int nearestNode = ipNodeMap_[ip];
-    
-    // save off scvol
-    const DoubleType scV = v_scv_volume(ip);
-    
-    // everyting lives at the quadrature points
-    DoubleType tkeIp = 0.0;
-    DoubleType rhoIp = 0.0;
-    DoubleType tviscIp = 0.0;
-    DoubleType dualNodalVolIp = 0.0;
-    DoubleType cEpsIp = 0.0;
-    for ( int i = 0; i < AlgTraits::nDim_; ++i )
-      for ( int j = 0; j < AlgTraits::nDim_; ++j )
-        w_dudx[i][j] = 0.0;
+ template<typename AlgTraits>
+ void
+ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
+   SharedMemView<DoubleType **>&lhs,
+   SharedMemView<DoubleType *>&rhs,
+   ScratchViews<DoubleType>& scratchViews)
+ {
+   NALU_ALIGNED DoubleType w_dudx [AlgTraits::nDim_][AlgTraits::nDim_];
+   NALU_ALIGNED DoubleType w_dsqrtkdx [AlgTraits::nDim_];
+
+   SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
+   SharedMemView<DoubleType*>& v_tkeNp1 = scratchViews.get_scratch_view_1D(
+     *tkeNp1_);
+   SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
+     *densityNp1_);
+   SharedMemView<DoubleType*>& v_tvisc = scratchViews.get_scratch_view_1D(
+     *tvisc_);
+   SharedMemView<DoubleType*>& v_dualNodalVolume = scratchViews.get_scratch_view_1D(
+     *dualNodalVolume_);
+   SharedMemView<DoubleType*>& v_cEps = scratchViews.get_scratch_view_1D(
+     *cEps_);
+   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+   SharedMemView<DoubleType*>& v_visc = scratchViews.get_scratch_view_1D(
+     *visc_);
+   SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
+
+   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+
+     const int nearestNode = ipNodeMap_[ip];
+
+     // save off scvol
+     const DoubleType scV = v_scv_volume(ip);
+
+     // everyting lives at the quadrature points
+     DoubleType tkeIp = 0.0;
+     DoubleType rhoIp = 0.0;
+     DoubleType tviscIp = 0.0;
+     DoubleType dualNodalVolIp = 0.0;
+     DoubleType cEpsIp = 0.0;
+     DoubleType viscIp = 0.0;
+     for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
+       w_dsqrtkdx[i] = 0.0;
+       for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
+         w_dudx[i][j] = 0.0;
+       }
+     }
 
     for (int ic = 0; ic < AlgTraits::nodesPerElement_; ++ic) {
       
@@ -120,16 +133,21 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
       tviscIp += r*v_tvisc(ic);
       dualNodalVolIp += r*v_dualNodalVolume(ic);
       cEpsIp += r*v_cEps(ic);
+      viscIp += r*v_visc(ic);
       for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
+        const DoubleType sqrtk = stk::math::sqrt(v_tkeNp1(ic));
+        w_dsqrtkdx[i] += v_dndx(ip,ic,i)*sqrtk;
         const DoubleType ui = v_velocityNp1(ic,i);
         for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
           w_dudx[i][j] += v_dndx(ip,ic,j)*ui;
         }
       }
     }  
-   
+    
     DoubleType Pk = 0.0;
+    DoubleType dsqrtkSqIp = 0.0;
     for ( int i = 0; i < AlgTraits::nDim_; ++i ) {
+      dsqrtkSqIp += w_dsqrtkdx[i]*w_dsqrtkdx[i];
       for ( int j = 0; j < AlgTraits::nDim_; ++j ) {
         Pk += w_dudx[i][j]*(w_dudx[i][j] + w_dudx[j][i]);
       }
@@ -146,7 +164,7 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
       : cEpsIp*rhoIp*stk::math::sqrt(tkeIp)/stk::math::cbrt(dualNodalVolIp);
     
     // dissipation and production (limited)
-    DoubleType Dk = tkeFac * tkeIp;
+    DoubleType Dk = tkeFac * tkeIp + lrksgsfac_*2.0*viscIp*dsqrtkSqIp;
     Pk = stk::math::min(Pk, tkeProdLimitRatio_*Dk);
     
     // assemble RHS and LHS


### PR DESCRIPTION
* new turbulence model, lr_ksgs

* add min distance as a required variable (with restart)

* coded projection of d(sqrt(tke)/dxj for non-design order.

* generalize ksgs node loop and kernel (including design order)
  for the design-order, I do not use the nodal field for d(sqrt(tke)/dxj

* folded in lr_ksgs to TurbViscKsgs

* logic check, need to be consolidated or edge-based for lr_ksgs
  to be supported.

Notes:

a) All of the source term methods have a fake out of gathering low-Re
   terms and scalings of zero and the like. This is the easiest
   way to avoid a proliferation of methods for EBVC and CVFEM.

b) Tested on Re395 with a great set of outcomes.

c) CVFEM only works with consolidated.

d) Why does UnitTest infrastructure provide negative values of density through
   a trigometric interface? Not sure...