### PR TITLE
Add data probes for planar surface

### DIFF
--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -48,16 +48,22 @@ public:
   // manage the types of probes
   std::vector<int> isLineOfSite_;
   std::vector<int> isRing_;
+  std::vector<int> isPlane_;
   std::vector<std::string> partName_;
   std::vector<int> probeOnThisRank_;
   std::vector<int> numPoints_;
   std::vector<int> numLinePoints_;
   std::vector<int> numTotalPoints_;
   std::vector<int> generateNewIds_;
+  std::vector<int> numPointsOne_;
+  std::vector<int> numPointsTwo_;
 
   // line of nodes
   std::vector<Coordinates> tipCoordinates_;
   std::vector<Coordinates> tailCoordinates_;
+  // two lines defining a plane
+  std::vector<Coordinates> tipCoordinatesOne_;
+  std::vector<Coordinates> tipCoordinatesTwo_;
 
   // ring unit normal and origin (vector or vectors to allow for 3D and 2D rotations)
   std::vector<std::array<double, 3> > unitNormal_;

--- a/reg_tests/test_files/re1kChannel/re1kChannel.i
+++ b/reg_tests/test_files/re1kChannel/re1kChannel.i
@@ -134,6 +134,40 @@ realms:
         - limiter:
             turbulent_ke: yes
 
+    data_probes:
+
+      output_frequency: 25
+
+      search_tolerance: 1.0e-3
+      search_expansion_factor: 2.0
+
+      specifications:
+
+        - name: probe_volume
+          from_target_part: Unspecified-2-HEX
+
+          plane_specifications:
+
+            - name: xTwo
+              number_of_points_dir_one: 201
+              number_of_points_dir_two: 101
+              tail_coordinates: [2.0, 0.0, 2.0]
+              tip_coordinates_dir_one: [2.0, 2.0, 2.0]
+              tip_coordinates_dir_two: [2.0, 0.0, 0.0]
+
+            - name: xFour
+              number_of_points_dir_one: 101
+              number_of_points_dir_two: 201
+              tail_coordinates: [4.0, 0.0, 2.0]
+              tip_coordinates_dir_one: [4.0, 2.0, 2.0]
+              tip_coordinates_dir_two: [4.0, 0.0, 0.0]
+
+          output_variables:
+            - field_name: velocity
+              field_size: 3
+            - field_name: turbulent_viscosity
+              field_size: 1
+
     post_processing:
     
     - type: surface
@@ -188,6 +222,8 @@ realms:
        - yplus_ra_two
        - tau_wall_ra_two
        - assembled_area_force_moment_wfp
+       - velocity_probe
+       - turbulent_viscosity_probe
 
 Time_Integrators:
   - StandardTimeIntegrator:


### PR DESCRIPTION
* usage: create two vectors, sharing a tail coordinate location along
         with the number of nodes in each direction (one and two).

         the code will provide the data file at the desired frequency
         and field data (should outpur be requested) by "theFieldName_probe"

    data_probes:

      output_frequency: 25

      search_tolerance: 1.0e-3
      search_expansion_factor: 2.0

      specifications:

        - name: probe_volume
          from_target_part: Unspecified-2-HEX

          plane_specifications:

            - name: xTwo
              number_of_points_dir_one: 201
              number_of_points_dir_two: 101
              tail_coordinates: [2.0, 0.0, 2.0]
              tip_coordinates_dir_one: [2.0, 2.0, 2.0]
              tip_coordinates_dir_two: [2.0, 0.0, 0.0]

            - name: xFour
              number_of_points_dir_one: 101
              number_of_points_dir_two: 201
              tail_coordinates: [4.0, 0.0, 2.0]
              tip_coordinates_dir_one: [4.0, 2.0, 2.0]
              tip_coordinates_dir_two: [4.0, 0.0, 0.0]

          output_variables:
            - field_name: velocity
              field_size: 3
            - field_name: turbulent_viscosity
              field_size: 1