### PR TITLE
Use relative submodule so that we can use SSH authentication if desired

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "reg_tests/mesh"]
 	path = reg_tests/mesh
-	url = https://github.com/NaluCFD/NaluMesh.git
+	url = ../NaluMesh.git
         ignore = dirty


### PR DESCRIPTION
This allows the usage of SSH authentication with GitHub if you are using SSH authentication for the main Nalu repo.  See:

* https://nalu.readthedocs.io/en/latest/source/developer/testing.html?highlight=cdash#testing-nalu

But if you are using HTTPS authentication for the main Nalu repo, then git submodule will use HTTPS authentication for the submodules as well.

And this works better if you want to mirror these repos on an internal GitLab site, for example. 

This change removes two of the big disadvantages of using git submodues (i.e. 1. killing the distributed aspect of Git and 2. locking your developers into an authentication protocol.)
