### PR TITLE
tethers + cylinder fix

### DIFF
--- a/include/MeshMotionInfo.h
+++ b/include/MeshMotionInfo.h
@@ -12,6 +12,7 @@
 // standard c++
 #include <string>
 #include <vector>
+#include <array>
 
 namespace sierra{
 namespace nalu{
@@ -42,7 +43,8 @@ class MeshMotionInfo
     const double bodyMass,
     const double bodyDen,
     std::vector<double> appliedForce,
-    const bool computeCentroid);
+    const bool computeCentroid,
+    std::vector<std::array<double,9>> tetherGeom);
 
   ~MeshMotionInfo();
 
@@ -51,13 +53,14 @@ class MeshMotionInfo
   std::vector<double> centroid_;
   std::vector<double> unitVec_;
   const double computeCentroid_;
+
+  std::vector<std::array<double,9>> tetherGeom_;
+
   double computeCentroidCompleted_;
   const double theAngle_;
 
 
   // General 6-DOF motion
-  // TODO :: Likely hooks to mass related quantities that
-  // can be used in place of inputs here.
   const bool sixDof_;
   std::vector<double> bodyDispCC_;
   std::vector<double> bodyAngle_;

--- a/include/overset/OversetManagerSTK.h
+++ b/include/overset/OversetManagerSTK.h
@@ -278,19 +278,19 @@ struct OrientedCylinder : public OrientedShape {
     switch (axialDir_) {
       case 0:
         if ( r_point[1]*r_point[1] + r_point[2]*r_point[2] < 
-          0.5*(halfDist_[1]+halfDist_[2]) && 
+          std::pow(0.5*(halfDist_[1]+halfDist_[2]),2) && 
           (abs(r_point[0]-cent_[0])<halfDist_[0] || halfDist_[0]<FLT_MIN) )  
           is_it = true;
         break;
       case 1:
         if ( r_point[0]*r_point[0] + r_point[2]*r_point[2] < 
-          0.5*(halfDist_[0]+halfDist_[2]) && 
+          std::pow(0.5*(halfDist_[0]+halfDist_[2]),2) && 
           (abs(r_point[1]-cent_[1])<halfDist_[1] || halfDist_[1]<FLT_MIN) )  
           is_it = true;
         break;
       case 2:
         if ( r_point[0]*r_point[0] + r_point[1]*r_point[1] < 
-          0.5*(halfDist_[0]+halfDist_[1]) && 
+          std::pow(0.5*(halfDist_[0]+halfDist_[1]),2) && 
           (abs(r_point[2]-cent_[2])<halfDist_[2] || halfDist_[2]<FLT_MIN) )  
           is_it = true;
         break;

--- a/src/MeshMotionInfo.C
+++ b/src/MeshMotionInfo.C
@@ -11,6 +11,7 @@
 // standard c++
 #include <string>
 #include <vector>
+#include <array>
 
 namespace sierra{
 namespace nalu{
@@ -63,7 +64,8 @@ MeshMotionInfo::MeshMotionInfo(
     const double bodyMass,
     const double bodyDen,
     std::vector<double> appliedForce, 
-    const bool computeCentroid)
+    const bool computeCentroid,
+    const std::vector<std::array<double, 9>> tetherGeom)
     : meshMotionBlock_(meshMotionBlock),
       omega_(0.0),
       centroid_(centroid),
@@ -84,8 +86,13 @@ MeshMotionInfo::MeshMotionInfo(
       bodyDen_(bodyDen),
       forceSurface_(forceSurface)
 {
-  
-  // Nothing to do
+
+  for (size_t i = 0; i < tetherGeom.size(); ++i) {
+    this->tetherGeom_.emplace_back(std::array<double,9>{});
+    for (size_t j = 0; j < 9; ++j)
+      tetherGeom_.back()[j] = tetherGeom[i][j];
+
+  }  
 
 }
 


### PR DESCRIPTION
This change includes the ability to add tethers to six-dof moving objects as well as fixes an issue with cylindrical overset cutting. 