### PR TITLE
Remove aggregation: phase2

### DIFF
--- a/reg_tests/xml/matches_ml_default.xml
+++ b/reg_tests/xml/matches_ml_default.xml
@@ -17,7 +17,6 @@
   "aggregation: drop tol" (aka aggregation thresholding) is problem dependent.
 -->
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.00"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>
   <Parameter        name="repartition: start level"         type="int"      value="2"/>

--- a/reg_tests/xml/milestone-nc.xml
+++ b/reg_tests/xml/milestone-nc.xml
@@ -14,7 +14,6 @@
 
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.02"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/milestone.xml
+++ b/reg_tests/xml/milestone.xml
@@ -14,7 +14,6 @@
 
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.02"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>
   <Parameter        name="repartition: start level"         type="int"      value="2"/>

--- a/reg_tests/xml/milestone_ABL.xml
+++ b/reg_tests/xml/milestone_ABL.xml
@@ -21,7 +21,6 @@
 
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.005"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/milestone_McAlister.xml
+++ b/reg_tests/xml/milestone_McAlister.xml
@@ -21,7 +21,6 @@
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.005"/>
   <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="300"/>

--- a/reg_tests/xml/milestone_aspect_ratio.xml
+++ b/reg_tests/xml/milestone_aspect_ratio.xml
@@ -15,7 +15,6 @@
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.02"/>
   <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/milestone_aspect_ratio_smooth.xml
+++ b/reg_tests/xml/milestone_aspect_ratio_smooth.xml
@@ -15,7 +15,6 @@
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.01"/>
   <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/milestone_aspect_ratio_smooth_s.xml
+++ b/reg_tests/xml/milestone_aspect_ratio_smooth_s.xml
@@ -20,7 +20,6 @@
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.01"/>
   <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/muelu_STV_HO.xml
+++ b/reg_tests/xml/muelu_STV_HO.xml
@@ -14,7 +14,6 @@
 
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.01"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/muelu_kovasznay_p7.xml
+++ b/reg_tests/xml/muelu_kovasznay_p7.xml
@@ -11,8 +11,6 @@
      <Parameter name="chebyshev: zero starting solution"    type="bool"     value="false"/>
      <Parameter name="chebyshev: eigenvalue max iterations" type="int"      value="20"/>
   </ParameterList>
-
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
  
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>

--- a/reg_tests/xml/readme.txt
+++ b/reg_tests/xml/readme.txt
@@ -22,3 +22,9 @@ if this is better or worse for low-Mach flow.
  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
  
 See: https://github.com/trilinos/Trilinos/issues/7295
+
+Muelu changed the name to, which is defaulted to false:
+
+  <Parameter        name="aggregation: match ML phase2a" type="bool"   value="false"/>
+
+I chose to remove this as perhaps the name will change again.

--- a/reg_tests/xml/vofBuoy.xml
+++ b/reg_tests/xml/vofBuoy.xml
@@ -20,7 +20,6 @@
   <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop tol"            type="double"   value="0.15"/>
   <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
-  <Parameter        name="aggregation: phase2a include root" type="bool"   value="false"/>
 
   <Parameter        name="repartition: enable"              type="bool"     value="true"/>
   <Parameter        name="repartition: min rows per proc"   type="int"      value="1000"/>


### PR DESCRIPTION
* change in Muelu XML. phase2 line command is gine (causes a throw) in favor
  of: "aggregation: match ML phase2a". However, this line command is
  false.

* remove old line command. Defaults in Muelu are such that match ML phase2a is false.

Notes:

a) no diffs [expected]