### PR TITLE
Move Tpetra over to Kokkos Views

### DIFF
--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1155,9 +1155,7 @@ void verify_row_lengths(const LinSys::Graph& graph,
       std::vector<GlobalOrdinal> vIndices(graph.getNumEntriesInGlobalRow(rowGID));
 
       Tpetra::CrsGraph<>::nonconst_global_inds_host_view_type colIndices("col_indices", vIndices.size());
-      for (size_t col_idx = 0; col_idx < vIndices.size(); ++col_idx) 
-        colIndices(col_idx) = vIndices[col_idx];
-      
+  
 
       size_t rowLen = 0;
       graph.getGlobalRowCopy(rowGID, colIndices, rowLen);
@@ -1180,8 +1178,7 @@ void dump_graph(const std::string& name, int counter, int proc, LinSys::Graph& g
     GlobalOrdinal rowGID = myGlobalIndices[i];
     std::vector<GlobalOrdinal> vIndices(graph.getNumEntriesInGlobalRow(rowGID));
     Tpetra::CrsGraph<>::nonconst_global_inds_host_view_type colIndices("col_indices", vIndices.size());
-    for (size_t col_idx = 0; col_idx < vIndices.size(); ++col_idx) 
-      colIndices(col_idx) = vIndices[col_idx];
+
     size_t rowLen = 0;
     graph.getGlobalRowCopy(rowGID, colIndices, rowLen);
     std::ostringstream os;

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -192,8 +192,8 @@ void verify_matrix_for_2_hex8_mesh(int numProcs, int localProc, sierra::nalu::Tp
   for(sierra::nalu::LinSys::LocalOrdinal rowlid=0; rowlid<expectedLocalNumRows; ++rowlid) {
     sierra::nalu::LinSys::GlobalOrdinal rowgid = rowMap->getGlobalElement(rowlid);
     unsigned rowLength = ownedMatrix->getNumEntriesInGlobalRow(rowgid);
-    Teuchos::ArrayView<const sierra::nalu::LinSys::LocalOrdinal> inds;
-    Teuchos::ArrayView<const double> vals;
+  Tpetra::CrsMatrix<>::local_inds_host_view_type inds;
+  Tpetra::CrsMatrix<>::values_host_view_type vals;
     ownedMatrix->getLocalRowView(rowlid, inds, vals);
     for(unsigned j=0; j<rowLength; ++j) {
       sierra::nalu::LinSys::GlobalOrdinal colgid = colMap->getGlobalElement(inds[j]);


### PR DESCRIPTION
Fixes host of deprecated code in Tpetra routines through the use of Kokkos::Views rather than Teuchos. Type definitions in Tpetra are used rather than directly creating Kokkos::Views to ensure that Device/Host memory layouts, etc are correct no matter the system. 