### PR TITLE
Updated Nalu for the new STK Mesh simple_fields workflow

### DIFF
--- a/docs/source/theory/codeAbstractions.rst
+++ b/docs/source/theory/codeAbstractions.rst
@@ -261,12 +261,11 @@ elemental, nodal, face and edge of desired size.
       const int numStates = realm_.number_of_states();
 
       // declare it
-      density_ 
-        =  &(metaData_.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, 
-                                                     "density", numStates));
+      density_ = &(metaData_.declare_field<double>(stk::topology::NODE_RANK, 
+                                                  "density", numStates));
 
       // put it on this part
-      stk::mesh::put_field(*density_, *part);
+      stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
     }
 
 :math:`\bullet` edge field registration:
@@ -278,10 +277,10 @@ elemental, nodal, face and edge of desired size.
       stk::mesh::Part *part)
     {
       const int nDim = metaData_.spatial_dimension();
-      edgeAreaVec_ 
-        = &(metaData_.declare_field<VectorFieldType>(stk::topology::EDGE_RANK, 
-                                                    "edge_area_vector"));
-      stk::mesh::put_field(*edgeAreaVec_, *part, nDim);
+      edgeAreaVec_ = &(metaData_.declare_field<double>(stk::topology::EDGE_RANK, 
+                                                      "edge_area_vector"));
+      stk::mesh::put_field_on_mesh(*edgeAreaVec_, *part, nDim, nullptr);
+      stk::io::set_field_output_type(*edgeAreaVec_, stk::io::FieldOutputType::VECTOR_3D);
     }
 
 :math:`\bullet` side/face field registration:
@@ -299,9 +298,9 @@ elemental, nodal, face and edge of desired size.
         stk::topology::rank_t sideRank 
           = static_cast<stk::topology::rank_t>(metaData_.side_rank());
         GenericFieldType *wallFrictionVelocityBip 
-          =  &(metaData_.declare_field<GenericFieldType>
+          =  &(metaData_.declare_field<double>
               (sideRank, "wall_friction_velocity_bip"));
-        stk::mesh::put_field(*wallFrictionVelocityBip, *part, numIp);
+        stk::mesh::put_field_on_mesh(*wallFrictionVelocityBip, *part, numIp, nullptr);
       }
     }
 
@@ -319,23 +318,20 @@ addition to the field template type,
 .. code-block:: c++
 
     VectorFieldType *velocityRTM 
-      = metaData_.get_field<VectorFieldType>(stk::topology::NODE_RANK, 
-                                            "velocity");
+      = metaData_.get_field<double>(stk::topology::NODE_RANK, "velocity");
     ScalarFieldType *density 
-      = metaData_.get_field<ScalarFieldType>(stk::topology::NODE_RANK, 
-                                            "density");}
+      = metaData_.get_field<double>(stk::topology::NODE_RANK, "density");}
 
     VectorFieldType *edgeAreaVec 
-      = metaData_.get_field<VectorFieldType>(stk::topology::EDGE_RANK, 
-                                            "edge_area_vector");
+      = metaData_.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 
     GenericFieldType  *massFlowRate
-      = metaData_.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, 
-                                             "mass_flow_rate_scs");
+      = metaData_.get_field<double>(stk::topology::ELEMENT_RANK, 
+                                   "mass_flow_rate_scs");
 
     GenericFieldType *wallFrictionVelocityBip_ 
-      = metaData_.get_field<GenericFieldType>(metaData_.side_rank(), 
-                                             "wall_friction_velocity_bip");
+      = metaData_.get_field<double>(metaData_.side_rank(), 
+                                   "wall_friction_velocity_bip");
 
 State
 ~~~~~
@@ -348,8 +344,7 @@ extracted,
 .. code-block:: c++
 
     ScalarFieldType *density 
-      = metaData_.get_field<ScalarFieldType>(stk::topology::NODE_RANK, 
-                                            "density");
+      = metaData_.get_field<double>(stk::topology::NODE_RANK, "density");
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
     densityN_ = &(density->field_of_state(stk::mesh::StateN));
     densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));

--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -25,10 +25,10 @@ typedef stk::mesh::Field<stk::mesh::EntityId> GlobalIdFieldType;
 typedef stk::mesh::Field<int>  ScalarIntFieldType;
 
 // define vector field typedef; however, what is the value of Cartesian?
-typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorFieldType;
+typedef stk::mesh::Field<double>  VectorFieldType;
 
 // define generic
-typedef stk::mesh::Field<double, stk::mesh::SimpleArrayTag>  GenericFieldType;
+typedef stk::mesh::Field<double>  GenericFieldType;
 
 // field type for local ids
 typedef unsigned LocalId;

--- a/include/overset/OversetManagerSTK.h
+++ b/include/overset/OversetManagerSTK.h
@@ -26,8 +26,8 @@
 
 // field types
 typedef stk::mesh::Field<double>  ScalarFieldType;
-typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorFieldType;
-typedef stk::mesh::Field<double, stk::mesh::SimpleArrayTag>  GenericFieldType;
+typedef stk::mesh::Field<double>  VectorFieldType;
+typedef stk::mesh::Field<double>  GenericFieldType;
 
 // search types
 typedef stk::search::IdentProc<uint64_t,int>  theKey;

--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -17,7 +17,7 @@ class tioga;
 
 namespace tioga_nalu {
 
-typedef stk::mesh::Field<double, stk::mesh::Cartesian> VectorFieldType;
+typedef stk::mesh::Field<double> VectorFieldType;
 typedef stk::mesh::Field<int> ScalarIntFieldType;
 
 /**

--- a/include/xfer/FromMesh.h
+++ b/include/xfer/FromMesh.h
@@ -122,7 +122,7 @@ public :
     : fromMetaData_   (fromMetaData),
     fromBulkData_   (fromBulkData),
     fromRealm_      (fromRealm),
-    fromcoordinates_(fromMetaData.get_field<VectorFieldType>(stk::topology::NODE_RANK,coordinates_name)),
+    fromcoordinates_(fromMetaData.get_field<double>(stk::topology::NODE_RANK,coordinates_name)),
     fromPartVec_    (fromPartVec),
     fromFieldVec_   (get_fields(fromMetaData, VarPairName)),
     comm_           (comm),

--- a/include/xfer/ToMesh.h
+++ b/include/xfer/ToMesh.h
@@ -119,7 +119,7 @@ public :
     : toMetaData_(toMetaData),
     toBulkData_(toBulkData),
     toRealm_      (toRealm),
-    tocoordinates_(toMetaData.get_field<VectorFieldType>(stk::topology::NODE_RANK,coordinates_name)),
+    tocoordinates_(toMetaData.get_field<double>(stk::topology::NODE_RANK,coordinates_name)),
     toPartVec_(toPartVec),
     toFieldVec_   (get_fields(toMetaData, VarPairName)),
     comm_(comm),

--- a/src/ActuatorLinePointDrag.C
+++ b/src/ActuatorLinePointDrag.C
@@ -399,18 +399,18 @@ ActuatorLinePointDrag::execute()
 
   // extract fields
   VectorFieldType *coordinates
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   VectorFieldType *actuator_source
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "actuator_source");
   VectorFieldType *actuator_source_lhs
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source_lhs");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "actuator_source_lhs");
   ScalarFieldType *density
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   // deal with proper viscosity
   const std::string viscName = realm_.is_turbulent() ? "effective_viscosity" : "viscosity";
   ScalarFieldType *viscosity
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
+    = metaData.get_field<double>(stk::topology::NODE_RANK, viscName);
 
   // fixed size scratch
   std::vector<double> ws_pointGasVelocity(nDim);
@@ -531,7 +531,7 @@ ActuatorLinePointDrag::populate_candidate_elements()
   const int nDim = metaData.spatial_dimension();
 
   // fields
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // point data structures
   Point minCorner, maxCorner;
@@ -790,7 +790,7 @@ ActuatorLinePointDrag::complete_search()
 
   // extract fields
   VectorFieldType *coordinates
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // now proceed with the standard search
   std::vector<std::pair<boundingSphere::second_type, boundingElementBox::second_type> >::const_iterator ii;

--- a/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
@@ -52,16 +52,16 @@ AssembleContinuityEdgeOpenSolverAlgorithm::AssembleContinuityEdgeOpenSolverAlgor
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-     velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+     velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
    else
-     velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+     velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  pressureBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleContinuityEdgeSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeSolverAlgorithm.C
@@ -49,14 +49,14 @@ AssembleContinuityEdgeSolverAlgorithm::AssembleContinuityEdgeSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleContinuityElemOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityElemOpenSolverAlgorithm.C
@@ -56,16 +56,16 @@ AssembleContinuityElemOpenSolverAlgorithm::AssembleContinuityElemOpenSolverAlgor
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  pressureBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
 
   // Implementation details: code is designed to manage the following
   // When shiftPoisson_ is TRUE, reducedSensitivities_ is enforced to be TRUE

--- a/src/AssembleContinuityElemSolverAlgorithm.C
+++ b/src/AssembleContinuityElemSolverAlgorithm.C
@@ -53,13 +53,13 @@ AssembleContinuityElemSolverAlgorithm::AssembleContinuityElemSolverAlgorithm(
   // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
 
   // Implementation details: code is designed to manage the following
   // When shiftPoisson_ is TRUE, reducedSensitivities_ is enforced to be TRUE

--- a/src/AssembleContinuityInflowSolverAlgorithm.C
+++ b/src/AssembleContinuityInflowSolverAlgorithm.C
@@ -47,10 +47,10 @@ AssembleContinuityInflowSolverAlgorithm::AssembleContinuityInflowSolverAlgorithm
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  velocityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
   // variable density will need density as a function of user inflow conditions
-  densityBC_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  densityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleContinuityNonConformalSolverAlgorithm.C
+++ b/src/AssembleContinuityNonConformalSolverAlgorithm.C
@@ -60,19 +60,19 @@ AssembleContinuityNonConformalSolverAlgorithm::AssembleContinuityNonConformalSol
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   if ( meshMotion_ ) {
     meshMotionFac_ = 1.0;
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
     meshMotionFac_ = 0.0;
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   }
 
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");  
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
   
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(pressure_);

--- a/src/AssembleCourantReynoldsElemAlgorithm.C
+++ b/src/AssembleCourantReynoldsElemAlgorithm.C
@@ -53,18 +53,18 @@ AssembleCourantReynoldsElemAlgorithm::AssembleCourantReynoldsElemAlgorithm(
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   const std::string viscName = (realm.is_turbulent())
      ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
 
   // provide for elemental fields
-  elemReynolds_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds");
-  elemCourant_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant");
+  elemReynolds_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_reynolds");
+  elemCourant_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_courant");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleCourantReynoldsFemAlgorithm.C
+++ b/src/AssembleCourantReynoldsFemAlgorithm.C
@@ -52,18 +52,18 @@ AssembleCourantReynoldsFemAlgorithm::AssembleCourantReynoldsFemAlgorithm(
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   const std::string viscName = (realm.is_turbulent())
      ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
 
   // provide for elemental fields
-  elemReynolds_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds");
-  elemCourant_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant");
+  elemReynolds_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_reynolds");
+  elemCourant_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_courant");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleHeatCondIrradWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondIrradWallSolverAlgorithm.C
@@ -48,10 +48,10 @@ AssembleHeatCondIrradWallSolverAlgorithm::AssembleHeatCondIrradWallSolverAlgorit
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
-  irradiation_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "irradiation");
-  emissivity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "emissivity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
+  irradiation_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "irradiation");
+  emissivity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "emissivity");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleHeatCondWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondWallSolverAlgorithm.C
@@ -50,8 +50,8 @@ AssembleHeatCondWallSolverAlgorithm::AssembleHeatCondWallSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
@@ -54,24 +54,24 @@ AssembleMomentumEdgeOpenSolverAlgorithm::AssembleMomentumEdgeOpenSolverAlgorithm
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   if ( realm.does_mesh_move() ) {
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   }
  
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   // extract viscosity  name
   const std::string viscName = realm_.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  velocityBc_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  velocityBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "open_velocity_bc");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumEdgeSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSolverAlgorithm.C
@@ -52,19 +52,19 @@ AssembleMomentumEdgeSolverAlgorithm::AssembleMomentumEdgeSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   // extract viscosity  name
   const std::string viscName = realm_.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  massFlowRate_ = meta_data.get_field<ScalarFieldType>(stk::topology::EDGE_RANK, "mass_flow_rate");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "mass_flow_rate");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(velocity_->name());

--- a/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
@@ -44,14 +44,14 @@ AssembleMomentumEdgeSymmetrySolverAlgorithm::AssembleMomentumEdgeSymmetrySolverA
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   // extract viscosity  name
   const std::string viscName = realm_.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumEdgeWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumEdgeWallFunctionSolverAlgoirthm.C
@@ -49,13 +49,13 @@ AssembleMomentumEdgeWallFunctionSolverAlgorithm::AssembleMomentumEdgeWallFunctio
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumElemOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumElemOpenSolverAlgorithm.C
@@ -57,23 +57,23 @@ AssembleMomentumElemOpenSolverAlgorithm::AssembleMomentumElemOpenSolverAlgorithm
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( realm.does_mesh_move() ) {
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
     meshVelocity_ = velocityRTM_;
   }
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   const std::string viscName = realm.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  velocityBc_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  velocityBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "open_velocity_bc");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(velocity_->name());

--- a/src/AssembleMomentumElemSolverAlgorithm.C
+++ b/src/AssembleMomentumElemSolverAlgorithm.C
@@ -55,17 +55,17 @@ AssembleMomentumElemSolverAlgorithm::AssembleMomentumElemSolverAlgorithm(
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   const std::string viscName = realm.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(velocity_->name());

--- a/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
@@ -44,12 +44,12 @@ AssembleMomentumElemSymmetrySolverAlgorithm::AssembleMomentumElemSymmetrySolverA
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   const std::string viscName = realm.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumElemWallFunctionProjectedSolverAlgorithm.C
+++ b/src/AssembleMomentumElemWallFunctionProjectedSolverAlgorithm.C
@@ -56,13 +56,13 @@ AssembleMomentumElemWallFunctionProjectedSolverAlgorithm::AssembleMomentumElemWa
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(&(velocity_->field_of_state(stk::mesh::StateNP1)));

--- a/src/AssembleMomentumElemWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumElemWallFunctionSolverAlgoirthm.C
@@ -51,13 +51,13 @@ AssembleMomentumElemWallFunctionSolverAlgorithm::AssembleMomentumElemWallFunctio
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleMomentumNonConformalSolverAlgorithm.C
+++ b/src/AssembleMomentumNonConformalSolverAlgorithm.C
@@ -55,9 +55,9 @@ AssembleMomentumNonConformalSolverAlgorithm::AssembleMomentumNonConformalSolverA
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");  
-  ncMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "nc_mass_flow_rate");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  ncMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "nc_mass_flow_rate");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(&(velocity_->field_of_state(stk::mesh::StateNP1)));

--- a/src/AssembleNodalGradAlgorithmDriver.C
+++ b/src/AssembleNodalGradAlgorithmDriver.C
@@ -70,7 +70,7 @@ AssembleNodalGradAlgorithmDriver::pre_work()
   const int nDim = metaData.spatial_dimension();
 
   // extract fields
-  VectorFieldType *dqdx = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, dqdxName_);
+  VectorFieldType *dqdx = metaData.get_field<double>(stk::topology::NODE_RANK, dqdxName_);
 
   // define some common selectors; select all nodes (locally and shared)
   // where dqdx is defined
@@ -100,7 +100,7 @@ AssembleNodalGradAlgorithmDriver::pre_work()
   }
 
   if ( areaWeight_ ) {
-    VectorFieldType *areaWeight = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, areaWeightName_);
+    VectorFieldType *areaWeight = metaData.get_field<double>(stk::topology::NODE_RANK, areaWeightName_);
     field_fill( metaData, bulkData, 0.0, *areaWeight, realm_.get_activate_aura());
   }
 }
@@ -117,7 +117,7 @@ AssembleNodalGradAlgorithmDriver::post_work()
   const unsigned nDim = meta_data.spatial_dimension();
 
   // extract fields
-  VectorFieldType *dqdx = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, dqdxName_);
+  VectorFieldType *dqdx = meta_data.get_field<double>(stk::topology::NODE_RANK, dqdxName_);
   std::vector<const stk::mesh::FieldBase*> sum_fields(1, dqdx);
   stk::mesh::parallel_sum(bulk_data, sum_fields);
 
@@ -127,7 +127,7 @@ AssembleNodalGradAlgorithmDriver::post_work()
 
   // allow for area weighting
   if ( areaWeight_ ) {
-    VectorFieldType *areaWeight = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, areaWeightName_);
+    VectorFieldType *areaWeight = meta_data.get_field<double>(stk::topology::NODE_RANK, areaWeightName_);
     std::vector<const stk::mesh::FieldBase*> sum_area(1, areaWeight);
     stk::mesh::parallel_sum(bulk_data, sum_area);
     if ( realm_.hasPeriodic_) {
@@ -154,8 +154,8 @@ AssembleNodalGradAlgorithmDriver::normalize_by_area()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  VectorFieldType *dqdx = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, dqdxName_);
-  VectorFieldType *areaWeight = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, areaWeightName_);
+  VectorFieldType *dqdx = meta_data.get_field<double>(stk::topology::NODE_RANK, dqdxName_);
+  VectorFieldType *areaWeight = meta_data.get_field<double>(stk::topology::NODE_RANK, areaWeightName_);
 
   // define some common selectors; select all nodes (locally and shared)
   // where dqdx is defined

--- a/src/AssembleNodalGradBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradBoundaryAlgorithm.C
@@ -60,8 +60,8 @@ AssembleNodalGradBoundaryAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // nodal fields to gather; gather everything other than what we are assembling
   std::vector<double> ws_scalarQ;

--- a/src/AssembleNodalGradEdgeAlgorithm.C
+++ b/src/AssembleNodalGradEdgeAlgorithm.C
@@ -44,8 +44,8 @@ AssembleNodalGradEdgeAlgorithm::AssembleNodalGradEdgeAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleNodalGradElemAlgorithm.C
+++ b/src/AssembleNodalGradElemAlgorithm.C
@@ -163,8 +163,8 @@ AssembleNodalGradElemAlgorithm::AssembleNodalGradElemAlgorithm(
   // extract fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleNodalGradNonConformalAlgorithm.C
+++ b/src/AssembleNodalGradNonConformalAlgorithm.C
@@ -50,8 +50,8 @@ AssembleNodalGradNonConformalAlgorithm::AssembleNodalGradNonConformalAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(scalarQ_);

--- a/src/AssembleNodalGradPAWBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradPAWBoundaryAlgorithm.C
@@ -57,13 +57,13 @@ AssembleNodalGradPAWBoundaryAlgorithm::AssembleNodalGradPAWBoundaryAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & metaData = realm_.meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  interfaceCurvature_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  bcPressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, bcPressureName);
-  areaWeight_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "png_area_weight");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  interfaceCurvature_ = metaData.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = metaData.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = metaData.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  bcPressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, bcPressureName);
+  areaWeight_ = metaData.get_field<double>(stk::topology::NODE_RANK, "png_area_weight");
   gravity_ = realm_.solutionOptions_->gravity_;
 
   NaluEnv::self().naluOutputP0() << "AssembleNodalGradPAWBoundaryAlgorithm Active" << std::endl;
@@ -81,7 +81,7 @@ AssembleNodalGradPAWBoundaryAlgorithm::execute()
   const int nDim = metaData.spatial_dimension();
 
   // extract fields
-  GenericFieldType *exposedAreaVec = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  GenericFieldType *exposedAreaVec = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
 
   // ip values; fixed size
   std::vector<double> dpdxBip(nDim);

--- a/src/AssembleNodalGradPAWElemAlgorithm.C
+++ b/src/AssembleNodalGradPAWElemAlgorithm.C
@@ -52,11 +52,11 @@ AssembleNodalGradPAWElemAlgorithm::AssembleNodalGradPAWElemAlgorithm(
 {
   // extract fields; nodal
   stk::mesh::MetaData & metaData = realm_.meta_data();
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  interfaceCurvature_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  areaWeight_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "png_area_weight");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  interfaceCurvature_ = metaData.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = metaData.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = metaData.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  areaWeight_ = metaData.get_field<double>(stk::topology::NODE_RANK, "png_area_weight");
   gravity_ = realm_.solutionOptions_->gravity_;
 }
 
@@ -72,7 +72,7 @@ AssembleNodalGradPAWElemAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // nodal fields to gather; gather everything other than what we are assembling
   std::vector<double> ws_pressure;

--- a/src/AssembleNodalGradPBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradPBoundaryAlgorithm.C
@@ -61,9 +61,9 @@ AssembleNodalGradPBoundaryAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  GenericFieldType *dynamicPressure = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  GenericFieldType *dynamicPressure = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // nodal fields to gather; gather everything other than what we are assembling
   std::vector<double> ws_pressure;

--- a/src/AssembleNodalGradUAlgorithmDriver.C
+++ b/src/AssembleNodalGradUAlgorithmDriver.C
@@ -53,7 +53,7 @@ AssembleNodalGradUAlgorithmDriver::pre_work()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  GenericFieldType *dudx = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, dudxName_);
+  GenericFieldType *dudx = meta_data.get_field<double>(stk::topology::NODE_RANK, dudxName_);
 
   // define some common selectors; select all nodes (locally and shared)
   // where dudx is defined
@@ -95,7 +95,7 @@ AssembleNodalGradUAlgorithmDriver::post_work()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // extract fields
-  GenericFieldType *dudx = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, dudxName_);
+  GenericFieldType *dudx = meta_data.get_field<double>(stk::topology::NODE_RANK, dudxName_);
   stk::mesh::parallel_sum(bulk_data, {dudx});
 
   if ( realm_.hasPeriodic_) {

--- a/src/AssembleNodalGradUBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradUBoundaryAlgorithm.C
@@ -60,8 +60,8 @@ AssembleNodalGradUBoundaryAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // nodal fields to gather; gather everything other than what we are assembling
   std::vector<double> ws_vectorQ;

--- a/src/AssembleNodalGradUEdgeAlgorithm.C
+++ b/src/AssembleNodalGradUEdgeAlgorithm.C
@@ -41,8 +41,8 @@ AssembleNodalGradUEdgeAlgorithm::AssembleNodalGradUEdgeAlgorithm(
 {
   // extract fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleNodalGradUElemAlgorithm.C
+++ b/src/AssembleNodalGradUElemAlgorithm.C
@@ -59,8 +59,8 @@ AssembleNodalGradUElemAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // nodal fields to gather; gather everything other than what we are assembling
   std::vector<double> ws_vectorQ;

--- a/src/AssembleNodalGradUNonConformalAlgorithm.C
+++ b/src/AssembleNodalGradUNonConformalAlgorithm.C
@@ -50,8 +50,8 @@ AssembleNodalGradUNonConformalAlgorithm::AssembleNodalGradUNonConformalAlgorithm
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(vectorQ_);

--- a/src/AssemblePNGBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGBoundarySolverAlgorithm.C
@@ -46,8 +46,8 @@ AssemblePNGBoundarySolverAlgorithm::AssemblePNGBoundarySolverAlgorithm(
 {
   // save off fields 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarQ_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, independentDofName);
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  scalarQ_ = meta_data.get_field<double>(stk::topology::NODE_RANK, independentDofName);
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssemblePNGElemSolverAlgorithm.C
+++ b/src/AssemblePNGElemSolverAlgorithm.C
@@ -47,9 +47,9 @@ AssemblePNGElemSolverAlgorithm::AssemblePNGElemSolverAlgorithm(
 {
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarQ_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, independentDofName);
-  dqdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, dofName);
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  scalarQ_ = meta_data.get_field<double>(stk::topology::NODE_RANK, independentDofName);
+  dqdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, dofName);
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssemblePNGNonConformalSolverAlgorithm.C
+++ b/src/AssemblePNGNonConformalSolverAlgorithm.C
@@ -52,10 +52,10 @@ AssemblePNGNonConformalSolverAlgorithm::AssemblePNGNonConformalSolverAlgorithm(
 {
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarQ_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, independentDofName);
-  Gjq_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, dofName);
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  scalarQ_ = meta_data.get_field<double>(stk::topology::NODE_RANK, independentDofName);
+  Gjq_ = meta_data.get_field<double>(stk::topology::NODE_RANK, dofName);
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(scalarQ_);

--- a/src/AssemblePNGPressureBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGPressureBoundarySolverAlgorithm.C
@@ -48,9 +48,9 @@ AssemblePNGPressureBoundarySolverAlgorithm::AssemblePNGPressureBoundarySolverAlg
 {
   // save off fields 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarQ_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, independentDofName);
-  dynamicP_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  scalarQ_ = meta_data.get_field<double>(stk::topology::NODE_RANK, independentDofName);
+  dynamicP_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleScalarDiffNonConformalSolverAlgorithm.C
+++ b/src/AssembleScalarDiffNonConformalSolverAlgorithm.C
@@ -55,8 +55,8 @@ AssembleScalarDiffNonConformalSolverAlgorithm::AssembleScalarDiffNonConformalSol
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");  
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
  
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(&(scalarQ_->field_of_state(stk::mesh::StateNP1)));

--- a/src/AssembleScalarEdgeDiffSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeDiffSolverAlgorithm.C
@@ -46,8 +46,8 @@ AssembleScalarEdgeDiffSolverAlgorithm::AssembleScalarEdgeDiffSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 }
 
 void

--- a/src/AssembleScalarEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeOpenSolverAlgorithm.C
@@ -52,8 +52,8 @@ AssembleScalarEdgeOpenSolverAlgorithm::AssembleScalarEdgeOpenSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleScalarEdgeSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeSolverAlgorithm.C
@@ -55,13 +55,13 @@ AssembleScalarEdgeSolverAlgorithm::AssembleScalarEdgeSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = meta_data.get_field<ScalarFieldType>(stk::topology::EDGE_RANK, "mass_flow_rate");
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "mass_flow_rate");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(scalarQ_->name());

--- a/src/AssembleScalarEigenEdgeSolverAlgorithm.C
+++ b/src/AssembleScalarEigenEdgeSolverAlgorithm.C
@@ -71,18 +71,18 @@ AssembleScalarEigenEdgeSolverAlgorithm::AssembleScalarEigenEdgeSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = meta_data.get_field<ScalarFieldType>(stk::topology::EDGE_RANK, "mass_flow_rate");
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "mass_flow_rate");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 
   // EXTRA GGDH
-  turbKe_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
+  turbKe_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(scalarQ_->name());

--- a/src/AssembleScalarElemDiffSolverAlgorithm.C
+++ b/src/AssembleScalarElemDiffSolverAlgorithm.C
@@ -51,7 +51,7 @@ AssembleScalarElemDiffSolverAlgorithm::AssembleScalarElemDiffSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleScalarElemOpenSolverAlgorithm.C
+++ b/src/AssembleScalarElemOpenSolverAlgorithm.C
@@ -58,12 +58,12 @@ AssembleScalarElemOpenSolverAlgorithm::AssembleScalarElemOpenSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(scalarQ_->name());

--- a/src/AssembleScalarElemSolverAlgorithm.C
+++ b/src/AssembleScalarElemSolverAlgorithm.C
@@ -57,12 +57,12 @@ AssembleScalarElemSolverAlgorithm::AssembleScalarElemSolverAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-     velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+     velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
    else
-     velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+     velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   // create the peclet blending function
   pecletFunction_ = eqSystem->create_peclet_function<double>(scalarQ_->name());

--- a/src/AssembleScalarFluxBCSolverAlgorithm.C
+++ b/src/AssembleScalarFluxBCSolverAlgorithm.C
@@ -46,7 +46,7 @@ AssembleScalarFluxBCSolverAlgorithm::AssembleScalarFluxBCSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleScalarNonConformalSolverAlgorithm.C
+++ b/src/AssembleScalarNonConformalSolverAlgorithm.C
@@ -55,9 +55,9 @@ AssembleScalarNonConformalSolverAlgorithm::AssembleScalarNonConformalSolverAlgor
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");  
-  ncMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "nc_mass_flow_rate");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  ncMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "nc_mass_flow_rate");
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(&(scalarQ_->field_of_state(stk::mesh::StateNP1)));

--- a/src/AssembleTemperatureNormalGradientBCSolverAlgorithm.C
+++ b/src/AssembleTemperatureNormalGradientBCSolverAlgorithm.C
@@ -53,7 +53,7 @@ AssembleTemperatureNormalGradientBCSolverAlgorithm::AssembleTemperatureNormalGra
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleWallHeatTransferAlgorithmDriver.C
+++ b/src/AssembleWallHeatTransferAlgorithmDriver.C
@@ -46,12 +46,12 @@ AssembleWallHeatTransferAlgorithmDriver::AssembleWallHeatTransferAlgorithmDriver
 {
   // register the fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
-  referenceTemperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "reference_temperature");
-  heatTransferCoefficient_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
-  normalHeatFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "normal_heat_flux");
-  robinCouplingParameter_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "robin_coupling_parameter");
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
+  referenceTemperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "reference_temperature");
+  heatTransferCoefficient_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
+  normalHeatFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "normal_heat_flux");
+  robinCouplingParameter_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "robin_coupling_parameter");
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
 }
 
 //--------------------------------------------------------------------------

--- a/src/AuxFunctionAlgorithm.C
+++ b/src/AuxFunctionAlgorithm.C
@@ -54,7 +54,7 @@ AuxFunctionAlgorithm::execute()
 
   const unsigned nDim = meta_data.spatial_dimension();
   const double time = realm_.get_current_time();
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   auxFunction_->setup(time);
 

--- a/src/ComputeDynamicPressureAlgorithm.C
+++ b/src/ComputeDynamicPressureAlgorithm.C
@@ -47,10 +47,10 @@ ComputeDynamicPressureAlgorithm::ComputeDynamicPressureAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeGeometryAlgorithmDriver.C
+++ b/src/ComputeGeometryAlgorithmDriver.C
@@ -55,7 +55,7 @@ ComputeGeometryAlgorithmDriver::pre_work()
   const int nDim = meta_data.spatial_dimension();
 
   // extract field that is always germane
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // define some common selectors
   stk::mesh::Selector s_locally_owned = meta_data.locally_owned_part();
@@ -83,7 +83,7 @@ ComputeGeometryAlgorithmDriver::pre_work()
   // handle case for realm using edge-based
   if ( realm_.realmUsesEdges_ ) {
 
-    VectorFieldType *edgeAreaVec = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    VectorFieldType *edgeAreaVec = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 
     // edge fields second
     stk::mesh::Selector s_all_area
@@ -118,11 +118,11 @@ ComputeGeometryAlgorithmDriver::post_work()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // extract field always germane
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // handle case for realm using edge-based
   if ( realm_.realmUsesEdges_ ) {
-    VectorFieldType *edgeAreaVec = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    VectorFieldType *edgeAreaVec = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
     stk::mesh::parallel_sum(bulk_data, {dualNodalVolume, edgeAreaVec});
   }
   else {
@@ -157,7 +157,7 @@ ComputeGeometryAlgorithmDriver::check_jacobians()
 
   // fields and future ws 
   VectorFieldType *coordinates 
-    = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   std::vector<double> ws_coordinates;
   std::vector<double> ws_scv_volume;

--- a/src/ComputeGeometryBoundaryAlgorithm.C
+++ b/src/ComputeGeometryBoundaryAlgorithm.C
@@ -52,8 +52,8 @@ ComputeGeometryBoundaryAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // setup for buckets; union parts and ask for locally owned
   stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()

--- a/src/ComputeGeometryInteriorAlgorithm.C
+++ b/src/ComputeGeometryInteriorAlgorithm.C
@@ -61,8 +61,8 @@ ComputeGeometryInteriorAlgorithm::execute()
   const int nDim = meta_data.spatial_dimension();
 
   // extract field always germane
-  ScalarFieldType *dualNodalVolume = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  ScalarFieldType *dualNodalVolume = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // setup for buckets; union parts and ask for locally owned
   stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part()
@@ -133,7 +133,7 @@ ComputeGeometryInteriorAlgorithm::execute()
   //===========================================================
   if ( assembleEdgeAreaVec_ ) {
 
-    VectorFieldType *edgeAreaVec = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+    VectorFieldType *edgeAreaVec = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 
     for ( stk::mesh::BucketVector::const_iterator ib = element_buckets.begin();
           ib != element_buckets.end() ; ++ib ) {

--- a/src/ComputeHeatTransferEdgeWallAlgorithm.C
+++ b/src/ComputeHeatTransferEdgeWallAlgorithm.C
@@ -55,18 +55,18 @@ ComputeHeatTransferEdgeWallAlgorithm::ComputeHeatTransferEdgeWallAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  temperature_= meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
-  dhdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dhdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  thermalCond_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "thermal_conductivity");
-  specificHeat_= meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
-  referenceTemperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "reference_temperature");
-  heatTransferCoefficient_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
-  normalHeatFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "normal_heat_flux");
-  robinCouplingParameter_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "robin_coupling_parameter");
+  temperature_= meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
+  dhdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dhdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  thermalCond_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "thermal_conductivity");
+  specificHeat_= meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
+  referenceTemperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "reference_temperature");
+  heatTransferCoefficient_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
+  normalHeatFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "normal_heat_flux");
+  robinCouplingParameter_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "robin_coupling_parameter");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeHeatTransferElemWallAlgorithm.C
+++ b/src/ComputeHeatTransferElemWallAlgorithm.C
@@ -54,17 +54,17 @@ ComputeHeatTransferElemWallAlgorithm::ComputeHeatTransferElemWallAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  thermalCond_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "thermal_conductivity");
-  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
-  referenceTemperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "reference_temperature");
-  heatTransferCoefficient_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
-  normalHeatFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "normal_heat_flux");
-  robinCouplingParameter_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "robin_coupling_parameter");
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  thermalCond_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "thermal_conductivity");
+  specificHeat_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_ht");
+  referenceTemperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "reference_temperature");
+  heatTransferCoefficient_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "heat_transfer_coefficient");
+  normalHeatFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "normal_heat_flux");
+  robinCouplingParameter_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "robin_coupling_parameter");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeLowReynoldsSDRWallAlgorithm.C
+++ b/src/ComputeLowReynoldsSDRWallAlgorithm.C
@@ -50,12 +50,12 @@ ComputeLowReynoldsSDRWallAlgorithm::ComputeLowReynoldsSDRWallAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  sdrBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_sdr_bc");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_sdr");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  sdrBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_model_sdr_bc");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_sdr");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotAlgorithmDriver.C
+++ b/src/ComputeMdotAlgorithmDriver.C
@@ -167,13 +167,13 @@ ComputeMdotAlgorithmDriver::compute_accumulation()
   const double gamma3 = realm_.get_gamma3(); // gamma3 may be zero
 
   // extract fields
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
+  ScalarFieldType *density = metaData.get_field<double>(
     stk::topology::NODE_RANK, "density");
   ScalarFieldType &densityNp1 = density->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType &densityN = density->field_of_state(stk::mesh::StateN);
   ScalarFieldType &densityNm1 = (density->number_of_states() == 2) 
     ? density->field_of_state(stk::mesh::StateN) : density->field_of_state(stk::mesh::StateNM1);
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts_.get_coordinates_name());
 
   //  required space

--- a/src/ComputeMdotEdgeAlgorithm.C
+++ b/src/ComputeMdotEdgeAlgorithm.C
@@ -50,15 +50,15 @@ ComputeMdotEdgeAlgorithm::ComputeMdotEdgeAlgorithm(
   // save off field
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  massFlowRate_ = meta_data.get_field<ScalarFieldType>(stk::topology::EDGE_RANK, "mass_flow_rate");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "mass_flow_rate");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotEdgeOpenAlgorithm.C
+++ b/src/ComputeMdotEdgeOpenAlgorithm.C
@@ -52,17 +52,17 @@ ComputeMdotEdgeOpenAlgorithm::ComputeMdotEdgeOpenAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  pressureBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotElemAlgorithm.C
+++ b/src/ComputeMdotElemAlgorithm.C
@@ -54,20 +54,20 @@ ComputeMdotElemAlgorithm::ComputeMdotElemAlgorithm(
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   if ( assembleMdotToEdge_ ) {
     // check to make sure edges are active
     if (!realm_.realmUsesEdges_ )
       throw std::runtime_error("Edges need to be activated for mixed edge/scalar; element/cont");
-    edgeMassFlowRate_ = meta_data.get_field<ScalarFieldType>(stk::topology::EDGE_RANK, "mass_flow_rate");
+    edgeMassFlowRate_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "mass_flow_rate");
   }
 }
 

--- a/src/ComputeMdotElemOpenAlgorithm.C
+++ b/src/ComputeMdotElemOpenAlgorithm.C
@@ -53,17 +53,17 @@ ComputeMdotElemOpenAlgorithm::ComputeMdotElemOpenAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( realm_.does_mesh_move() )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  pressureBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotInflowAlgorithm.C
+++ b/src/ComputeMdotInflowAlgorithm.C
@@ -44,10 +44,10 @@ ComputeMdotInflowAlgorithm::ComputeMdotInflowAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  velocityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
   // variable density will need density as a function of user inflow conditions
-  densityBC_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  densityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeMdotNonConformalAlgorithm.C
+++ b/src/ComputeMdotNonConformalAlgorithm.C
@@ -57,20 +57,20 @@ ComputeMdotNonConformalAlgorithm::ComputeMdotNonConformalAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   if ( meshMotion_ ) {
     meshMotionFac_ = 1.0;
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
     meshMotionFac_ = 0.0;
-    meshVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    meshVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   }
 
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  ncMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "nc_mass_flow_rate");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  ncMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "nc_mass_flow_rate");
   
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(pressure_);

--- a/src/ComputeMdotVofElemAlgorithm.C
+++ b/src/ComputeMdotVofElemAlgorithm.C
@@ -58,18 +58,18 @@ ComputeMdotVofElemAlgorithm::ComputeMdotVofElemAlgorithm(
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  interfaceCurvature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  massFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
-  volumeFlowRate_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "volume_flow_rate_scs");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  interfaceCurvature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  massFlowRate_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  volumeFlowRate_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "volume_flow_rate_scs");
   gravity_ = realm_.solutionOptions_->gravity_;
 }
 

--- a/src/ComputeMdotVofElemOpenAlgorithm.C
+++ b/src/ComputeMdotVofElemOpenAlgorithm.C
@@ -58,21 +58,21 @@ ComputeMdotVofElemOpenAlgorithm::ComputeMdotVofElemOpenAlgorithm(
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( solnOpts.does_mesh_move() )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  interfaceCurvature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "dynamic_pressure");
-  openMassFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_mass_flow_rate");
-  openVolumeFlowRate_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "open_volume_flow_rate");
-  pressureBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  interfaceCurvature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = meta_data.get_field<double>(meta_data.side_rank(), "dynamic_pressure");
+  openMassFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_mass_flow_rate");
+  openVolumeFlowRate_ = meta_data.get_field<double>(meta_data.side_rank(), "open_volume_flow_rate");
+  pressureBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
   gravity_ = realm_.solutionOptions_->gravity_;
 }
 

--- a/src/ComputeMdotVofInflowAlgorithm.C
+++ b/src/ComputeMdotVofInflowAlgorithm.C
@@ -44,10 +44,10 @@ ComputeMdotVofInflowAlgorithm::ComputeMdotVofInflowAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocityBC_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  velocityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
   // variable density will need density as a function of user inflow conditions
-  densityBC_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  densityBC_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -46,8 +46,8 @@ ComputeSSTMaxLengthScaleElemAlgorithm::ComputeSSTMaxLengthScaleElemAlgorithm(
 {
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  maxLengthScale_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_max_length_scale");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  maxLengthScale_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_max_length_scale");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
+++ b/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
@@ -44,12 +44,12 @@ ComputeTurbKineticEnergyWallFunctionAlgorithm::ComputeTurbKineticEnergyWallFunct
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  turbKineticEnergy_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  bcTurbKineticEnergy_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tke_bc");
-  bcAssembledTurbKineticEnergy_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_tke_bc");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  turbKineticEnergy_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  bcTurbKineticEnergy_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "tke_bc");
+  bcAssembledTurbKineticEnergy_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_model_tke_bc");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityAlgorithm.C
@@ -52,16 +52,16 @@ ComputeWallFrictionVelocityAlgorithm::ComputeWallFrictionVelocityAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
-  assembledWallNormalDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
+  assembledWallNormalDistance_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeWallFrictionVelocityProjectedAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityProjectedAlgorithm.C
@@ -88,16 +88,16 @@ ComputeWallFrictionVelocityProjectedAlgorithm::ComputeWallFrictionVelocityProjec
     needToGhostCount_(0)
 {
   // save off fields
-  velocity_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  bcVelocity_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  coordinates_ = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = metaData_->get_field<GenericFieldType>(metaData_->side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = metaData_->get_field<GenericFieldType>(metaData_->side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = metaData_->get_field<GenericFieldType>(metaData_->side_rank(), "wall_normal_distance_bip");
-  assembledWallArea_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
-  assembledWallNormalDistance_ = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+  velocity_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "velocity");
+  bcVelocity_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  coordinates_ = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = metaData_->get_field<double>(metaData_->side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = metaData_->get_field<double>(metaData_->side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = metaData_->get_field<double>(metaData_->side_rank(), "wall_normal_distance_bip");
+  assembledWallArea_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
+  assembledWallNormalDistance_ = metaData_->get_field<double>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
   
   // set data
   set_data(projectedDistance);
@@ -483,7 +483,7 @@ ComputeWallFrictionVelocityProjectedAlgorithm::construct_bounding_points()
 
   // field extraction
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   // nodal fields to gather
   std::vector<double> ws_coordinates;
@@ -617,7 +617,7 @@ ComputeWallFrictionVelocityProjectedAlgorithm::construct_bounding_boxes()
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   // setup data structures for search
   Point minCorner, maxCorner;
@@ -774,7 +774,7 @@ ComputeWallFrictionVelocityProjectedAlgorithm::manage_ghosting()
   // ensure that the coordinates for the ghosted elements (required for the fine search) are up-to-date
   if (g_needToGhostCount > 0 ) {
     VectorFieldType *coordinates 
-      = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+      = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
     std::vector<const stk::mesh::FieldBase*> fieldVec = {coordinates};
     stk::mesh::communicate_field_data(*wallFunctionGhosting_, fieldVec);
   }
@@ -787,7 +787,7 @@ void
 ComputeWallFrictionVelocityProjectedAlgorithm::complete_search()
 {
   // fields
-  VectorFieldType *coordinates = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // coordinates
   std::vector<double> isoParCoords(nDim_);

--- a/src/ComputeWallModelSDRWallAlgorithm.C
+++ b/src/ComputeWallModelSDRWallAlgorithm.C
@@ -50,11 +50,11 @@ ComputeWallModelSDRWallAlgorithm::ComputeWallModelSDRWallAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  sdrBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_sdr_bc");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_sdr");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  sdrBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_model_sdr_bc");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_sdr");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ComputeWallModelTurbDissipationWallAlgorithm.C
+++ b/src/ComputeWallModelTurbDissipationWallAlgorithm.C
@@ -48,11 +48,11 @@ ComputeWallModelTurbDissipationWallAlgorithm::ComputeWallModelTurbDissipationWal
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
-  epsBc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_eps_bc");
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_eps");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
+  epsBc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_model_eps_bc");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_eps");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ContinuityGclNodeSuppAlg.C
+++ b/src/ContinuityGclNodeSuppAlg.C
@@ -40,10 +40,10 @@ ContinuityGclNodeSuppAlg::ContinuityGclNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  divV_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ContinuityLowSpeedCompressibleNodeSuppAlg.C
+++ b/src/ContinuityLowSpeedCompressibleNodeSuppAlg.C
@@ -40,10 +40,10 @@ ContinuityLowSpeedCompressibleNodeSuppAlg::ContinuityLowSpeedCompressibleNodeSup
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ContinuityMassBDF2NodeSuppAlg.C
+++ b/src/ContinuityMassBDF2NodeSuppAlg.C
@@ -42,11 +42,11 @@ ContinuityMassBDF2NodeSuppAlg::ContinuityMassBDF2NodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ContinuityMassBackwardEulerNodeSuppAlg.C
+++ b/src/ContinuityMassBackwardEulerNodeSuppAlg.C
@@ -39,10 +39,10 @@ ContinuityMassBackwardEulerNodeSuppAlg::ContinuityMassBackwardEulerNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -497,8 +497,9 @@ DataProbePostProcessing::setup()
         stk::mesh::Part *probePart = probeInfo->part_[p];
         // everyone needs coordinates to be registered
         VectorFieldType *coordinates 
-          =  &(metaData.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
+          =  &(metaData.declare_field<double>(stk::topology::NODE_RANK, "coordinates"));
         stk::mesh::put_field_on_mesh(*coordinates, *probePart, nDim, nullptr);
+        stk::io::set_field_output_type(*coordinates, stk::io::FieldOutputType::VECTOR_3D);
         // now the general set of fields for this probe
         for ( size_t j = 0; j < probeSpec->fieldInfo_.size(); ++j ) 
           register_field(probeSpec->fieldInfo_[j].first, probeSpec->fieldInfo_[j].second, metaData, probePart);
@@ -604,7 +605,7 @@ DataProbePostProcessing::initialize()
   
   // populate values for coord; probe stays the same place
   // FIXME: worry about mesh motion (if the probe moves around?)
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");
+  VectorFieldType *coordinates = metaData.get_field<double>(stk::topology::NODE_RANK, "coordinates");
 
   const int nDim = metaData.spatial_dimension();
   for ( size_t idps = 0; idps < dataProbeSpecInfo_.size(); ++idps ) {
@@ -765,12 +766,13 @@ DataProbePostProcessing::register_field(
 {
   // check for velocity as this is the only current vector supported
   if ( fieldName.find("velocity") != std::string::npos ) { //FIXME: require FieldType as in InputOutpu and TurbAverga
-    VectorFieldType *someVelocity = &(metaData.declare_field<VectorFieldType>(stk::topology::NODE_RANK, fieldName));
+    VectorFieldType *someVelocity = &(metaData.declare_field<double>(stk::topology::NODE_RANK, fieldName));
     stk::mesh::put_field_on_mesh(*someVelocity, *part, fieldSize, nullptr);
+    stk::io::set_field_output_type(*someVelocity, stk::io::FieldOutputType::VECTOR_3D);
   }
   else {
-    stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *toField 
-      = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
+    stk::mesh::Field<double> *toField
+      = &(metaData.declare_field<double>(stk::topology::NODE_RANK, fieldName));
     stk::mesh::put_field_on_mesh(*toField, *part, fieldSize, nullptr);
   }
 }
@@ -873,7 +875,7 @@ DataProbePostProcessing::provide_output(
   stk::mesh::MetaData &metaData = realm_.meta_data();
   stk::mesh::BulkData &bulkData = realm_.bulk_data();
   VectorFieldType *coordinates 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "coordinates");
   
   const int nDim = metaData.spatial_dimension();
  

--- a/src/EffectiveSSTDiffFluxCoeffAlgorithm.C
+++ b/src/EffectiveSSTDiffFluxCoeffAlgorithm.C
@@ -48,7 +48,7 @@ EffectiveSSTDiffFluxCoeffAlgorithm::EffectiveSSTDiffFluxCoeffAlgorithm(
 {
   // extract blending nodal variable
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  fOneBlend_= meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_f_one_blending");
+  fOneBlend_= meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending");
 }
 
 //--------------------------------------------------------------------------

--- a/src/EnthalpyLowSpeedCompressibleNodeSuppAlg.C
+++ b/src/EnthalpyLowSpeedCompressibleNodeSuppAlg.C
@@ -39,9 +39,9 @@ EnthalpyLowSpeedCompressibleNodeSuppAlg::EnthalpyLowSpeedCompressibleNodeSuppAlg
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  pressureN_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_old");
-  pressureNp1_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  pressureN_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_old");
+  pressureNp1_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/EnthalpyPmrSrcNodeSuppAlg.C
+++ b/src/EnthalpyPmrSrcNodeSuppAlg.C
@@ -38,10 +38,10 @@ EnthalpyPmrSrcNodeSuppAlg::EnthalpyPmrSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  divRadFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux");
-  divRadFluxLin_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin");
-  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  divRadFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux");
+  divRadFluxLin_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin");
+  specificHeat_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/EnthalpyPressureWorkNodeSuppAlg.C
+++ b/src/EnthalpyPressureWorkNodeSuppAlg.C
@@ -39,9 +39,9 @@ EnthalpyPressureWorkNodeSuppAlg::EnthalpyPressureWorkNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/EnthalpyViscousWorkNodeSuppAlg.C
+++ b/src/EnthalpyViscousWorkNodeSuppAlg.C
@@ -40,10 +40,10 @@ EnthalpyViscousWorkNodeSuppAlg::EnthalpyViscousWorkNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
   const std::string viscName = realm.is_turbulent() ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/FixPressureAtNodeAlgorithm.C
+++ b/src/FixPressureAtNodeAlgorithm.C
@@ -34,9 +34,9 @@ FixPressureAtNodeAlgorithm::FixPressureAtNodeAlgorithm(
 {
   auto& meta = realm_.meta_data();
 
-  coordinates_ = meta.get_field<VectorFieldType>(
+  coordinates_ = meta.get_field<double>(
     stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta.get_field<ScalarFieldType>(
+  pressure_ = meta.get_field<double>(
     stk::topology::NODE_RANK, "pressure");
 }
 

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -208,31 +208,33 @@ HeatCondEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  temperature_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature", numStates));
+  temperature_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature", numStates));
   stk::mesh::put_field_on_mesh(*temperature_, *part, nullptr);
   realm_.augment_restart_variable_list("temperature");
 
-  dtdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dtdx"));
+  dtdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dtdx"));
   stk::mesh::put_field_on_mesh(*dtdx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dtdx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver
-  tTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tTmp"));
+  tTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "tTmp"));
   stk::mesh::put_field_on_mesh(*tTmp_, *part, nullptr);
 
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume"));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
 
-  coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
+  coordinates_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*coordinates_, stk::io::FieldOutputType::VECTOR_3D);
 
   // props
-  density_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density"));
+  density_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "density"));
   stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
 
-  specHeat_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat"));
+  specHeat_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "specific_heat"));
   stk::mesh::put_field_on_mesh(*specHeat_, *part, nullptr);
 
-  thermalCond_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "thermal_conductivity"));
+  thermalCond_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "thermal_conductivity"));
   stk::mesh::put_field_on_mesh(*thermalCond_, *part, nullptr);
 
   // push to property list
@@ -242,9 +244,9 @@ HeatCondEquationSystem::register_nodal_fields(
 
   // register divergence of radiative heat flux and linearization (controled by transfer)
   if ( pmrCouplingActive_ ) {
-    ScalarFieldType *divQ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux"));
+    ScalarFieldType *divQ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux"));
     stk::mesh::put_field_on_mesh(*divQ, *part, nullptr);
-    ScalarFieldType *divQLin = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin"));
+    ScalarFieldType *divQLin = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin"));
     stk::mesh::put_field_on_mesh(*divQLin, *part, nullptr);
   }
 
@@ -265,7 +267,7 @@ HeatCondEquationSystem::register_nodal_fields(
   // register the fringe nodal field 
   if ( realm_.query_for_overset() && realm_.has_mesh_motion() ) {
     ScalarFieldType *fringeNode
-      = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "fringe_node"));
+      = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "fringe_node"));
     stk::mesh::put_field_on_mesh(*fringeNode, *part, nullptr);
   }
 }
@@ -285,8 +287,9 @@ HeatCondEquationSystem::register_edge_fields(
   //====================================================
   if ( realm_.realmUsesEdges_ ) {
     const int nDim = meta_data.spatial_dimension();
-    edgeAreaVec_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector"));
+    edgeAreaVec_ = &(meta_data.declare_field<double>(stk::topology::EDGE_RANK, "edge_area_vector"));
     stk::mesh::put_field_on_mesh(*edgeAreaVec_, *part, nDim, nullptr);
+    stk::io::set_field_output_type(*edgeAreaVec_, stk::io::FieldOutputType::VECTOR_3D);
   }
 
 }
@@ -304,7 +307,7 @@ HeatCondEquationSystem::register_element_fields(
   // deal with heat conduction error indicator; elemental field of size unity
   if ( realm_.solutionOptions_->errorIndicatorActive_ ) {
     const int numIp = 1;
-    GenericFieldType *pstabEI= &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator"));
+    GenericFieldType *pstabEI= &(meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, "error_indicator"));
     stk::mesh::put_field_on_mesh(*pstabEI, *part, numIp, nullptr);
   }
   
@@ -312,7 +315,7 @@ HeatCondEquationSystem::register_element_fields(
   if ( realm_.query_for_overset() ) {
     const int sizeOfElemField = 1;
     GenericFieldType *intersectedElement
-      = &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "intersected_element"));
+      = &(meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, "intersected_element"));
     stk::mesh::put_field_on_mesh(*intersectedElement, *part, sizeOfElemField, nullptr);
   }
 }
@@ -575,7 +578,7 @@ HeatCondEquationSystem::register_wall_bc(
   if ( userData.tempSpec_ ||  FUNCTION_UD == theDataType ) {
  
     // register boundary data; temperature_bc
-    ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature_bc"));
+    ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature_bc"));
     stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
     AuxFunction *theAuxFunc = NULL;
@@ -628,15 +631,15 @@ HeatCondEquationSystem::register_wall_bc(
     // check for post processing
     if ( userData.ppHeatFlux_ ) {
       // register the fields
-      ScalarFieldType *assembledWallArea =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_ht"));
+      ScalarFieldType *assembledWallArea =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_ht"));
       stk::mesh::put_field_on_mesh(*assembledWallArea, *part, nullptr);
-      ScalarFieldType *referenceTemperature =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "reference_temperature"));
+      ScalarFieldType *referenceTemperature =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "reference_temperature"));
       stk::mesh::put_field_on_mesh(*referenceTemperature, *part, nullptr);
-      ScalarFieldType *heatTransferCoeff =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_transfer_coefficient"));
+      ScalarFieldType *heatTransferCoeff =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "heat_transfer_coefficient"));
       stk::mesh::put_field_on_mesh(*heatTransferCoeff, *part, nullptr);
-      ScalarFieldType *normalHeatFlux = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "normal_heat_flux"));
+      ScalarFieldType *normalHeatFlux = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "normal_heat_flux"));
       stk::mesh::put_field_on_mesh(*normalHeatFlux, *part, nullptr);
-      ScalarFieldType *robinCouplingParameter = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "robin_coupling_parameter"));
+      ScalarFieldType *robinCouplingParameter = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "robin_coupling_parameter"));
       stk::mesh::put_field_on_mesh(*robinCouplingParameter, *part, nullptr);
       
       // provide restart fields
@@ -709,7 +712,7 @@ HeatCondEquationSystem::register_wall_bc(
 
     const AlgorithmType algTypeHF = WALL_HF;
 
-    ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc"));
+    ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "heat_flux_bc"));
     stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
     NormalHeatFlux heatFlux = userData.q_;
@@ -756,9 +759,9 @@ HeatCondEquationSystem::register_wall_bc(
       throw std::runtime_error("Sorry, irradiation was specified while emissivity was not");
 
     // register boundary data;
-    ScalarFieldType *irradField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "irradiation"));
+    ScalarFieldType *irradField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "irradiation"));
     stk::mesh::put_field_on_mesh(*irradField, *part, nullptr);
-    ScalarFieldType *emissField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "emissivity"));
+    ScalarFieldType *emissField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "emissivity"));
     stk::mesh::put_field_on_mesh(*emissField, *part, nullptr);
 
     // aux algs; irradiation
@@ -834,19 +837,19 @@ HeatCondEquationSystem::register_wall_bc(
     }
 
     // register boundary data
-    ScalarFieldType *normalHeatFluxField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "normal_heat_flux"));
+    ScalarFieldType *normalHeatFluxField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "normal_heat_flux"));
     stk::mesh::put_field_on_mesh(*normalHeatFluxField, *part, nullptr);
-    ScalarFieldType *tRefField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "reference_temperature"));
+    ScalarFieldType *tRefField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "reference_temperature"));
     stk::mesh::put_field_on_mesh(*tRefField, *part, nullptr);
 
     ScalarFieldType *alphaField = NULL;
     if (isConvectionCHT)
     {
-      alphaField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_transfer_coefficient"));
+      alphaField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "heat_transfer_coefficient"));
     }
     if (isRobinCHT)
     {
-      alphaField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "robin_coupling_parameter"));
+      alphaField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "robin_coupling_parameter"));
     }
     stk::mesh::put_field_on_mesh(*alphaField, *part, nullptr);
   

--- a/src/HeatCondMassBDF2NodeSuppAlg.C
+++ b/src/HeatCondMassBDF2NodeSuppAlg.C
@@ -44,13 +44,13 @@ HeatCondMassBDF2NodeSuppAlg::HeatCondMassBDF2NodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *temperature = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+  ScalarFieldType *temperature = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
   temperatureNm1_ = &(temperature->field_of_state(stk::mesh::StateNM1));
   temperatureN_ = &(temperature->field_of_state(stk::mesh::StateN));
   temperatureNp1_ = &(temperature->field_of_state(stk::mesh::StateNP1));
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  specificHeat_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/HeatCondMassBackwardEulerNodeSuppAlg.C
+++ b/src/HeatCondMassBackwardEulerNodeSuppAlg.C
@@ -41,12 +41,12 @@ HeatCondMassBackwardEulerNodeSuppAlg::HeatCondMassBackwardEulerNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *temperature = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+  ScalarFieldType *temperature = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
   temperatureN_ = &(temperature->field_of_state(stk::mesh::StateN));
   temperatureNp1_ = &(temperature->field_of_state(stk::mesh::StateNP1));
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  specificHeat_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/InputOutputRealm.C
+++ b/src/InputOutputRealm.C
@@ -95,12 +95,13 @@ InputOutputRealm::register_io_fields() {
       }
       else { 
         if ( fieldName.find(velocityName) != std::string::npos ) { //FIXME: require FieldType?
-          VectorFieldType *velocity = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, fieldName));
+          VectorFieldType *velocity = &(meta_data().declare_field<double>(stk::topology::NODE_RANK, fieldName));
           stk::mesh::put_field_on_mesh(*velocity, *targetPart, fieldSize, nullptr);
+          stk::io::set_field_output_type(*velocity, stk::io::FieldOutputType::VECTOR_3D);
         }
         else {
-          stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *theField 
-            = &(meta_data().declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
+          stk::mesh::Field<double> *theField
+            = &(meta_data().declare_field<double>(stk::topology::NODE_RANK, fieldName));
           stk::mesh::put_field_on_mesh(*theField,*targetPart,fieldSize, nullptr);
         }
       }

--- a/src/KEpsilonEquationSystem.C
+++ b/src/KEpsilonEquationSystem.C
@@ -95,9 +95,9 @@ KEpsilonEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // re-register tke and sdr for convenience; other specifics managed by EQS
-  tke_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
+  tke_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
   stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
-  eps_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation", numStates));
+  eps_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation", numStates));
   stk::mesh::put_field_on_mesh(*eps_, *part, nullptr);
 }
 
@@ -156,8 +156,8 @@ KEpsilonEquationSystem::initial_work()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // required fields
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  ScalarFieldType *viscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *viscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
 
   // required fields with state
   ScalarFieldType &epsNp1 = eps_->field_of_state(stk::mesh::StateNP1);
@@ -224,9 +224,9 @@ KEpsilonEquationSystem::update_and_clip()
   const double small = 1.0e-16;
 
   // required fields
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  ScalarFieldType *viscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  ScalarFieldType *turbViscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *viscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  ScalarFieldType *turbViscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 
   // required fields with state
   ScalarFieldType &epsNp1 = eps_->field_of_state(stk::mesh::StateNP1);

--- a/src/LimiterErrorIndicatorElemAlgorithm.C
+++ b/src/LimiterErrorIndicatorElemAlgorithm.C
@@ -40,10 +40,10 @@ LimiterErrorIndicatorElemAlgorithm::LimiterErrorIndicatorElemAlgorithm(
 {
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  LimiterEI_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  LimiterEI_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "error_indicator");
 }
 
 //--------------------------------------------------------------------------

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -140,29 +140,30 @@ MassFractionEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  massFraction_ =  &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction", numStates));
+  massFraction_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mass_fraction", numStates));
   stk::mesh::put_field_on_mesh(*massFraction_, *part, numMassFraction_, nullptr);
   realm_.augment_restart_variable_list("mass_fraction");
 
-  currentMassFraction_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "current_mass_fraction", numStates));
+  currentMassFraction_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "current_mass_fraction", numStates));
   stk::mesh::put_field_on_mesh(*currentMassFraction_, *part, nullptr);
 
   // delta solution for linear solver
-  yTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "yTmp"));
+  yTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "yTmp"));
   stk::mesh::put_field_on_mesh(*yTmp_, *part, nullptr);
 
-  dydx_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dydx"));
+  dydx_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dydx"));
   stk::mesh::put_field_on_mesh(*dydx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dydx_, stk::io::FieldOutputType::VECTOR_3D);
 
-  visc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  visc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
 
   if ( realm_.is_turbulent() ) {
-    tvisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
+    tvisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity"));
     stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
   }
   
-  evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_y"));
+  evisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "effective_viscosity_y"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
 }
@@ -297,11 +298,11 @@ MassFractionEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; massFraction_bc for all mass fraction number
-  GenericFieldType *theBcField = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction_bc"));
+  GenericFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mass_fraction_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, numMassFraction_, nullptr);
 
   // register single scalar bc value
-  ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "current_mass_fraction_bc"));
+  ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "current_mass_fraction_bc"));
   stk::mesh::put_field_on_mesh(*theCurrentBcField, *part, nullptr);
 
   // insert to the set of bcs
@@ -383,11 +384,11 @@ MassFractionEquationSystem::register_open_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; mass fraction_bc for all speecies number
-  GenericFieldType *theBcField = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction_open_bc"));
+  GenericFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mass_fraction_open_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, numMassFraction_, nullptr);
 
   // register single scalar bc value
-  ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "current_mass_fraction_open_bc"));
+  ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "current_mass_fraction_open_bc"));
   stk::mesh::put_field_on_mesh(*theCurrentBcField, *part, nullptr);
 
   // insert to the set of bcs
@@ -464,11 +465,11 @@ MassFractionEquationSystem::register_wall_bc(
     // FIXME: Generalize for constant vs function
 
     // register boundary data; mass fraction_bc for all mass fraction number
-    GenericFieldType *theBcField = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction_bc"));
+    GenericFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mass_fraction_bc"));
     stk::mesh::put_field_on_mesh(*theBcField, *part, numMassFraction_, nullptr);
 
     // register single scalar bc value
-    ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "current_mass_fraction_bc"));
+    ScalarFieldType *theCurrentBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "current_mass_fraction_bc"));
     stk::mesh::put_field_on_mesh(*theCurrentBcField, *part, nullptr);
 
     // insert to the set of bcs

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -180,39 +180,40 @@ MixtureFractionEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  mixFrac_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "mixture_fraction", numStates));
+  mixFrac_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mixture_fraction", numStates));
   stk::mesh::put_field_on_mesh(*mixFrac_, *part, nullptr);
   realm_.augment_restart_variable_list("mixture_fraction");
 
   // for a sanity check, keep around the un-filterd/clipped field
-  mixFracUF_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "uf_mixture_fraction", numStates));
+  mixFracUF_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "uf_mixture_fraction", numStates));
   stk::mesh::put_field_on_mesh(*mixFracUF_, *part, nullptr);
  
-  dzdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dzdx"));
+  dzdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dzdx"));
   stk::mesh::put_field_on_mesh(*dzdx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dzdx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver; share delta since this is a split system
-  zTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pTmp"));
+  zTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "pTmp"));
   stk::mesh::put_field_on_mesh(*zTmp_, *part, nullptr);
 
-  visc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  visc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
 
   if ( realm_.is_turbulent() ) {
-    tvisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
+    tvisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity"));
     stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
   }
 
-  evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_z"));
+  evisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "effective_viscosity_z"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
-  scalarVar_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_variance"));
+  scalarVar_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scalar_variance"));
   stk::mesh::put_field_on_mesh(*scalarVar_, *part, nullptr);
 
-  scaledScalarVar_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scaled_scalar_variance"));
+  scaledScalarVar_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scaled_scalar_variance"));
   stk::mesh::put_field_on_mesh(*scaledScalarVar_, *part, nullptr);
 
-  scalarDiss_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_dissipation"));
+  scalarDiss_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scalar_dissipation"));
   stk::mesh::put_field_on_mesh(*scalarDiss_, *part, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
@@ -455,7 +456,7 @@ MixtureFractionEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; mixFrac_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "mixFrac_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mixFrac_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified mixFrac and save off the AuxFunction
@@ -556,7 +557,7 @@ MixtureFractionEquationSystem::register_open_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; mixFrac_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "open_mixFrac_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "open_mixFrac_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified mixFrac and save off the AuxFunction
@@ -660,7 +661,7 @@ MixtureFractionEquationSystem::register_wall_bc(
     // FIXME: Generalize for constant vs function
 
     // register boundary data; mixFrac_bc
-    ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "mixFrac_bc"));
+    ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mixFrac_bc"));
     stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
     // extract data
@@ -1046,8 +1047,8 @@ MixtureFractionEquationSystem::compute_scalar_var_diss()
 
   const int nDim = meta_data.spatial_dimension();
 
-  ScalarFieldType *dualNodalVol = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *dualNodalVol = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
 
   // define some common selectors
   stk::mesh::Selector s_all_nodes

--- a/src/MomentumActuatorSrcNodeSuppAlg.C
+++ b/src/MomentumActuatorSrcNodeSuppAlg.C
@@ -38,9 +38,9 @@ MomentumActuatorSrcNodeSuppAlg::MomentumActuatorSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  actuatorSrc_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source");
-  actuatorSrcLHS_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "actuator_source_lhs");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  actuatorSrc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "actuator_source");
+  actuatorSrcLHS_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "actuator_source_lhs");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 }
 

--- a/src/MomentumBodyForceSrcNodeSuppAlg.C
+++ b/src/MomentumBodyForceSrcNodeSuppAlg.C
@@ -38,7 +38,7 @@ MomentumBodyForceSrcNodeSuppAlg::MomentumBodyForceSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 }
 

--- a/src/MomentumBoussinesqSrcNodeSuppAlg.C
+++ b/src/MomentumBoussinesqSrcNodeSuppAlg.C
@@ -41,8 +41,8 @@ MomentumBoussinesqSrcNodeSuppAlg::MomentumBoussinesqSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "temperature");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // extract user parameters from solution options
   tRef_ = realm_.solutionOptions_->referenceTemperature_;

--- a/src/MomentumBuoyancySrcNodeSuppAlg.C
+++ b/src/MomentumBuoyancySrcNodeSuppAlg.C
@@ -39,9 +39,9 @@ MomentumBuoyancySrcNodeSuppAlg::MomentumBuoyancySrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 
   // extract user parameters from solution options

--- a/src/MomentumGclSrcNodeSuppAlg.C
+++ b/src/MomentumGclSrcNodeSuppAlg.C
@@ -40,12 +40,12 @@ MomentumGclSrcNodeSuppAlg::MomentumGclSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *velocity = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  divV_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 }
 

--- a/src/MomentumMassBDF2NodeSuppAlg.C
+++ b/src/MomentumMassBDF2NodeSuppAlg.C
@@ -47,16 +47,16 @@ MomentumMassBDF2NodeSuppAlg::MomentumMassBDF2NodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *velocity = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNm1_ = &(velocity->field_of_state(stk::mesh::StateNM1));
   velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 
 }

--- a/src/MomentumMassBackwardEulerNodeSuppAlg.C
+++ b/src/MomentumMassBackwardEulerNodeSuppAlg.C
@@ -43,14 +43,14 @@ MomentumMassBackwardEulerNodeSuppAlg::MomentumMassBackwardEulerNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *velocity = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dpdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dpdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   nDim_ = meta_data.spatial_dimension();
 
 }

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -260,7 +260,7 @@ NonConformalInfo::construct_bounding_points()
   std::vector<double> ws_face_shape_function;
 
   // fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   std::vector<std::vector<DgInfo*> >::iterator ii;
   for( ii=dgInfoVec_.begin(); ii!=dgInfoVec_.end(); ++ii ) {
@@ -478,7 +478,7 @@ NonConformalInfo::complete_search()
   double bestElemIpCoords[3];
 
   // fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   std::vector<double> currentGaussPointCoords(nDim);
   std::vector<double> opposingIsoParCoords(nDim);
@@ -698,7 +698,7 @@ NonConformalInfo::construct_bounding_boxes()
   const double dynamicFac = dynamicSearchTolAlg_ ? 0.0 : 1.0;
 
   // fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // points
   Point minCorner, maxCorner;
@@ -773,7 +773,7 @@ NonConformalInfo::provide_diagnosis()
   stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   const int nDim = meta_data.spatial_dimension();
 
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   std::vector<double> currentGaussPointCoords(nDim);
   std::vector<double> opposingGaussPointCoords(nDim);

--- a/src/NonConformalManager.C
+++ b/src/NonConformalManager.C
@@ -263,7 +263,7 @@ NonConformalManager::initialize()
   // ensure that the coordinates for the ghosted elements (required for the fine search) are up-to-date
   if (nonConformalGhosting_ != NULL) {
     VectorFieldType *coordinates 
-      = realm_.bulk_data().mesh_meta_data().get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+      = realm_.bulk_data().mesh_meta_data().get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
     std::vector<const stk::mesh::FieldBase*> fieldVec = {coordinates};
     stk::mesh::communicate_field_data(*nonConformalGhosting_, fieldVec);
   }

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -240,7 +240,7 @@ PeriodicManager::determine_translation(
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   const int nDim = meta_data.spatial_dimension();
 
   // Monarch: global_sum_coords_monarch
@@ -408,7 +408,7 @@ PeriodicManager::populate_search_key_vec(
   std::vector<sphereBoundingBox> sphereBoundingBoxSubjectVec;
 
   // fields
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   const int nDim = meta_data.spatial_dimension();
 
   // Point

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -150,12 +150,14 @@ ProjectedNodalGradientEquationSystem::register_nodal_fields(
 
   const int nDim = meta_data.spatial_dimension();
 
-  dqdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, dofName_));
+  dqdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, dofName_));
   stk::mesh::put_field_on_mesh(*dqdx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dqdx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver
-  qTmp_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, deltaName_));
+  qTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, deltaName_));
   stk::mesh::put_field_on_mesh(*qTmp_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*qTmp_, stk::io::FieldOutputType::VECTOR_3D);
 }
 
 //--------------------------------------------------------------------------

--- a/src/PstabErrorIndicatorEdgeAlgorithm.C
+++ b/src/PstabErrorIndicatorEdgeAlgorithm.C
@@ -50,9 +50,9 @@ PstabErrorIndicatorEdgeAlgorithm::PstabErrorIndicatorEdgeAlgorithm(
 {
   // save off field
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  pstabEI_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  pstabEI_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "error_indicator");
 }
 
 //--------------------------------------------------------------------------

--- a/src/PstabErrorIndicatorElemAlgorithm.C
+++ b/src/PstabErrorIndicatorElemAlgorithm.C
@@ -47,8 +47,8 @@ PstabErrorIndicatorElemAlgorithm::PstabErrorIndicatorElemAlgorithm(
 {
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pstabEI_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pstabEI_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "error_indicator");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ScalarGclNodeSuppAlg.C
+++ b/src/ScalarGclNodeSuppAlg.C
@@ -40,10 +40,10 @@ ScalarGclNodeSuppAlg::ScalarGclNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  divV_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ScalarMassBDF2NodeSuppAlg.C
+++ b/src/ScalarMassBDF2NodeSuppAlg.C
@@ -49,11 +49,11 @@ ScalarMassBDF2NodeSuppAlg::ScalarMassBDF2NodeSuppAlg(
   scalarQNm1_ = &(scalarQ->field_of_state(stk::mesh::StateNM1));
   scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));
   scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ScalarMassBackwardEulerNodeSuppAlg.C
+++ b/src/ScalarMassBackwardEulerNodeSuppAlg.C
@@ -44,10 +44,10 @@ ScalarMassBackwardEulerNodeSuppAlg::ScalarMassBackwardEulerNodeSuppAlg(
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));
   scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -97,20 +97,20 @@ ShearStressTransportEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // re-register tke and sdr for convenience
-  tke_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
+  tke_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
   stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
-  sdr_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
+  sdr_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
   stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
 
   // SST parameters that everyone needs
-  minDistanceToWall_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "minimum_distance_to_wall"));
+  minDistanceToWall_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "minimum_distance_to_wall"));
   stk::mesh::put_field_on_mesh(*minDistanceToWall_, *part, nullptr);
-  fOneBlending_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_f_one_blending"));
+  fOneBlending_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending"));
   stk::mesh::put_field_on_mesh(*fOneBlending_, *part, nullptr);
   
   // DES model
   if ( SST_DES == realm_.solutionOptions_->turbulenceModel_ ) {
-    maxLengthScale_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_max_length_scale"));
+    maxLengthScale_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "sst_max_length_scale"));
     stk::mesh::put_field_on_mesh(*maxLengthScale_, *part, nullptr);
   }
 
@@ -232,8 +232,8 @@ ShearStressTransportEquationSystem::initial_work()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // required fields
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  ScalarFieldType *viscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *viscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
 
   // required fields with state
   ScalarFieldType &sdrNp1 = sdr_->field_of_state(stk::mesh::StateNP1);
@@ -292,9 +292,9 @@ ShearStressTransportEquationSystem::update_and_clip()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // required fields
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  ScalarFieldType *viscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  ScalarFieldType *turbViscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *viscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  ScalarFieldType *turbViscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 
   // required fields with state
   ScalarFieldType &sdrNp1 = sdr_->field_of_state(stk::mesh::StateNP1);
@@ -374,8 +374,8 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
   const int nDim = meta_data.spatial_dimension();
 
   // extract fields required
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  VectorFieldType *coordinates = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  VectorFieldType *coordinates = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // define vector of parent topos; should always be UNITY in size
   std::vector<stk::topology> parentTopo;
@@ -493,8 +493,8 @@ ShearStressTransportEquationSystem::compute_f_one_blending()
   ScalarFieldType &tkeNp1 = tke_->field_of_state(stk::mesh::StateNP1);
 
   // fields not saved off
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  ScalarFieldType *viscosity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *viscosity = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   VectorFieldType *dkdx = tkeEqSys_->dkdx_;
   VectorFieldType *dwdx = sdrEqSys_->dwdx_;
 

--- a/src/SimpleErrorIndicatorElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorElemAlgorithm.C
@@ -45,10 +45,10 @@ SimpleErrorIndicatorElemAlgorithm::SimpleErrorIndicatorElemAlgorithm(
 {
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  errorIndicatorField_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator");
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  errorIndicatorField_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "error_indicator");
 }
 
 //--------------------------------------------------------------------------

--- a/src/SimpleErrorIndicatorScalarElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorScalarElemAlgorithm.C
@@ -48,13 +48,13 @@ SimpleErrorIndicatorScalarElemAlgorithm::SimpleErrorIndicatorScalarElemAlgorithm
 {
    // extract fields; nodal
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   velocity_ = scalarQ;
   dudx_ = dqdx;
   nUnk_ = 1;
 
-  errorIndicatorField_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "error_indicator");
+  errorIndicatorField_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "error_indicator");
 }
 
 //--------------------------------------------------------------------------

--- a/src/SixDofSurfaceForceAndMomentAlgorithm.C
+++ b/src/SixDofSurfaceForceAndMomentAlgorithm.C
@@ -65,17 +65,17 @@ SixDofSurfaceForceAndMomentAlgorithm::SixDofSurfaceForceAndMomentAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   NaluEnv::self().naluOutputP0() << "Coords name :: " << realm_.get_coordinates_name() << std::endl;
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
   // extract viscosity name
   const std::string viscName = realm_.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
 
 }
 //--------------------------------------------------------------------------

--- a/src/SixDofSurfaceForceAndMomentAlgorithmDriver.C
+++ b/src/SixDofSurfaceForceAndMomentAlgorithmDriver.C
@@ -64,7 +64,7 @@ SixDofSurfaceForceAndMomentAlgorithmDriver::zero_fields()
   stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   
-  ScalarFieldType *assembledArea = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_six_dof");
+  ScalarFieldType *assembledArea = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_six_dof");
   // zero fields
   field_fill( meta_data, bulk_data, 0.0, *assembledArea, realm_.get_activate_aura());
 }
@@ -91,7 +91,7 @@ SixDofSurfaceForceAndMomentAlgorithmDriver::parallel_assemble_area()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // extract the fields; one of these might be null
-  ScalarFieldType *assembledArea = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_six_dof");
+  ScalarFieldType *assembledArea = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_six_dof");
   // parallel assemble
   std::vector<const stk::mesh::FieldBase*> fields;
   fields.push_back(assembledArea);

--- a/src/SolutionNormPostProcessing.C
+++ b/src/SolutionNormPostProcessing.C
@@ -207,8 +207,8 @@ SolutionNormPostProcessing::setup()
     // register the field, "dofName + _exact"
     const std::string dofNameExact = dofName + "_exact";
     
-    stk::mesh::Field<double, stk::mesh::SimpleArrayTag> *exactDofField
-      = &(metaData.declare_field<stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, dofNameExact));
+    stk::mesh::Field<double> *exactDofField
+      = &(metaData.declare_field<double>(stk::topology::NODE_RANK, dofNameExact));
         
     // push back to vector of pairs; unique list 
     fieldPairVec_.push_back(std::make_pair(dofField, exactDofField));

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -155,24 +155,25 @@ SpecificDissipationRateEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  sdr_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
+  sdr_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
   stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
   realm_.augment_restart_variable_list("specific_dissipation_rate");
 
-  dwdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dwdx"));
+  dwdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dwdx"));
   stk::mesh::put_field_on_mesh(*dwdx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dwdx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver; share delta since this is a split system
-  wTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wTmp"));
+  wTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "wTmp"));
   stk::mesh::put_field_on_mesh(*wTmp_, *part, nullptr);
 
-  visc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  visc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
 
-  tvisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
+  tvisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity"));
   stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
 
-  evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_sdr"));
+  evisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "effective_viscosity_sdr"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
@@ -415,7 +416,7 @@ SpecificDissipationRateEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; sdr_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "sdr_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "sdr_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -496,7 +497,7 @@ SpecificDissipationRateEquationSystem::register_open_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; sdr_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "open_sdr_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "open_sdr_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -566,14 +567,14 @@ SpecificDissipationRateEquationSystem::register_wall_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; sdr_bc
-  sdrWallBc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "sdr_bc"));
+  sdrWallBc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "sdr_bc"));
   stk::mesh::put_field_on_mesh(*sdrWallBc_, *part, nullptr);
 
   // need to register the assembles wall value for sdr; can not share with sdr_bc
-  assembledWallSdr_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_sdr_bc"));
+  assembledWallSdr_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "wall_model_sdr_bc"));
   stk::mesh::put_field_on_mesh(*assembledWallSdr_, *part, nullptr);
 
-  assembledWallArea_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_sdr"));
+  assembledWallArea_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_sdr"));
   stk::mesh::put_field_on_mesh(*assembledWallArea_, *part, nullptr);
 
   // are we using wall functions or is this a low Re model?

--- a/src/SpecificDissipationRateSSTDESNodeSourceSuppAlg.C
+++ b/src/SpecificDissipationRateSSTDESNodeSourceSuppAlg.C
@@ -54,19 +54,19 @@ SpecificDissipationRateSSTDESNodeSourceSuppAlg::SpecificDissipationRateSSTDESNod
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *sdr = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate");
+  ScalarFieldType *sdr = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &(sdr->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  fOneBlend_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_f_one_blending");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dkdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dkdx");
-  dwdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dwdx");
-  maxLengthScale_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_max_length_scale");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  fOneBlend_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dkdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dkdx");
+  dwdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dwdx");
+  maxLengthScale_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_max_length_scale");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/SpecificDissipationRateSSTNodeSourceSuppAlg.C
+++ b/src/SpecificDissipationRateSSTNodeSourceSuppAlg.C
@@ -51,18 +51,18 @@ SpecificDissipationRateSSTNodeSourceSuppAlg::SpecificDissipationRateSSTNodeSourc
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *sdr = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate");
+  ScalarFieldType *sdr = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &(sdr->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  fOneBlend_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_f_one_blending");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dkdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dkdx");
-  dwdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dwdx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  fOneBlend_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dkdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dkdx");
+  dwdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dwdx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -70,18 +70,18 @@ SurfaceForceAndMomentAlgorithm::SurfaceForceAndMomentAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureForce_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
-  tauWall_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
-  yplus_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureForce_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_force");
+  tauWall_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "tau_wall");
+  yplus_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "yplus");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   // extract viscosity name
   const std::string viscName = realm_.is_turbulent()
     ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
   // error check on params
   const size_t nDim = meta_data.spatial_dimension();
   if ( parameters_.size() > nDim )

--- a/src/SurfaceForceAndMomentAlgorithmDriver.C
+++ b/src/SurfaceForceAndMomentAlgorithmDriver.C
@@ -67,13 +67,13 @@ SurfaceForceAndMomentAlgorithmDriver::zero_fields()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   
   // extract the fields
-  VectorFieldType *pressureForce = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
-  ScalarFieldType *tauWall = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
-  ScalarFieldType *yplus = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
+  VectorFieldType *pressureForce = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_force");
+  ScalarFieldType *tauWall = meta_data.get_field<double>(stk::topology::NODE_RANK, "tau_wall");
+  ScalarFieldType *yplus = meta_data.get_field<double>(stk::topology::NODE_RANK, "yplus");
   // one of these might be null
-  ScalarFieldType *assembledArea = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment");
-  ScalarFieldType *assembledAreaWF = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf");
-  ScalarFieldType *assembledAreaWFP = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wfp");
+  ScalarFieldType *assembledArea = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment");
+  ScalarFieldType *assembledAreaWF = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf");
+  ScalarFieldType *assembledAreaWFP = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment_wfp");
 
   // zero fields
   field_fill( meta_data, bulk_data, 0.0, *pressureForce, realm_.get_activate_aura());
@@ -99,9 +99,9 @@ SurfaceForceAndMomentAlgorithmDriver::parallel_assemble_fields()
   const size_t nDim = meta_data.spatial_dimension();
 
   // extract the fields
-  VectorFieldType *pressureForce = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
-  ScalarFieldType *tauWall = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
-  ScalarFieldType *yplus = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
+  VectorFieldType *pressureForce = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_force");
+  ScalarFieldType *tauWall = meta_data.get_field<double>(stk::topology::NODE_RANK, "tau_wall");
+  ScalarFieldType *yplus = meta_data.get_field<double>(stk::topology::NODE_RANK, "yplus");
 
   // parallel assemble
   stk::mesh::parallel_sum(bulk_data, {pressureForce, tauWall, yplus});
@@ -127,9 +127,9 @@ SurfaceForceAndMomentAlgorithmDriver::parallel_assemble_area()
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // extract the fields; one of these might be null
-  ScalarFieldType *assembledArea = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment");
-  ScalarFieldType *assembledAreaWF = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf");
-  ScalarFieldType *assembledAreaWFP = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_area_force_moment_wfp");
+  ScalarFieldType *assembledArea = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment");
+  ScalarFieldType *assembledAreaWF = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment_wf");
+  ScalarFieldType *assembledAreaWFP = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_area_force_moment_wfp");
 
   // parallel assemble
   std::vector<const stk::mesh::FieldBase*> fields;

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -74,18 +74,18 @@ SurfaceForceAndMomentWallFunctionAlgorithm::SurfaceForceAndMomentWallFunctionAlg
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureForce_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
-  tauWall_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
-  yplus_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureForce_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_force");
+  tauWall_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "tau_wall");
+  yplus_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "yplus");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // error check on params
   const size_t nDim = meta_data.spatial_dimension();

--- a/src/SurfaceForceAndMomentWallFunctionProjectedAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionProjectedAlgorithm.C
@@ -80,18 +80,18 @@ SurfaceForceAndMomentWallFunctionProjectedAlgorithm::SurfaceForceAndMomentWallFu
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  velocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureForce_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "pressure_force");
-  tauWall_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "tau_wall");
-  yplus_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "yplus");
-  bcVelocity_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  wallFrictionVelocityBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "wall_normal_distance_bip");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  velocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureForce_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure_force");
+  tauWall_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "tau_wall");
+  yplus_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "yplus");
+  bcVelocity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  wallFrictionVelocityBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = meta_data.get_field<double>(meta_data.side_rank(), "wall_normal_distance_bip");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // error check on params
   const size_t nDim = meta_data.spatial_dimension();

--- a/src/TemperaturePmrSrcNodeSuppAlg.C
+++ b/src/TemperaturePmrSrcNodeSuppAlg.C
@@ -37,9 +37,9 @@ TemperaturePmrSrcNodeSuppAlg::TemperaturePmrSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  divRadFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux");
-  divRadFluxLin_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  divRadFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux");
+  divRadFluxLin_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1346,7 +1346,7 @@ TpetraLinearSystem::finalizeLinearSystem()
 
   TpetraLinearSolver *linearSolver = reinterpret_cast<TpetraLinearSolver *>(linearSolver_);
 
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   if (linearSolver->activeMueLu())
     copy_stk_to_tpetra(coordinates, coords);
 

--- a/src/TurbDissipationEquationSystem.C
+++ b/src/TurbDissipationEquationSystem.C
@@ -153,24 +153,25 @@ TurbDissipationEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  eps_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation", numStates));
+  eps_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation", numStates));
   stk::mesh::put_field_on_mesh(*eps_, *part, nullptr);
   realm_.augment_restart_variable_list("turbulent_dissipation");
 
-  dedx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dedx"));
+  dedx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dedx"));
   stk::mesh::put_field_on_mesh(*dedx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dedx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver; share delta since this is a split system
-  eTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "eTmp"));
+  eTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "eTmp"));
   stk::mesh::put_field_on_mesh(*eTmp_, *part, nullptr);
 
-  visc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  visc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
 
-  tvisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
+  tvisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity"));
   stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
 
-  evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_eps"));
+  evisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "effective_viscosity_eps"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
@@ -412,7 +413,7 @@ TurbDissipationEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; eps_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -493,7 +494,7 @@ TurbDissipationEquationSystem::register_open_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; eps_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "open_eps_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "open_eps_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -563,14 +564,14 @@ TurbDissipationEquationSystem::register_wall_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; eps_bc
-  epsWallBc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "eps_bc"));
+  epsWallBc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "eps_bc"));
   stk::mesh::put_field_on_mesh(*epsWallBc_, *part, nullptr);
 
   // need to register the assembles wall value for eps; can not share with eps_bc
-  assembledWallEps_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_eps_bc"));
+  assembledWallEps_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "wall_model_eps_bc"));
   stk::mesh::put_field_on_mesh(*assembledWallEps_, *part, nullptr);
 
-  assembledWallArea_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_eps"));
+  assembledWallArea_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_eps"));
   stk::mesh::put_field_on_mesh(*assembledWallArea_, *part, nullptr);
 
   // wall function support only 

--- a/src/TurbDissipationKEpsilonNodeSourceSuppAlg.C
+++ b/src/TurbDissipationKEpsilonNodeSourceSuppAlg.C
@@ -49,15 +49,15 @@ TurbDissipationKEpsilonNodeSourceSuppAlg::TurbDissipationKEpsilonNodeSourceSuppA
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *eps = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation");
+  ScalarFieldType *eps = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation");
   epsNp1_ = &(eps->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -186,83 +186,86 @@ TurbKineticEnergyEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  tke_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
+  tke_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
   stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
   realm_.augment_restart_variable_list("turbulent_ke");
 
-  dkdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dkdx"));
+  dkdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dkdx"));
   stk::mesh::put_field_on_mesh(*dkdx_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dkdx_, stk::io::FieldOutputType::VECTOR_3D);
 
   // delta solution for linear solver; share delta since this is a split system
-  kTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pTmp"));
+  kTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "pTmp"));
   stk::mesh::put_field_on_mesh(*kTmp_, *part, nullptr);
 
-  visc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  visc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
 
-  tvisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
+  tvisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity"));
   stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
 
-  evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_tke"));
+  evisc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "effective_viscosity_tke"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
   // allow for nodal values for ksgs model constants
   if ( turbulenceModel_ == KSGS || turbulenceModel_ == LRKSGS || turbulenceModel_ == DKSGS ) {
     const double cEpsConstant = realm_.get_turb_model_constant(TM_cEps);
     ScalarFieldType *cEpsField 
-      = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon"));
+      = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "c_epsilon"));
     stk::mesh::put_field_on_mesh(*cEpsField, *part, &cEpsConstant);  
   
     const double cmuEpsConstant = realm_.get_turb_model_constant(TM_cmuEps);
     ScalarFieldType *cmuEpsField 
-      = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_mu_epsilon"));
+      = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "c_mu_epsilon"));
     stk::mesh::put_field_on_mesh(*cmuEpsField, *part, &cmuEpsConstant);
 
     if ( turbulenceModel_ == LRKSGS ) {
       ScalarFieldType *dsqrtk_dx_sq
-        = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dsqrtk_dx_sq"));
       stk::mesh::put_field_on_mesh(*dsqrtk_dx_sq, *part, nullptr);
       ScalarFieldType *minDistanceToWall 
-        =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "minimum_distance_to_wall"));
+        =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "minimum_distance_to_wall"));
       stk::mesh::put_field_on_mesh(*minDistanceToWall, *part, nullptr);
       realm_.augment_restart_variable_list("minimum_distance_to_wall");
     }
 
     if ( turbulenceModel_ == DKSGS ) {
       ScalarFieldType *filteredFilter 
-        = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_filter"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_filter"));
       stk::mesh::put_field_on_mesh(*filteredFilter, *part, nullptr);
 
       ScalarFieldType *filteredDensity 
-        = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_density"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_density"));
       stk::mesh::put_field_on_mesh(*filteredDensity, *part, nullptr);
 
       ScalarFieldType *filteredKineticEnergy 
-        = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_kinetic_energy"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_kinetic_energy"));
       stk::mesh::put_field_on_mesh(*filteredKineticEnergy, *part, nullptr);
 
       ScalarFieldType *filteredSijDij 
-        = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_sij_dij"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_sij_dij"));
       stk::mesh::put_field_on_mesh(*filteredSijDij, *part, nullptr);
 
       VectorFieldType *filteredVelocity 
-        = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "filtered_velocity"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_velocity"));
       stk::mesh::put_field_on_mesh(*filteredVelocity, *part, nDim, nullptr);
+      stk::io::set_field_output_type(*filteredVelocity, stk::io::FieldOutputType::VECTOR_3D);
 
       VectorFieldType *filteredDensityVelocity 
-        = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "filtered_density_velocity"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_density_velocity"));
       stk::mesh::put_field_on_mesh(*filteredDensityVelocity, *part, nDim, nullptr);
+      stk::io::set_field_output_type(*filteredDensityVelocity, stk::io::FieldOutputType::VECTOR_3D);
 
       GenericFieldType *filteredStrainRate 
-        = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_strain_rate"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_strain_rate"));
       stk::mesh::put_field_on_mesh(*filteredStrainRate, *part, nDim*nDim, nullptr);
       
       GenericFieldType *filteredVelocityGradient 
-        = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_velocity_gradient"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_velocity_gradient"));
       stk::mesh::put_field_on_mesh(*filteredVelocityGradient, *part, nDim*nDim, nullptr);
 
       GenericFieldType *filteredDensityStress 
-        = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_density_stress"));
+        = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "filtered_density_stress"));
       stk::mesh::put_field_on_mesh(*filteredDensityStress, *part, nDim*nDim, nullptr);  
     }
   }
@@ -571,7 +574,7 @@ TurbKineticEnergyEquationSystem::register_inflow_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; tke_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tke_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "tke_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -653,7 +656,7 @@ TurbKineticEnergyEquationSystem::register_open_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; tke_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "open_tke_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "open_tke_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -750,7 +753,7 @@ TurbKineticEnergyEquationSystem::register_wall_bc(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
   // register boundary data; tke_bc
-  ScalarFieldType *theBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tke_bc"));
+  ScalarFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "tke_bc"));
   stk::mesh::put_field_on_mesh(*theBcField, *part, nullptr);
 
   // extract the value for user specified tke and save off the AuxFunction
@@ -771,7 +774,7 @@ TurbKineticEnergyEquationSystem::register_wall_bc(
       wallFunctionTurbKineticEnergyAlgDriver_ = new AlgorithmDriver(realm_);
 
     // need to register the assembles wall value for tke; can not share with tke_bc
-    ScalarFieldType *theAssembledField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_tke_bc"));
+    ScalarFieldType *theAssembledField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "wall_model_tke_bc"));
     stk::mesh::put_field_on_mesh(*theAssembledField, *part, nullptr);
 
     // wall function value will prevail at bc intersections
@@ -1138,39 +1141,39 @@ TurbKineticEnergyEquationSystem::compute_filtered_quantities()
 
   // nodal fileds that need to be gathered
   ScalarFieldType *dualNodalVolume
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   ScalarFieldType *density 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   VectorFieldType *velocity 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   VectorFieldType *coordinates 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // the filtered quantities
   ScalarFieldType *filteredFilter 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_filter");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_filter");
   ScalarFieldType *filteredDensity 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_density");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_density");
   ScalarFieldType *filteredKineticEnergy 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_kinetic_energy");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_kinetic_energy");
   ScalarFieldType *filteredSijDij 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "filtered_sij_dij");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_sij_dij");
   VectorFieldType *filteredVelocity 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "filtered_velocity");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_velocity");
   VectorFieldType *filteredDensityVelocity 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "filtered_density_velocity");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_density_velocity");
   GenericFieldType *filteredStrainRate 
-    = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_strain_rate");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_strain_rate");
   GenericFieldType *filteredVelocityGradient 
-    = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_velocity_gradient");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_velocity_gradient");
   GenericFieldType *filteredDensityStress 
-    = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "filtered_density_stress");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "filtered_density_stress");
 
   // the constants
   ScalarFieldType *cEpsField 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "c_epsilon");
   ScalarFieldType *cmuEpsField 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_mu_epsilon");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "c_mu_epsilon");
   
   // zero fields (nodal loop over shared/owned where filtered varibale was registered)
   stk::mesh::Selector s_all_nodes
@@ -1488,7 +1491,7 @@ TurbKineticEnergyEquationSystem::compute_filtered_quantities()
 
   // formulation uses a nodal effective viscosity to form Ceps
   ScalarFieldType *evisc 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_u");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "effective_viscosity_u");
 
   // nodal loop over locally owned to define nodal constants
   for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin() ;
@@ -1664,14 +1667,14 @@ TurbKineticEnergyEquationSystem::compute_dsqrtk_dx_sq()
 
   // extract nodal fields
   VectorFieldType *coordinates 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   ScalarFieldType *dualNodalVolume 
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // extract fields
   ScalarFieldType &tkeNp1 = tke_->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType *dsqrtk_dx_sq
-    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
 
   // zero assembled gradient
   field_fill( metaData, bulkData, 0.0, *dsqrtk_dx_sq, realm_.get_activate_aura());

--- a/src/TurbKineticEnergyKEpsilonNodeSourceSuppAlg.C
+++ b/src/TurbKineticEnergyKEpsilonNodeSourceSuppAlg.C
@@ -48,15 +48,15 @@ TurbKineticEnergyKEpsilonNodeSourceSuppAlg::TurbKineticEnergyKEpsilonNodeSourceS
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *eps = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation");
+  ScalarFieldType *eps = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation");
   epsNp1_ = &(eps->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbKineticEnergyKsgsNodeSourceSuppAlg.C
+++ b/src/TurbKineticEnergyKsgsNodeSourceSuppAlg.C
@@ -47,21 +47,21 @@ TurbKineticEnergyKsgsNodeSourceSuppAlg::TurbKineticEnergyKsgsNodeSourceSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  cEps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  cEps_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "c_epsilon");
   
   // low-Re form
-  visc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  visc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   // assign required variables that may not be registered to an arbitrary field
-  dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  dsqrtkSq_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   if ( realm_.solutionOptions_->turbulenceModel_ == LRKSGS ) {
-    dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
+    dsqrtkSq_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
     lrksgsfac_ = 1.0;
   }
 }

--- a/src/TurbKineticEnergyRodiNodeSourceSuppAlg.C
+++ b/src/TurbKineticEnergyRodiNodeSourceSuppAlg.C
@@ -42,10 +42,10 @@ TurbKineticEnergyRodiNodeSourceSuppAlg::TurbKineticEnergyRodiNodeSourceSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dhdx_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dhdx");
-  specificHeat_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dhdx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dhdx");
+  specificHeat_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // extract and size gravity
   gravity_ = realm_.solutionOptions_->gravity_;

--- a/src/TurbKineticEnergySSTDESNodeSourceSuppAlg.C
+++ b/src/TurbKineticEnergySSTDESNodeSourceSuppAlg.C
@@ -48,17 +48,17 @@ TurbKineticEnergySSTDESNodeSourceSuppAlg::TurbKineticEnergySSTDESNodeSourceSuppA
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *sdr = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate");
+  ScalarFieldType *sdr = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &(sdr->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  maxLengthScale_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_max_length_scale");
-  fOneBlend_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_f_one_blending");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  maxLengthScale_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_max_length_scale");
+  fOneBlend_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbKineticEnergySSTNodeSourceSuppAlg.C
+++ b/src/TurbKineticEnergySSTNodeSourceSuppAlg.C
@@ -44,15 +44,15 @@ TurbKineticEnergySSTNodeSourceSuppAlg::TurbKineticEnergySSTNodeSourceSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  ScalarFieldType *tke = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType *tke = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *sdr = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate");
+  ScalarFieldType *sdr = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &(sdr->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbViscKEpsilonAlgorithm.C
+++ b/src/TurbViscKEpsilonAlgorithm.C
@@ -42,10 +42,10 @@ TurbViscKEpsilonAlgorithm::TurbViscKEpsilonAlgorithm(
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  tke_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  eps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  tke_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  eps_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbViscKsgsAlgorithm.C
+++ b/src/TurbViscKsgsAlgorithm.C
@@ -55,21 +55,21 @@ TurbViscKsgsAlgorithm::TurbViscKsgsAlgorithm(
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  tke_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ =meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  cmuEps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_mu_epsilon");
+  tke_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dualNodalVolume_ =meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  cmuEps_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "c_mu_epsilon");
 
   // low-Re form
-  cEps_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
-  visc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  cEps_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "c_epsilon");
+  visc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   // assign required variables that may not be registered to an arbitrary field
-  minDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  minDistance_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  dsqrtkSq_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   if (realm_.solutionOptions_->turbulenceModel_ == LRKSGS ) {
-    minDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "minimum_distance_to_wall");
-    dsqrtkSq_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
+    minDistance_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "minimum_distance_to_wall");
+    dsqrtkSq_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
     lrksgsfac_ = 1.0;
   }
 }

--- a/src/TurbViscSSTAlgorithm.C
+++ b/src/TurbViscSSTAlgorithm.C
@@ -46,13 +46,13 @@ TurbViscSSTAlgorithm::TurbViscSSTAlgorithm(
 {
   // 2003 variant; basically, sijMag replaces vorticityMag
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  tke_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  sdr_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate");
-  minDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "minimum_distance_to_wall");
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  tke_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  sdr_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
+  minDistance_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "minimum_distance_to_wall");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbViscSmagorinskyAlgorithm.C
+++ b/src/TurbViscSmagorinskyAlgorithm.C
@@ -44,10 +44,10 @@ TurbViscSmagorinskyAlgorithm::TurbViscSmagorinskyAlgorithm(
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ =meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dualNodalVolume_ =meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
 }
 

--- a/src/TurbViscWaleAlgorithm.C
+++ b/src/TurbViscWaleAlgorithm.C
@@ -44,10 +44,10 @@ TurbViscWaleAlgorithm::TurbViscWaleAlgorithm(
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
-  dudx_ = meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tvisc_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dudx_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dudx");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  tvisc_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   // need NDTW...
 }
 

--- a/src/WallFunctionParamsAlgorithmDriver.C
+++ b/src/WallFunctionParamsAlgorithmDriver.C
@@ -42,8 +42,8 @@ WallFunctionParamsAlgorithmDriver::WallFunctionParamsAlgorithmDriver(
 {
   // register the fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  assembledWallArea_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
-  assembledWallNormalDistance_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+  assembledWallArea_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_area_wf");
+  assembledWallNormalDistance_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "assembled_wall_normal_distance");
 }
 
 //--------------------------------------------------------------------------

--- a/src/gas_dynamics/AssembleGasDynamicsAlgorithmDriver.C
+++ b/src/gas_dynamics/AssembleGasDynamicsAlgorithmDriver.C
@@ -60,7 +60,7 @@ AssembleGasDynamicsAlgorithmDriver::pre_work()
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
 
   // zero
-  GenericFieldType *rhsGasDyn = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "rhs_gas_dynamics");
+  GenericFieldType *rhsGasDyn = metaData.get_field<double>(stk::topology::NODE_RANK, "rhs_gas_dynamics");
   field_fill( metaData, bulkData, 0.0, *rhsGasDyn, realm_.get_activate_aura());
 }
 
@@ -73,7 +73,7 @@ AssembleGasDynamicsAlgorithmDriver::post_work()
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   stk::mesh::MetaData & metaData = realm_.meta_data();
 
-  GenericFieldType *rhsGasDyn = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "rhs_gas_dynamics");
+  GenericFieldType *rhsGasDyn = metaData.get_field<double>(stk::topology::NODE_RANK, "rhs_gas_dynamics");
 
   // u, v, w + cont + e 
   const unsigned totalSize  = metaData.spatial_dimension() + 2;

--- a/src/gas_dynamics/AssembleGasDynamicsCourantReynoldsElemAlgorithm.C
+++ b/src/gas_dynamics/AssembleGasDynamicsCourantReynoldsElemAlgorithm.C
@@ -54,19 +54,19 @@ AssembleGasDynamicsCourantReynoldsElemAlgorithm::AssembleGasDynamicsCourantReyno
   // save off data
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   if ( meshMotion_ )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   const std::string viscName = (realm.is_turbulent())
      ? "effective_viscosity_u" : "viscosity";
-  viscosity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName);
-  speedOfSound_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "speed_of_sound");
+  viscosity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, viscName);
+  speedOfSound_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "speed_of_sound");
   
   // provide for elemental fields
-  elemReynolds_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds");
-  elemCourant_ = meta_data.get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant");
+  elemReynolds_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_reynolds");
+  elemCourant_ = meta_data.get_field<double>(stk::topology::ELEMENT_RANK, "element_courant");
 }
 
 //--------------------------------------------------------------------------

--- a/src/gas_dynamics/AssembleGasDynamicsFluxAlgorithm.C
+++ b/src/gas_dynamics/AssembleGasDynamicsFluxAlgorithm.C
@@ -64,11 +64,11 @@ AssembleGasDynamicsFluxAlgorithm::AssembleGasDynamicsFluxAlgorithm(
   // save off mising fields
   stk::mesh::MetaData & metaData = realm_.meta_data();
   if ( realm_.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  edgeAreaVec_ = metaData.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  edgeAreaVec_ = metaData.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 }
 
 //--------------------------------------------------------------------------

--- a/src/gas_dynamics/AssembleGasDynamicsNonConformalAlgorithm.C
+++ b/src/gas_dynamics/AssembleGasDynamicsNonConformalAlgorithm.C
@@ -71,14 +71,14 @@ AssembleGasDynamicsNonConformalAlgorithm::AssembleGasDynamicsNonConformalAlgorit
   stk::mesh::MetaData & metaData = realm_.meta_data();
   if ( realm_.does_mesh_move() ) {
     meshMotionFac_ = 1.0;
-    meshVelocity_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    meshVelocity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
     meshMotionFac_ = 0.0;
-    meshVelocity_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    meshVelocity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   }
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");  
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // what do we need ghosted for this alg to work?
   ghostFieldVec_.push_back(density_);

--- a/src/gas_dynamics/AssembleGasDynamicsOpenAlgorithm.C
+++ b/src/gas_dynamics/AssembleGasDynamicsOpenAlgorithm.C
@@ -60,10 +60,10 @@ AssembleGasDynamicsOpenAlgorithm::AssembleGasDynamicsOpenAlgorithm(
   // save off mising fields
   stk::mesh::MetaData & metaData = realm_.meta_data();
   if ( realm_.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/gas_dynamics/AssembleGasDynamicsSymmetryAlgorithm.C
+++ b/src/gas_dynamics/AssembleGasDynamicsSymmetryAlgorithm.C
@@ -46,7 +46,7 @@ AssembleGasDynamicsSymmetryAlgorithm::AssembleGasDynamicsSymmetryAlgorithm(
 {
   // save off mising fields
   stk::mesh::MetaData & metaData = realm_.meta_data();
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/gas_dynamics/GasDynamicsEquationSystem.C
+++ b/src/gas_dynamics/GasDynamicsEquationSystem.C
@@ -190,41 +190,43 @@ GasDynamicsEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // dofs first
-  density_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", numStates));
+  density_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "density", numStates));
   stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
-  momentum_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "momentum", numStates));
+  momentum_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "momentum", numStates));
   stk::mesh::put_field_on_mesh(*momentum_, *part, nDim, nullptr);
-  totalEnergy_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "total_energy", numStates));
+  stk::io::set_field_output_type(*momentum_, stk::io::FieldOutputType::VECTOR_3D);
+  totalEnergy_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "total_energy", numStates));
   stk::mesh::put_field_on_mesh(*totalEnergy_, *part, nullptr);
 
   // aux
-  velocity_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity"));
+  velocity_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "velocity"));
   stk::mesh::put_field_on_mesh(*velocity_, *part, nDim, nullptr);
-  totalEnthalpy_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "total_enthalpy"));
+  stk::io::set_field_output_type(*velocity_, stk::io::FieldOutputType::VECTOR_3D);
+  totalEnthalpy_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "total_enthalpy"));
   stk::mesh::put_field_on_mesh(*totalEnthalpy_, *part, nullptr);
-  staticEnthalpy_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "enthalpy"));
+  staticEnthalpy_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "enthalpy"));
   stk::mesh::put_field_on_mesh(*staticEnthalpy_, *part, nullptr);
-  pressure_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure"));
+  pressure_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "pressure"));
   stk::mesh::put_field_on_mesh(*pressure_, *part, nullptr);
-  temperature_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature"));
+  temperature_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature"));
   stk::mesh::put_field_on_mesh(*temperature_, *part, nullptr);
-  machNumber_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "mach_number"));
+  machNumber_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mach_number"));
   stk::mesh::put_field_on_mesh(*machNumber_, *part, nullptr);
-  speedOfSound_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "speed_of_sound"));
+  speedOfSound_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "speed_of_sound"));
   stk::mesh::put_field_on_mesh(*speedOfSound_, *part, nullptr);
 
   // properties: user specifies: mu, R, MW, gamma, and kappa
   //             property evaluator populates nodal fields for 
   //             mu, gamma, kappa, cp and cv (each based on gamma and R/MW)
-  viscosity_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity"));
+  viscosity_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "viscosity"));
   stk::mesh::put_field_on_mesh(*viscosity_, *part, nullptr);
-  cp_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat"));
+  cp_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "specific_heat"));
   stk::mesh::put_field_on_mesh(*cp_, *part, nullptr);
-  cv_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat_v"));
+  cv_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "specific_heat_v"));
   stk::mesh::put_field_on_mesh(*cv_, *part, nullptr);
-  thermalCond_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "thermal_conductivity"));
+  thermalCond_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "thermal_conductivity"));
   stk::mesh::put_field_on_mesh(*thermalCond_, *part, nullptr);
-  gamma_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "gamma"));
+  gamma_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "gamma"));
   stk::mesh::put_field_on_mesh(*gamma_, *part, nullptr);
 
   // push to property list: density needs to be populated for IC
@@ -235,11 +237,11 @@ GasDynamicsEquationSystem::register_nodal_fields(
   realm_.augment_property_map(GAMMA_ID, gamma_);
 
   // dual nodal volume (should push up...)
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume"));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
 
   // residual; special ordering... Pick momentum first, then continuity, then total energy
-  rhsGasDyn_ = &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "rhs_gas_dynamics"));
+  rhsGasDyn_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "rhs_gas_dynamics"));
   stk::mesh::put_field_on_mesh(*rhsGasDyn_, *part, nDim+2, nullptr);
 
   // fileds that require restart
@@ -264,8 +266,9 @@ GasDynamicsEquationSystem::register_edge_fields(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
   const int nDim = meta_data.spatial_dimension();
   VectorFieldType *edgeAreaVec 
-    = &(meta_data.declare_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector"));
+    = &(meta_data.declare_field<double>(stk::topology::EDGE_RANK, "edge_area_vector"));
   stk::mesh::put_field_on_mesh(*edgeAreaVec, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*edgeAreaVec, stk::io::FieldOutputType::VECTOR_3D);
 }
 
 //--------------------------------------------------------------------------
@@ -282,17 +285,17 @@ GasDynamicsEquationSystem::register_element_fields(
   if ( realm_.query_for_overset() ) {
     const int sizeOfElemField = 1;
     GenericFieldType *intersectedElement
-      = &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "intersected_element"));
+      = &(meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, "intersected_element"));
     stk::mesh::put_field_on_mesh(*intersectedElement, *part, sizeOfElemField, nullptr);
   }
 
   // provide mean element Peclet and Courant fields; always...
   GenericFieldType *elemReynolds
-    = &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_reynolds"));
-  stk::mesh::put_field_on_mesh(*elemReynolds, *part, 1, nullptr);
+    = &(meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, "element_reynolds"));
+  stk::mesh::put_field_on_mesh(*elemReynolds, *part, nullptr);
   GenericFieldType *elemCourant
-    = &(meta_data.declare_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "element_courant"));
-  stk::mesh::put_field_on_mesh(*elemCourant, *part, 1, nullptr);
+    = &(meta_data.declare_field<double>(stk::topology::ELEMENT_RANK, "element_courant"));
+  stk::mesh::put_field_on_mesh(*elemCourant, *part, nullptr);
 }
 
 //--------------------------------------------------------------------------
@@ -370,8 +373,9 @@ GasDynamicsEquationSystem::register_inflow_bc(
 
   // register boundary data; velocity
   primitiveName = "velocity";
-  VectorFieldType *uBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_bc"));
+  VectorFieldType *uBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "velocity_bc"));
   stk::mesh::put_field_on_mesh(*uBcField, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*uBcField, stk::io::FieldOutputType::VECTOR_3D);
 
   theDataType = get_bc_data_type(userData, primitiveName);
   if ( CONSTANT_UD != theDataType )
@@ -405,7 +409,7 @@ GasDynamicsEquationSystem::register_inflow_bc(
 
   // register boundary data; temperature
   primitiveName = "temperature";
-  ScalarFieldType *tBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature_bc"));
+  ScalarFieldType *tBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature_bc"));
   stk::mesh::put_field_on_mesh(*tBcField, *part, nullptr);
   
   theDataType = get_bc_data_type(userData, primitiveName);
@@ -458,8 +462,9 @@ GasDynamicsEquationSystem::register_open_bc(
 
   // register boundary data; velocity
   primitiveName = "velocity";
-  VectorFieldType *uBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_bc"));
+  VectorFieldType *uBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "velocity_bc"));
   stk::mesh::put_field_on_mesh(*uBcField, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*uBcField, stk::io::FieldOutputType::VECTOR_3D);
 
   theDataType = get_bc_data_type(userData, primitiveName);
   if ( CONSTANT_UD != theDataType )
@@ -485,7 +490,7 @@ GasDynamicsEquationSystem::register_open_bc(
 
   // register boundary data; temperature
   primitiveName = "temperature";
-  ScalarFieldType *tBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature_bc"));
+  ScalarFieldType *tBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature_bc"));
   stk::mesh::put_field_on_mesh(*tBcField, *part, nullptr);
   
   theDataType = get_bc_data_type(userData, primitiveName);
@@ -509,7 +514,7 @@ GasDynamicsEquationSystem::register_open_bc(
 
   // register boundary data; pressure
   primitiveName = "pressure";
-  ScalarFieldType *pBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
+  ScalarFieldType *pBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "pressure_bc"));
   stk::mesh::put_field_on_mesh(*pBcField, *part, nullptr);
   
   theDataType = get_bc_data_type(userData, primitiveName);
@@ -568,8 +573,9 @@ GasDynamicsEquationSystem::register_wall_bc(
 
   // register boundary data; velocity
   primitiveName = "velocity";
-  VectorFieldType *uBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_bc"));
+  VectorFieldType *uBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "velocity_bc"));
   stk::mesh::put_field_on_mesh(*uBcField, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*uBcField, stk::io::FieldOutputType::VECTOR_3D);
 
   theDataType = get_bc_data_type(userData, primitiveName);
   if ( CONSTANT_UD != theDataType )
@@ -605,7 +611,7 @@ GasDynamicsEquationSystem::register_wall_bc(
   primitiveName = "temperature";
   if ( bc_data_specified(userData, primitiveName) ) {
     
-    ScalarFieldType *tBcField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature_bc"));
+    ScalarFieldType *tBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature_bc"));
     stk::mesh::put_field_on_mesh(*tBcField, *part, nullptr);
     
     theDataType = get_bc_data_type(userData, primitiveName);
@@ -927,7 +933,7 @@ GasDynamicsEquationSystem::dump_state(
 
   // extract coords
   VectorFieldType *coords_ 
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   // deal with state
   ScalarFieldType &densityN = density_->field_of_state(stk::mesh::StateN);

--- a/src/kernel/ContinuityAdvElemKernel.C
+++ b/src/kernel/ContinuityAdvElemKernel.C
@@ -40,15 +40,12 @@ ContinuityAdvElemKernel<AlgTraits>::ContinuityAdvElemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   std::string velocity_name = meshMotion_ ? "velocity_rtm" : "velocity";
 
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  Gpdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   dataPreReqs.add_cvfem_surface_me(meSCS);

--- a/src/kernel/ContinuityAdvFemKernel.C
+++ b/src/kernel/ContinuityAdvFemKernel.C
@@ -39,13 +39,12 @@ ContinuityAdvFemKernel<AlgTraits>::ContinuityAdvFemKernel(
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   std::string velocityRTM_name = meshMotion_ ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, velocityRTM_name);
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocityRTM_name);
+  Gjp_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>( stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>( stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/ContinuityGclElemKernel.C
+++ b/src/kernel/ContinuityGclElemKernel.C
@@ -39,13 +39,10 @@ ContinuityGclElemKernel<AlgTraits>::ContinuityGclElemKernel(
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  divV_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "div_mesh_velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  divV_ = metaData.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -35,9 +35,9 @@ ContinuityInflowElemKernel<BcAlgTraits>::ContinuityInflowElemKernel(
  {
   // save off fields
   const stk::mesh::MetaData &metaData = bulkData.mesh_meta_data();
-  velocityBC_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
-  densityBC_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  velocityBC_ = metaData.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  densityBC_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
   
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
   

--- a/src/kernel/ContinuityInflowFemKernel.C
+++ b/src/kernel/ContinuityInflowFemKernel.C
@@ -34,11 +34,11 @@ ContinuityInflowFemKernel<BcAlgTraits>::ContinuityInflowFemKernel(
 {
   // save off fields
   const stk::mesh::MetaData &metaData = bulkData.mesh_meta_data();
-  velocityBC_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
-  densityBC_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  velocityBC_ = metaData.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  densityBC_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   
   // extract field not required in execute()
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   // extract master element

--- a/src/kernel/ContinuityMassElemKernel.C
+++ b/src/kernel/ContinuityMassElemKernel.C
@@ -37,16 +37,14 @@ ContinuityMassElemKernel<AlgTraits>::ContinuityMassElemKernel(
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
-  ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType* density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
   if (density->number_of_states() == 2)
     densityNm1_ = densityN_;
   else
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -34,16 +34,16 @@ ContinuityOpenElemKernel<BcAlgTraits>::ContinuityOpenElemKernel(
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
   if ( solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "dynamic_pressure");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = metaData.get_field<double>(metaData.side_rank(), "dynamic_pressure");
   
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/ContinuityOpenFemKernel.C
+++ b/src/kernel/ContinuityOpenFemKernel.C
@@ -34,17 +34,17 @@ ContinuityOpenFemKernel<BcAlgTraits>::ContinuityOpenFemKernel(
     meFEM_(sierra::nalu::MasterElementRepo::get_fem_master_element(BcAlgTraits::elemTopo_))
 {
   if ( solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  dynamicPressure_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "dynamic_pressure");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  dynamicPressure_ = metaData.get_field<double>(metaData.side_rank(), "dynamic_pressure");
   
   // extract field not required in execute()
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master elements

--- a/src/kernel/ContinuityVofAdvElemKernel.C
+++ b/src/kernel/ContinuityVofAdvElemKernel.C
@@ -40,18 +40,15 @@ ContinuityVofAdvElemKernel<AlgTraits>::ContinuityVofAdvElemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   std::string velocity_name = meshMotion_ ? "velocity_rtm" : "velocity";
 
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  Gpdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  interfaceCurvature_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  interfaceCurvature_ = metaData.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = metaData.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = metaData.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   for (int i = 0; i < AlgTraits::nDim_; ++i)
     gravity_(i) = solnOpts.gravity_[i];

--- a/src/kernel/ContinuityVofEvaporationElemKernel.C
+++ b/src/kernel/ContinuityVofEvaporationElemKernel.C
@@ -41,10 +41,8 @@ ContinuityVofEvaporationElemKernel<AlgTraits>::ContinuityVofEvaporationElemKerne
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   
-  vofNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "volume_of_fluid");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  vofNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ContinuityVofInflowElemKernel.C
+++ b/src/kernel/ContinuityVofInflowElemKernel.C
@@ -35,8 +35,8 @@ ContinuityVofInflowElemKernel<BcAlgTraits>::ContinuityVofInflowElemKernel(
  {
   // save off fields
   const stk::mesh::MetaData &metaData = bulkData.mesh_meta_data();
-  velocityBC_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "cont_velocity_bc");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  velocityBC_ = metaData.get_field<double>(stk::topology::NODE_RANK, "cont_velocity_bc");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
   
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
 

--- a/src/kernel/ContinuityVofOpenElemKernel.C
+++ b/src/kernel/ContinuityVofOpenElemKernel.C
@@ -34,19 +34,19 @@ ContinuityVofOpenElemKernel<BcAlgTraits>::ContinuityVofOpenElemKernel(
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
   if ( solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  interfaceCurvature_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "interface_curvature");
-  surfaceTension_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_tension");
-  vof_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "volume_of_fluid");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  dynamicPressure_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "dynamic_pressure");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  Gpdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  interfaceCurvature_ = metaData.get_field<double>(stk::topology::NODE_RANK, "interface_curvature");
+  surfaceTension_ = metaData.get_field<double>(stk::topology::NODE_RANK, "surface_tension");
+  vof_ = metaData.get_field<double>(stk::topology::NODE_RANK, "volume_of_fluid");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
+  dynamicPressure_ = metaData.get_field<double>(metaData.side_rank(), "dynamic_pressure");
   for (int i = 0; i < BcAlgTraits::nDim_; ++i)
     gravity_(i) = solnOpts.gravity_[i];
 

--- a/src/kernel/HeatCondMassFemKernel.C
+++ b/src/kernel/HeatCondMassFemKernel.C
@@ -38,7 +38,7 @@ HeatCondMassFemKernel<AlgTraits>::HeatCondMassFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   temperatureN_ = &(temperature->field_of_state(stk::mesh::StateN));
   temperatureNp1_ = &(temperature->field_of_state(stk::mesh::StateNP1));

--- a/src/kernel/MeshDisplacementElasticElemKernel.C
+++ b/src/kernel/MeshDisplacementElasticElemKernel.C
@@ -37,12 +37,11 @@ MeshDisplacementElasticElemKernel<AlgTraits>::MeshDisplacementElasticElemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   
   meshDisplacement_ = &(meshDisplacement->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
 
-  mu_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_mu");
-  lambda_     = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_lambda");
+  mu_ = metaData.get_field<double>(stk::topology::NODE_RANK, "lame_mu");
+  lambda_     = metaData.get_field<double>(stk::topology::NODE_RANK, "lame_lambda");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);

--- a/src/kernel/MeshDisplacementMassElemKernel.C
+++ b/src/kernel/MeshDisplacementMassElemKernel.C
@@ -44,10 +44,9 @@ MeshDisplacementMassElemKernel<AlgTraits>::MeshDisplacementMassElemKernel(
   const int numStates = meshDisplacement->number_of_states(); 
   meshDisplacementNm1_ = (numStates == 2) ? meshDisplacement_ : &(meshDisplacement->field_of_state(stk::mesh::StateNM1));
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MeshDisplacementSimplifiedNeohookeanElemKernel.C
+++ b/src/kernel/MeshDisplacementSimplifiedNeohookeanElemKernel.C
@@ -37,12 +37,11 @@ MeshDisplacementSimplifiedNeohookeanElemKernel<AlgTraits>::MeshDisplacementSimpl
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   
   meshDisplacement_ = &(meshDisplacement->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
 
-  mu_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_mu");
-  lambda_     = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_lambda");
+  mu_ = metaData.get_field<double>(stk::topology::NODE_RANK, "lame_mu");
+  lambda_     = metaData.get_field<double>(stk::topology::NODE_RANK, "lame_lambda");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);

--- a/src/kernel/MomentumActuatorSrcElemKernel.C
+++ b/src/kernel/MomentumActuatorSrcElemKernel.C
@@ -34,10 +34,10 @@ MomentumActuatorSrcElemKernel<AlgTraits>::MomentumActuatorSrcElemKernel(
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   actuator_source_
-      = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source");
+      = metaData.get_field<double>(stk::topology::NODE_RANK, "actuator_source");
   actuator_source_lhs_
-      = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source_lhs");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+      = metaData.get_field<double>(stk::topology::NODE_RANK, "actuator_source_lhs");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MomentumAdvDiffElemKernel.C
+++ b/src/kernel/MomentumAdvDiffElemKernel.C
@@ -38,10 +38,8 @@ MomentumAdvDiffElemKernel<AlgTraits>::MomentumAdvDiffElemKernel(
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  massFlowRate_ = metaData.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MomentumAdvFemKernel.C
+++ b/src/kernel/MomentumAdvFemKernel.C
@@ -41,8 +41,8 @@ MomentumAdvFemKernel<AlgTraits>::MomentumAdvFemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);
@@ -69,9 +69,9 @@ MomentumAdvFemKernel<AlgTraits>::MomentumAdvFemKernel(
     dataPreReqs.add_master_element_call(FEM_GRAD_OP, CURRENT_COORDINATES);
 
   // with pstab
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  vrtmL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "vrtm_lagged");
-  GjpL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx_lagged");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  vrtmL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "vrtm_lagged");
+  GjpL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx_lagged");
   dataPreReqs.add_gathered_nodal_field(*vrtmL_, AlgTraits::nDim_);
   dataPreReqs.add_gathered_nodal_field(*pressure_, 1);
   dataPreReqs.add_gathered_nodal_field(*GjpL_, AlgTraits::nDim_);

--- a/src/kernel/MomentumBodyForceFemKernel.C
+++ b/src/kernel/MomentumBodyForceFemKernel.C
@@ -32,7 +32,7 @@ MomentumBodyForceFemKernel<AlgTraits>::MomentumBodyForceFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
@@ -33,10 +33,10 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *temperature = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+  ScalarFieldType *temperature = metaData.get_field<double>(stk::topology::NODE_RANK, "temperature");
 
   temperatureNp1_ = &(temperature->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   const std::array<double,3>& solnOptsGravity = solnOpts.get_gravity_vector();
   for (int i = 0; i < AlgTraits::nDim_; i++)

--- a/src/kernel/MomentumBuoyancySrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancySrcElemKernel.C
@@ -33,11 +33,9 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::MomentumBuoyancySrcElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   const std::array<double,3>& solnOptsGravity = solnOpts.get_gravity_vector();
   for (int i = 0; i < AlgTraits::nDim_; i++)

--- a/src/kernel/MomentumDiffFemKernel.C
+++ b/src/kernel/MomentumDiffFemKernel.C
@@ -39,7 +39,7 @@ MomentumDiffFemKernel<AlgTraits>::MomentumDiffFemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/MomentumGclElemKernel.C
+++ b/src/kernel/MomentumGclElemKernel.C
@@ -36,20 +36,15 @@ MomentumGclElemKernel<AlgTraits>::MomentumGclElemKernel(
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
 
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
 
-  divV_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "div_mesh_velocity");
-  velocityNp1_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  divV_ = metaData.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  velocityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MomentumHybridTurbElemKernel.C
+++ b/src/kernel/MomentumHybridTurbElemKernel.C
@@ -37,19 +37,13 @@ MomentumHybridTurbElemKernel<AlgTraits>::MomentumHybridTurbElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op("velocity"))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  densityNp1_ =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  alphaNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "adaptivity_parameter");
-  mutij_ = metaData.get_field<GenericFieldType>(
-    stk::topology::NODE_RANK, "tensor_turbulent_viscosity");
+  velocityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  tkeNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  alphaNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "adaptivity_parameter");
+  mutij_ = metaData.get_field<double>(stk::topology::NODE_RANK, "tensor_turbulent_viscosity");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCS =
     sierra::nalu::MasterElementRepo::get_surface_master_element(

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -38,10 +38,8 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
 {
 
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
@@ -57,9 +55,8 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   else
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  Gjp_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MomentumMassFemKernel.C
+++ b/src/kernel/MomentumMassFemKernel.C
@@ -35,8 +35,8 @@ MomentumMassFemKernel<AlgTraits>::MomentumMassFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  Gjp_ =  metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  Gjp_ =  metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
   
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
   velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -49,18 +49,18 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::MomentumOpenAdvDiffElemKernel(
   // save off fields
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
   if ( solnOpts.does_mesh_move() ) {
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
-    meshVelocity_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
+    meshVelocity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
     velocityRTM_ = velocityNp1_;
     meshVelocity_ = velocityNp1_;
   }
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  openMassFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
-  velocityBc_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
+  openMassFlowRate_ = metaData.get_field<double>(metaData.side_rank(), "open_mass_flow_rate");
+  velocityBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "open_velocity_bc");
   
   // extract master elements
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/MomentumOpenAdvDiffFemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffFemKernel.C
@@ -42,22 +42,22 @@ MomentumOpenAdvDiffFemKernel<BcAlgTraits>::MomentumOpenAdvDiffFemKernel(
 {
   // save off fields
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  vrtmL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "vrtm_lagged");
-  velocityBc_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+  vrtmL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "vrtm_lagged");
+  velocityBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "open_velocity_bc");
   if ( solnOpts.does_mesh_move() ) {
-    meshVelocity_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity");
+    meshVelocity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
   }
   else {
     meshVelocity_ = velocityNp1_;
   }
-  GjpL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx_lagged");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  dynamicPressure_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "dynamic_pressure");
+  GjpL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx_lagged");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  dynamicPressure_ = metaData.get_field<double>(metaData.side_rank(), "dynamic_pressure");
     
   // extract field not required in execute()
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master elements

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -36,9 +36,8 @@ MomentumSymmetryElemKernel<BcAlgTraits>::MomentumSymmetryElemKernel(
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
 
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/MomentumUpwAdvDiffElemKernel.C
+++ b/src/kernel/MomentumUpwAdvDiffElemKernel.C
@@ -52,15 +52,13 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::MomentumUpwAdvDiffElemKernel(
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   if ( solnOpts_.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  massFlowRate_ = metaData.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
   
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 

--- a/src/kernel/MomentumWallFunctionElemKernel.C
+++ b/src/kernel/MomentumWallFunctionElemKernel.C
@@ -34,16 +34,15 @@ MomentumWallFunctionElemKernel<BcAlgTraits>::MomentumWallFunctionElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  bcVelocity_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "wall_normal_distance_bip");
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  bcVelocity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
+  wallFrictionVelocityBip_ = metaData.get_field<double>(metaData.side_rank(), "wall_friction_velocity_bip");
+  wallNormalDistanceBip_ = metaData.get_field<double>(metaData.side_rank(), "wall_normal_distance_bip");
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
  
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);

--- a/src/kernel/ScalarAdvDiffElemKernel.C
+++ b/src/kernel/ScalarAdvDiffElemKernel.C
@@ -38,10 +38,8 @@ ScalarAdvDiffElemKernel<AlgTraits>::ScalarAdvDiffElemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  massFlowRate_ = metaData.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ScalarAdvFemKernel.C
+++ b/src/kernel/ScalarAdvFemKernel.C
@@ -39,7 +39,7 @@ ScalarAdvFemKernel<AlgTraits>::ScalarAdvFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/ScalarDiffElemKernel.C
+++ b/src/kernel/ScalarDiffElemKernel.C
@@ -39,8 +39,7 @@ ScalarDiffElemKernel<AlgTraits>::ScalarDiffElemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/kernel/ScalarDiffFemKernel.C
+++ b/src/kernel/ScalarDiffFemKernel.C
@@ -37,7 +37,7 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -39,8 +39,8 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::ScalarFluxPenaltyElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op("pressure")),
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
   
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/ScalarFluxPenaltyFemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyFemKernel.C
@@ -39,7 +39,7 @@ ScalarFluxPenaltyFemKernel<BcAlgTraits>::ScalarFluxPenaltyFemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name())),
     meFEM_(sierra::nalu::MasterElementRepo::get_fem_master_element(BcAlgTraits::elemTopo_))
 {
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_fem_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/ScalarGclElemKernel.C
+++ b/src/kernel/ScalarGclElemKernel.C
@@ -37,13 +37,10 @@ ScalarGclElemKernel<AlgTraits>::ScalarGclElemKernel(
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
-  ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType* density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  divV_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "div_mesh_velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  divV_ = metaData.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ScalarMassElemKernel.C
+++ b/src/kernel/ScalarMassElemKernel.C
@@ -45,8 +45,7 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
   else
     scalarQNm1_ = &(scalarQ->field_of_state(stk::mesh::StateNM1));
 
-  ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType* density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
 
@@ -54,8 +53,7 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
     densityNm1_ = densityN_;
   else
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/ScalarMassFemKernel.C
+++ b/src/kernel/ScalarMassFemKernel.C
@@ -35,7 +35,7 @@ ScalarMassFemKernel<AlgTraits>::ScalarMassFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
   scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -48,12 +48,12 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::ScalarOpenAdvElemKernel(
 {
   // save off fields
   if ( solnOpts.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  openMassFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  openMassFlowRate_ = metaData.get_field<double>(metaData.side_rank(), "open_mass_flow_rate");
   
   // extract master elements
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/ScalarOpenAdvFemKernel.C
+++ b/src/kernel/ScalarOpenAdvFemKernel.C
@@ -40,15 +40,15 @@ ScalarOpenAdvFemKernel<BcAlgTraits>::ScalarOpenAdvFemKernel(
     meFEM_(sierra::nalu::MasterElementRepo::get_fem_master_element(BcAlgTraits::elemTopo_))
 {
   // save off fields
-  vrtmL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "vrtm_lagged");
-  GjpL_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx_lagged");
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  dynamicPressure_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "dynamic_pressure");
+  vrtmL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "vrtm_lagged");
+  GjpL_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx_lagged");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  pressureBc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure_bc");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  dynamicPressure_ = metaData.get_field<double>(metaData.side_rank(), "dynamic_pressure");
     
   // extract field not required in execute()
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master elements

--- a/src/kernel/ScalarPngBcFemKernel.C
+++ b/src/kernel/ScalarPngBcFemKernel.C
@@ -31,8 +31,8 @@ ScalarPngBcFemKernel<BcAlgTraits>::ScalarPngBcFemKernel(
   : Kernel()
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  scalarQ_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, fieldName);
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  scalarQ_ = metaData.get_field<double>(stk::topology::NODE_RANK, fieldName);
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
  
   // extract master element

--- a/src/kernel/ScalarPngFemKernel.C
+++ b/src/kernel/ScalarPngFemKernel.C
@@ -34,10 +34,10 @@ ScalarPngFemKernel<AlgTraits>::ScalarPngFemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  scalarQ_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, independentDofName);
-  Gjq_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, dofName);
+  scalarQ_ = metaData.get_field<double>(stk::topology::NODE_RANK, independentDofName);
+  Gjq_ = metaData.get_field<double>(stk::topology::NODE_RANK, dofName);
 
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master element
   MasterElement *meFEM = sierra::nalu::MasterElementRepo::get_fem_master_element(AlgTraits::topo_);

--- a/src/kernel/ScalarUpwAdvDiffElemKernel.C
+++ b/src/kernel/ScalarUpwAdvDiffElemKernel.C
@@ -52,19 +52,14 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
-  density_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  massFlowRate_ = metaData.get_field<double>(stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  density_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-        stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -43,24 +43,19 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType* tke = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "specific_dissipation_rate");
+  ScalarFieldType* sdr = metaData.get_field<double>(stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
   VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  fOneBlend_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "sst_f_one_blending");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  fOneBlend_ = metaData.get_field<double>(stk::topology::NODE_RANK, "sst_f_one_blending");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =
     sierra::nalu::MasterElementRepo::get_volume_master_element(

--- a/src/kernel/TurbDissipationKEpsilonSrcElemKernel.C
+++ b/src/kernel/TurbDissipationKEpsilonSrcElemKernel.C
@@ -43,16 +43,16 @@ TurbDissipationKEpsilonSrcElemKernel<AlgTraits>::
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  VectorFieldType* velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  VectorFieldType* velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  ScalarFieldType* tke = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* eps = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation");
+  ScalarFieldType* eps = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation");
   epsNp1_ = &eps->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* density = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType* density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
-  tvisc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 
   MasterElement* meSCV =
     sierra::nalu::MasterElementRepo::get_volume_master_element(

--- a/src/kernel/TurbKineticEnergyKEpsilonSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKEpsilonSrcElemKernel.C
@@ -43,14 +43,14 @@ TurbKineticEnergyKEpsilonSrcElemKernel<AlgTraits>::TurbKineticEnergyKEpsilonSrcE
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
-  epsNp1_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_dissipation");
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  tkeNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  epsNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_dissipation");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/TurbKineticEnergyKsgsBuoyancySrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsBuoyancySrcElemKernel.C
@@ -35,13 +35,12 @@ TurbKineticEnergyKsgsBuoyancySrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsBuoy
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  ScalarFieldType *tke = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  ScalarFieldType *tke = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &(tke->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -37,23 +37,17 @@
  {
    // save off fields
    const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-   coordinates_ = metaData.get_field<VectorFieldType>(
-     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-   VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
-     stk::topology::NODE_RANK, "velocity");
+   coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+   VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
    velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-   tkeNp1_ = metaData.get_field<ScalarFieldType>(
-     stk::topology::NODE_RANK, "turbulent_ke");
-   densityNp1_ = metaData.get_field<ScalarFieldType>(
-     stk::topology::NODE_RANK, "density");
-   tvisc_ = metaData.get_field<ScalarFieldType>(
-     stk::topology::NODE_RANK, "turbulent_viscosity");
-   dualNodalVolume_ = metaData.get_field<ScalarFieldType>(
-     stk::topology::NODE_RANK, "dual_nodal_volume");
-   cEps_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
+   tkeNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+   densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+   tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+   dualNodalVolume_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+   cEps_ = metaData.get_field<double>(stk::topology::NODE_RANK, "c_epsilon");
 
    // low-Re form
-   visc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+   visc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "viscosity");
 
    MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
    get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);

--- a/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
@@ -37,24 +37,20 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsSrcElemKerne
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  cEps_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "c_epsilon");
-  Gju_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  tkeNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_ke");
+  densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
+  dualNodalVolume_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  cEps_ = metaData.get_field<double>(stk::topology::NODE_RANK, "c_epsilon");
+  Gju_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dudx");
 
   // low-Re form
-  visc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  visc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   // assign required variables that may not be registered to an arbitrary field
-  dsqrtkSq_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+  dsqrtkSq_ = metaData.get_field<double>(stk::topology::NODE_RANK, "viscosity");
   if (lrksgsfac > 0.0 ) {
-    dsqrtkSq_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
+    dsqrtkSq_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dsqrtk_dx_sq");
   }
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);

--- a/src/kernel/TurbKineticEnergyRodiSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyRodiSrcElemKernel.C
@@ -36,14 +36,10 @@ TurbKineticEnergyRodiSrcElemKernel<AlgTraits>::TurbKineticEnergyRodiSrcElemKerne
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  dhdx_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "dhdx");
-  specificHeat_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "specific_heat");
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  dhdx_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dhdx");
+  specificHeat_ = metaData.get_field<double>(stk::topology::NODE_RANK, "specific_heat");
+  tvisc_ = metaData.get_field<double>(stk::topology::NODE_RANK, "turbulent_viscosity");
 
   const std::array<double,3>& solnOptsGravity = solnOpts.get_gravity_vector();
   for (int i = 0; i < AlgTraits::nDim_; i++)

--- a/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
@@ -40,25 +40,25 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
+  ScalarFieldType* tke = metaData.get_field<double>(
     stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
+  ScalarFieldType* sdr = metaData.get_field<double>(
     stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
   VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
+  tvisc_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, "turbulent_viscosity");
-  maxLengthScale_ = metaData.get_field<ScalarFieldType>(
+  maxLengthScale_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, "sst_max_length_scale");
-  fOneBlend_ = metaData.get_field<ScalarFieldType>(
+  fOneBlend_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, "sst_f_one_blending");
-  coordinates_ = metaData.get_field<VectorFieldType>(
+  coordinates_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =

--- a/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
@@ -37,21 +37,21 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::TurbKineticEnergySSTSrcElemKernel(
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
+  ScalarFieldType* tke = metaData.get_field<double>(
     stk::topology::NODE_RANK, "turbulent_ke");
   tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
+  ScalarFieldType* sdr = metaData.get_field<double>(
     stk::topology::NODE_RANK, "specific_dissipation_rate");
   sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
   ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
   VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
+  tvisc_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, "turbulent_viscosity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
+  coordinates_ = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =

--- a/src/kernel/VolumeOfFluidDivElemKernel.C
+++ b/src/kernel/VolumeOfFluidDivElemKernel.C
@@ -38,10 +38,8 @@ VolumeOfFluidDivElemKernel<AlgTraits>::VolumeOfFluidDivElemKernel(
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
 
   std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidEvaporationElemKernel.C
+++ b/src/kernel/VolumeOfFluidEvaporationElemKernel.C
@@ -41,8 +41,7 @@ VolumeOfFluidEvaporationElemKernel<AlgTraits>::VolumeOfFluidEvaporationElemKerne
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidGclElemKernel.C
+++ b/src/kernel/VolumeOfFluidGclElemKernel.C
@@ -38,10 +38,8 @@ VolumeOfFluidGclElemKernel<AlgTraits>::VolumeOfFluidGclElemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
-  divV_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "div_mesh_velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  divV_ = metaData.get_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidMassElemKernel.C
+++ b/src/kernel/VolumeOfFluidMassElemKernel.C
@@ -45,8 +45,7 @@ VolumeOfFluidMassElemKernel<AlgTraits>::VolumeOfFluidMassElemKernel(
   else
     vofNm1_ = &(vof->field_of_state(stk::mesh::StateNM1));
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidOpenAdvElemKernel.C
+++ b/src/kernel/VolumeOfFluidOpenAdvElemKernel.C
@@ -38,8 +38,8 @@ VolumeOfFluidOpenAdvElemKernel<BcAlgTraits>::VolumeOfFluidOpenAdvElemKernel(
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
   // save off fields
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  openVolumeFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_volume_flow_rate");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  openVolumeFlowRate_ = metaData.get_field<double>(metaData.side_rank(), "open_volume_flow_rate");
   
   // extract master elements
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);

--- a/src/kernel/VolumeOfFluidScsAdvElemKernel.C
+++ b/src/kernel/VolumeOfFluidScsAdvElemKernel.C
@@ -38,12 +38,9 @@ VolumeOfFluidScsAdvElemKernel<AlgTraits>::VolumeOfFluidScsAdvElemKernel(
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
 
   std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  volumeFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "volume_flow_rate_scs");
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  volumeFlowRate_ = metaData.get_field<double>(stk::topology::ELEMENT_RANK, "volume_flow_rate_scs");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidScvAdvElemKernel.C
+++ b/src/kernel/VolumeOfFluidScvAdvElemKernel.C
@@ -38,10 +38,8 @@ VolumeOfFluidScvAdvElemKernel<AlgTraits>::VolumeOfFluidScvAdvElemKernel(
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
 
   std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidSharpenElemKernel.C
+++ b/src/kernel/VolumeOfFluidSharpenElemKernel.C
@@ -39,13 +39,10 @@ VolumeOfFluidSharpenElemKernel<AlgTraits>::VolumeOfFluidSharpenElemKernel(
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   
   vofNp1_ = &(vof->field_of_state(stk::mesh::StateNP1));
-  interfaceNormal_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "interface_normal");
+  interfaceNormal_ = metaData.get_field<double>(stk::topology::NODE_RANK, "interface_normal");
   std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
   
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/kernel/VolumeOfFluidSucvNsoElemKernel.C
+++ b/src/kernel/VolumeOfFluidSucvNsoElemKernel.C
@@ -50,11 +50,9 @@ VolumeOfFluidSucvNsoElemKernel<AlgTraits>::VolumeOfFluidSucvNsoElemKernel(
     vofNm1_ = &(vof->field_of_state(stk::mesh::StateNM1));
   
   std::string velocity_name = solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, velocity_name);
+  velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, velocity_name);
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 

--- a/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
+++ b/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
@@ -46,8 +46,8 @@ AssemblePressureForceBCSolverAlgorithm::AssemblePressureForceBCSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/mesh_motion/MeshDisplacementEquationSystem.C
+++ b/src/mesh_motion/MeshDisplacementEquationSystem.C
@@ -153,43 +153,48 @@ MeshDisplacementEquationSystem::register_nodal_fields(
   const int numStates = realm_.number_of_states();
 
   // register dof; set it as a restart variable
-  meshDisplacement_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_displacement", numStates));
+  meshDisplacement_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mesh_displacement", numStates));
   stk::mesh::put_field_on_mesh(*meshDisplacement_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*meshDisplacement_, stk::io::FieldOutputType::VECTOR_3D);
   realm_.augment_restart_variable_list("mesh_displacement");
 
   // mesh velocity (used for fluids coupling)
-  meshVelocity_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity"));
+  meshVelocity_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mesh_velocity"));
   stk::mesh::put_field_on_mesh(*meshVelocity_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*meshVelocity_, stk::io::FieldOutputType::VECTOR_3D);
 
   // projected nodal gradient
-  dvdx_ =  &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dvdx"));
+  dvdx_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dvdx"));
   stk::mesh::put_field_on_mesh(*dvdx_, *part, nDim*nDim, nullptr);
 
-  divV_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity"));
+  divV_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "div_mesh_velocity"));
    stk::mesh::put_field_on_mesh(*divV_, *part, nullptr);
 
    // delta solution for linear solver
-  dxTmp_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dxTmp"));
+  dxTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dxTmp"));
   stk::mesh::put_field_on_mesh(*dxTmp_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*dxTmp_, stk::io::FieldOutputType::VECTOR_3D);
 
   // geometry
-  coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
+  coordinates_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*coordinates_, stk::io::FieldOutputType::VECTOR_3D);
 
-  currentCoordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "current_coordinates"));
+  currentCoordinates_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "current_coordinates"));
   stk::mesh::put_field_on_mesh(*currentCoordinates_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*currentCoordinates_, stk::io::FieldOutputType::VECTOR_3D);
 
-  dualNodalVolume_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume"));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
 
-  density_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density"));
+  density_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "density"));
   stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
   realm_.augment_property_map(DENSITY_ID, density_);
 
-  lameMu_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_mu"));
+  lameMu_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "lame_mu"));
   stk::mesh::put_field_on_mesh(*lameMu_, *part, nullptr);
 
-  lameLambda_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_lambda"));
+  lameLambda_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "lame_lambda"));
   stk::mesh::put_field_on_mesh(*lameLambda_, *part, nullptr);
 
   // push to property list
@@ -305,8 +310,9 @@ MeshDisplacementEquationSystem::register_wall_bc(
   if ( bc_data_specified(userData, displacementName) ) {
 
     // register boundary data; mesh_displacement_bc
-    VectorFieldType *theBcField = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_displacement_bc"));
+    VectorFieldType *theBcField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "mesh_displacement_bc"));
     stk::mesh::put_field_on_mesh(*theBcField, *part, nDim, nullptr);
+    stk::io::set_field_output_type(*theBcField, stk::io::FieldOutputType::VECTOR_3D);
 
     AuxFunction *theAuxFunc = NULL;
 
@@ -375,7 +381,7 @@ MeshDisplacementEquationSystem::register_wall_bc(
   }
   else if (bc_data_specified(userData, pressureName) ) {
     // register the bc pressure field
-    ScalarFieldType *bcPressureField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure_bc"));
+    ScalarFieldType *bcPressureField = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "pressure_bc"));
     stk::mesh::put_field_on_mesh(*bcPressureField, *part, nDim, nullptr);
 
     // extract the value for user specified pressure and save off the AuxFunction

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -45,8 +45,7 @@ MomentumNSOElemKernel<AlgTraits>::MomentumNSOElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op(velocity->name()))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
@@ -63,17 +62,13 @@ MomentumNSOElemKernel<AlgTraits>::MomentumNSOElemKernel(
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/nso/MomentumNSOGradElemSuppAlg.C
+++ b/src/nso/MomentumNSOGradElemSuppAlg.C
@@ -52,18 +52,18 @@ MomentumNSOGradElemSuppAlg::MomentumNSOGradElemSuppAlg(
   // save off fields with and without state
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  pressure_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  Gjp_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dpdx");
 
   // check for mesh motion for proper velocity
   const bool meshMotion = realm_.does_mesh_move();
   if ( meshMotion )
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    velocityRTM_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // fixed size
   ws_dukdxScs_.resize(nDim_);

--- a/src/nso/MomentumNSOKeElemKernel.C
+++ b/src/nso/MomentumNSOKeElemKernel.C
@@ -39,27 +39,20 @@ MomentumNSOKeElemKernel<AlgTraits>::MomentumNSOKeElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op("velocity"))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  velocityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  Gjp_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -36,27 +36,20 @@ MomentumNSOSijElemKernel<AlgTraits>::MomentumNSOSijElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op("velocity"))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  velocityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  Gjp_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/nso/ScalarNSOElemKernel.C
+++ b/src/nso/ScalarNSOElemKernel.C
@@ -44,8 +44,7 @@ ScalarNSOElemKernel<AlgTraits>::ScalarNSOElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));
   scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
@@ -62,14 +61,11 @@ ScalarNSOElemKernel<AlgTraits>::ScalarNSOElemKernel(
     densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/nso/ScalarNSOFemKernel.C
+++ b/src/nso/ScalarNSOFemKernel.C
@@ -33,21 +33,18 @@ ScalarNSOFemKernel<AlgTraits>::ScalarNSOFemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
 
   scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
   // extract field not required in execute()
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
+  VectorFieldType *coordinates = metaData.get_field<double>(
     stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   // extract master element

--- a/src/nso/ScalarNSOKeElemKernel.C
+++ b/src/nso/ScalarNSOKeElemKernel.C
@@ -42,24 +42,18 @@ ScalarNSOKeElemKernel<AlgTraits>::ScalarNSOKeElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  pressure_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "pressure");
+  velocityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+  densityNp1_ = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
   if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity_rtm");
   else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+    velocityRTM_ = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+  Gjp_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dpdx");
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);

--- a/src/overset/AssembleOversetSolverConstraintAlgorithm.C
+++ b/src/overset/AssembleOversetSolverConstraintAlgorithm.C
@@ -59,8 +59,8 @@ AssembleOversetSolverConstraintAlgorithm::AssembleOversetSolverConstraintAlgorit
 
   // extract fields (only used for density scaling)
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  density_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  density_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "density");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   if ( densityScaling ) {
     ghostFieldVec_.push_back(density_);
     ghostFieldVec_.push_back(dualNodalVolume_);    

--- a/src/overset/OversetManagerSTK.C
+++ b/src/overset/OversetManagerSTK.C
@@ -288,8 +288,8 @@ OversetManagerSTK::define_inactive_bounding_box()
   // extract model coordinates
   VectorFieldType *coordinates
     = (oversetUserData_.cuttingShape_=="aabb") ? 
-      (metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name())) :
-      (metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates")) ;
+      (metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name())) :
+      (metaData_->get_field<double>(stk::topology::NODE_RANK, "coordinates")) ;
 
   NaluEnv::self().naluOutputP0() << "Cutting shape :: " << oversetUserData_.cuttingShape_ << std::endl;
 
@@ -550,7 +550,7 @@ OversetManagerSTK::define_overset_bounding_boxes()
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   // setup data structures for search
   Point minBackgroundCorner, maxBackgroundCorner;
@@ -621,7 +621,7 @@ OversetManagerSTK::define_background_bounding_boxes()
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   // setup data structures for search
   Point minBackgroundCorner, maxBackgroundCorner;
@@ -711,7 +711,7 @@ OversetManagerSTK::determine_intersected_elements(
 
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // proceed with coarse search
   stk::search::coarse_search(boundingBoxVec, boundingBoxesVec, searchMethod_, NaluEnv::self().parallel_comm(), searchKeyPair);
@@ -947,7 +947,7 @@ OversetManagerSTK::create_overset_info_vec()
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   Point localNodalCoords;
   
@@ -1054,7 +1054,7 @@ OversetManagerSTK::create_fringe_info_vec()
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
   
   Point localNodalCoords;
   
@@ -1140,7 +1140,7 @@ OversetManagerSTK::set_data_on_inactive_part()
 {
   // extract elemental field
   GenericFieldType *intersectedElement
-    = metaData_->get_field<GenericFieldType>(stk::topology::ELEMENT_RANK, "intersected_element");
+    = metaData_->get_field<double>(stk::topology::ELEMENT_RANK, "intersected_element");
 
   // first, initialize element field to zero everywhere
   stk::mesh::Selector s_everywhere = stk::mesh::selectField(*intersectedElement);
@@ -1177,7 +1177,7 @@ OversetManagerSTK::set_data_on_fringe_part()
 {
   // extract nodal field
   ScalarFieldType *fringeNode
-    = metaData_->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "fringe_node");
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, "fringe_node");
 
   // first, initialize field to zero everywhere
   stk::mesh::Selector s_everywhere = stk::mesh::selectField(*fringeNode);
@@ -1286,7 +1286,7 @@ OversetManagerSTK::complete_search(
 {
   // extract coordinates
   VectorFieldType *coordinates
-    = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData_->get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // define vectors; fixed size
   std::vector<double> isoParCoords(nDim_);

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -76,10 +76,10 @@ void TiogaBlock::setup(stk::mesh::PartVector& bcPartVec)
   if (ovsetNames_.size() > 0)
     names_to_parts(ovsetNames_, ovsetParts_);
 
-  ScalarIntFieldType& ibf = meta_.declare_field<ScalarIntFieldType>(
+  ScalarIntFieldType& ibf = meta_.declare_field<int>(
     stk::topology::NODE_RANK, "iblank");
 
-  ScalarIntFieldType& ibcell = meta_.declare_field<ScalarIntFieldType>(
+  ScalarIntFieldType& ibcell = meta_.declare_field<int>(
     stk::topology::ELEM_RANK, "iblank_cell");
 
   for (auto p: blkParts_) {
@@ -111,7 +111,7 @@ void TiogaBlock::update_coords()
   stk::mesh::Selector mesh_selector = stk::mesh::selectUnion(blkParts_);
   const stk::mesh::BucketVector& mbkts = bulk_.get_buckets(
     stk::topology::NODE_RANK, mesh_selector);
-  VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+  VectorFieldType* coords = meta_.get_field<int>(
     stk::topology::NODE_RANK, coords_name_);
 
 #if 0
@@ -169,7 +169,7 @@ void
 TiogaBlock::update_iblanks()
 {
   ScalarIntFieldType* ibf =
-    meta_.get_field<ScalarIntFieldType>(stk::topology::NODE_RANK, "iblank");
+    meta_.get_field<int>(stk::topology::NODE_RANK, "iblank");
 
   stk::mesh::Selector mesh_selector = stk::mesh::selectUnion(blkParts_);
   const stk::mesh::BucketVector& mbkts =
@@ -186,7 +186,7 @@ TiogaBlock::update_iblanks()
 
 void TiogaBlock::update_iblank_cell()
 {
-  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<int>(
     stk::topology::ELEM_RANK, "iblank_cell");
 
   stk::mesh::Selector mesh_selector = meta_.locally_owned_part() &
@@ -279,7 +279,7 @@ void TiogaBlock::process_nodes()
   stk::mesh::Selector mesh_selector = stk::mesh::selectUnion(blkParts_);
   const stk::mesh::BucketVector& mbkts = bulk_.get_buckets(
     stk::topology::NODE_RANK, mesh_selector);
-  VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+  VectorFieldType* coords = meta_.get_field<double>(
     stk::topology::NODE_RANK, coords_name_);
 
   int ncount = 0;

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -144,7 +144,7 @@ void TiogaSTKIface::execute()
   }
 
   // Synchronize IBLANK data for shared nodes
-  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<int>(
           stk::topology::NODE_RANK, "iblank");
   std::vector<const stk::mesh::FieldBase*> pvec{ibf};
   stk::mesh::copy_owned_to_shared(bulk_, pvec);
@@ -280,9 +280,9 @@ void TiogaSTKIface::update_fringe_info()
   // Before we begin ensure that we have cleaned up oversetInfoVec
   ThrowAssert(osetInfo.size() == 0);
 
-  VectorFieldType *coords = meta_.get_field<VectorFieldType>
+  VectorFieldType *coords = meta_.get_field<double>
     (stk::topology::NODE_RANK, realm.get_coordinates_name());
-  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<int>(
           stk::topology::NODE_RANK, "iblank");
   int nbadnodes = 0;
 
@@ -389,7 +389,7 @@ void TiogaSTKIface::update_fringe_info()
 void
 TiogaSTKIface::get_receptor_info()
 {
-  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<int>(
     stk::topology::NODE_RANK, "iblank");
 
   std::vector<unsigned long> nodesToReset;
@@ -505,7 +505,7 @@ TiogaSTKIface::populate_overset_info()
   // Ensure that the oversetInfoVec has been cleared out
   ThrowAssert(osetInfo.size() == 0);
 
-  VectorFieldType *coords = meta_.get_field<VectorFieldType>
+  VectorFieldType *coords = meta_.get_field<double>
     (stk::topology::NODE_RANK, realm.get_coordinates_name());
 
   size_t numReceptors = receptorIDs_.size();

--- a/src/pmr/AssembleRadTransEdgeSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransEdgeSolverAlgorithm.C
@@ -52,14 +52,14 @@ AssembleRadTransEdgeSolverAlgorithm::AssembleRadTransEdgeSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
   // residual contribution
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  absorption_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "absorption_coefficient");
-  scattering_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
-  scalarFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux");
-  radiationSource_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "radiation_source");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  absorption_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "absorption_coefficient");
+  scattering_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
+  scalarFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "scalar_flux");
+  radiationSource_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "radiation_source");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/pmr/AssembleRadTransEdgeUpwindSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransEdgeUpwindSolverAlgorithm.C
@@ -46,7 +46,7 @@ AssembleRadTransEdgeUpwindSolverAlgorithm::AssembleRadTransEdgeUpwindSolverAlgor
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  edgeAreaVec_ = meta_data.get_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector");
+  edgeAreaVec_ = meta_data.get_field<double>(stk::topology::EDGE_RANK, "edge_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/pmr/AssembleRadTransWallSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransWallSolverAlgorithm.C
@@ -49,8 +49,8 @@ AssembleRadTransWallSolverAlgorithm::AssembleRadTransWallSolverAlgorithm(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  bcIntensity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity_bc");
-  exposedAreaVec_ = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  bcIntensity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "intensity_bc");
+  exposedAreaVec_ = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 }
 
 //--------------------------------------------------------------------------

--- a/src/pmr/RadTransAbsorptionBlackBodyElemKernel.C
+++ b/src/pmr/RadTransAbsorptionBlackBodyElemKernel.C
@@ -33,10 +33,10 @@ RadTransAbsorptionBlackBodyElemKernel<AlgTraits>::RadTransAbsorptionBlackBodyEle
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  intensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity");
-  absorption_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "absorption_coefficient");
-  scattering_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
-  radiationSource_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "radiation_source");
+  intensity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "intensity");
+  absorption_ = metaData.get_field<double>(stk::topology::NODE_RANK, "absorption_coefficient");
+  scattering_ = metaData.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
+  radiationSource_ = metaData.get_field<double>(stk::topology::NODE_RANK, "radiation_source");
   
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/pmr/RadTransAdvectionSUCVElemKernel.C
+++ b/src/pmr/RadTransAdvectionSUCVElemKernel.C
@@ -41,14 +41,13 @@ RadTransAdvectionSUCVElemKernel<AlgTraits>::RadTransAdvectionSUCVElemKernel(
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  intensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity");
-  absorption_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "absorption_coefficient");
-  scattering_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
-  scalarFlux_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux");
-  radiationSource_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "radiation_source");
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  intensity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "intensity");
+  absorption_ = metaData.get_field<double>(stk::topology::NODE_RANK, "absorption_coefficient");
+  scattering_ = metaData.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
+  scalarFlux_ = metaData.get_field<double>(stk::topology::NODE_RANK, "scalar_flux");
+  radiationSource_ = metaData.get_field<double>(stk::topology::NODE_RANK, "radiation_source");
+  dualNodalVolume_ = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
   
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);

--- a/src/pmr/RadTransBlackBodyNodeSuppAlg.C
+++ b/src/pmr/RadTransBlackBodyNodeSuppAlg.C
@@ -43,10 +43,10 @@ RadTransBlackBodyNodeSuppAlg::RadTransBlackBodyNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  absorption_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "absorption_coefficient");
-  scattering_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
-  radiationSource_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "radiation_source");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  absorption_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "absorption_coefficient");
+  scattering_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
+  radiationSource_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "radiation_source");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/pmr/RadTransIsoScatteringNodeSuppAlg.C
+++ b/src/pmr/RadTransIsoScatteringNodeSuppAlg.C
@@ -42,9 +42,9 @@ RadTransIsoScatteringNodeSuppAlg::RadTransIsoScatteringNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarFlux_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux");
-  scattering_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  scalarFlux_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "scalar_flux");
+  scattering_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/pmr/RadTransIsotropicScatteringElemKernel.C
+++ b/src/pmr/RadTransIsotropicScatteringElemKernel.C
@@ -34,8 +34,8 @@ RadTransIsotropicScatteringElemKernel<AlgTraits>::RadTransIsotropicScatteringEle
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  scalarFlux_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux");
-  scattering_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient");
+  scalarFlux_ = metaData.get_field<double>(stk::topology::NODE_RANK, "scalar_flux");
+  scattering_ = metaData.get_field<double>(stk::topology::NODE_RANK, "scattering_coefficient");
  
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 

--- a/src/pmr/RadTransWallElemKernel.C
+++ b/src/pmr/RadTransWallElemKernel.C
@@ -34,9 +34,9 @@ RadTransWallElemKernel<BcAlgTraits>::RadTransWallElemKernel(
  {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  bcIntensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity_bc");
-  intensity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  bcIntensity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "intensity_bc");
+  intensity_ = metaData.get_field<double>(stk::topology::NODE_RANK, "intensity");
+  exposedAreaVec_ = metaData.get_field<double>(metaData.side_rank(), "exposed_area_vector");
   
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
  

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -389,7 +389,7 @@ RadiativeTransportEquationSystem::register_nodal_fields(
   const int nDim = meta_data.spatial_dimension();
 
   // register all number of ordinates intensity; reserve intensity_ for "curent"
-  intensity_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity"));
+  intensity_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "intensity"));
   stk::mesh::put_field_on_mesh(*intensity_, *part, nullptr);
 
   // may not want all of these at production time...
@@ -398,53 +398,55 @@ RadiativeTransportEquationSystem::register_nodal_fields(
     ss << k;
     const std::string incrementName = ss.str();
     const std::string theName = "intensity_" + incrementName;
-    ScalarFieldType *intensityK = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, theName));
+    ScalarFieldType *intensityK = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, theName));
     stk::mesh::put_field_on_mesh(*intensityK, *part, nullptr);
   }
 
   // delta solution for linear solver
-  iTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "iTmp"));
+  iTmp_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "iTmp"));
   stk::mesh::put_field_on_mesh(*iTmp_, *part, nullptr);
 
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume"));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
 
-  coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
+  coordinates_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*coordinates_, stk::io::FieldOutputType::VECTOR_3D);
 
-  temperature_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature"));
+  temperature_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature"));
   stk::mesh::put_field_on_mesh(*temperature_, *part, nullptr);
 
-  radiativeHeatFlux_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "radiative_heat_flux"));
+  radiativeHeatFlux_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "radiative_heat_flux"));
   stk::mesh::put_field_on_mesh(*radiativeHeatFlux_, *part, nDim, nullptr);
+  stk::io::set_field_output_type(*radiativeHeatFlux_, stk::io::FieldOutputType::VECTOR_3D);
 
-  divRadiativeHeatFlux_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux"));
+  divRadiativeHeatFlux_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux"));
   stk::mesh::put_field_on_mesh(*divRadiativeHeatFlux_, *part, nullptr);
   realm_.augment_restart_variable_list(divRadiativeHeatFlux_->name());
 
-  divRadiativeHeatFluxLin_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin"));
+  divRadiativeHeatFluxLin_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "div_radiative_heat_flux_lin"));
   stk::mesh::put_field_on_mesh(*divRadiativeHeatFluxLin_, *part, nullptr);
   realm_.augment_restart_variable_list(divRadiativeHeatFluxLin_->name());
   
-  radiationSource_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "radiation_source"));
+  radiationSource_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "radiation_source"));
   stk::mesh::put_field_on_mesh(*radiationSource_, *part, nullptr);
 
-  scalarFlux_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux"));
+  scalarFlux_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scalar_flux"));
   stk::mesh::put_field_on_mesh(*scalarFlux_, *part, nullptr);
 
   // for non-linear residual
-  scalarFluxOld_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_flux_old"));
+  scalarFluxOld_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scalar_flux_old"));
   stk::mesh::put_field_on_mesh(*scalarFluxOld_, *part, nullptr);
 
   // props; register and push
-  absorptionCoeff_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "absorption_coefficient"));
+  absorptionCoeff_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "absorption_coefficient"));
   stk::mesh::put_field_on_mesh(*absorptionCoeff_, *part, nullptr);
   // possibly provided by another coupling mechanism; if so, do not push to propery evaluation
   if (!externalCoupling_)
     realm_.augment_property_map(ABSORBTION_COEFF_ID, absorptionCoeff_);
 
   // always register, however, do not make the user provide a value (default to zero)
-  scatteringCoeff_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scattering_coefficient"));
+  scatteringCoeff_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "scattering_coefficient"));
   stk::mesh::put_field_on_mesh(*scatteringCoeff_, *part, nullptr);
   if ( activateScattering_ )
     realm_.augment_property_map(SCATTERING_COEFF_ID, scatteringCoeff_);
@@ -466,8 +468,9 @@ RadiativeTransportEquationSystem::register_edge_fields(
   //====================================================
   if ( realm_.realmUsesEdges_ ) {
     const int nDim = meta_data.spatial_dimension();
-    edgeAreaVec_ = &(meta_data.declare_field<VectorFieldType>(stk::topology::EDGE_RANK, "edge_area_vector"));
+    edgeAreaVec_ = &(meta_data.declare_field<double>(stk::topology::EDGE_RANK, "edge_area_vector"));
     stk::mesh::put_field_on_mesh(*edgeAreaVec_, *part, nDim, nullptr);
+    stk::io::set_field_output_type(*edgeAreaVec_, stk::io::FieldOutputType::VECTOR_3D);
   }
 
 }
@@ -599,26 +602,26 @@ RadiativeTransportEquationSystem::register_wall_bc(
     const bool isInterface = userData.isInterface_;
 
     // register germane fields (boundary data)
-    intensityBc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "intensity_bc"));
+    intensityBc_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "intensity_bc"));
     stk::mesh::put_field_on_mesh(*intensityBc_, *part, nullptr);
 
-    emissivity_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "emissivity"));
+    emissivity_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "emissivity"));
     stk::mesh::put_field_on_mesh(*emissivity_, *part, nullptr);
 
-    transmissivity_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "transmissivity"));
+    transmissivity_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "transmissivity"));
     stk::mesh::put_field_on_mesh(*transmissivity_, *part, nullptr);
 
-    environmentalT_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "environmental_temperature"));
+    environmentalT_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "environmental_temperature"));
     stk::mesh::put_field_on_mesh(*environmentalT_, *part, nullptr);
 
-    irradiation_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "irradiation"));
+    irradiation_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "irradiation"));
     stk::mesh::put_field_on_mesh(*irradiation_, *part, nullptr);
     realm_.augment_restart_variable_list(irradiation_->name());
     
-    bcTemperature_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature_bc"));
+    bcTemperature_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "temperature_bc"));
     stk::mesh::put_field_on_mesh(*bcTemperature_, *part, nullptr);
 
-    assembledBoundaryArea_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "assembled_boundary_area"));
+    assembledBoundaryArea_ = &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "assembled_boundary_area"));
     stk::mesh::put_field_on_mesh(*assembledBoundaryArea_, *part, nullptr);
 
     // interior temperature is not over written by boundary value; push to bcTemperature_
@@ -758,7 +761,7 @@ RadiativeTransportEquationSystem::set_current_ordinate_info(
   const std::string theName = "intensity_" + incrementName;
 
   // advertise current pointer
-  currentIntensity_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, theName);
+  currentIntensity_ = meta_data.get_field<double>(stk::topology::NODE_RANK, theName);
 
   // copy intensity_k -> intensity_
   copy_ordinate_intensity(*currentIntensity_, *intensity_);
@@ -994,7 +997,7 @@ RadiativeTransportEquationSystem::initialize_intensity()
      ss << k;
      const std::string incrementName = ss.str();
      const std::string theName = "intensity_" + incrementName;
-     ScalarFieldType *kthIntensity = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, theName);
+     ScalarFieldType *kthIntensity = meta_data.get_field<double>(stk::topology::NODE_RANK, theName);
      copy_ordinate_intensity(*intensity_, *kthIntensity);
    }
 
@@ -1158,7 +1161,7 @@ RadiativeTransportEquationSystem::assemble_boundary_area()
 
   const int nDim = meta_data.spatial_dimension();
 
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // zero all nodes for assemble boundary area
   stk::mesh::Selector s_all_nodes_bc
@@ -1288,7 +1291,7 @@ RadiativeTransportEquationSystem::assemble_irradiation()
 
   const int nDim = meta_data.spatial_dimension();
 
-  GenericFieldType *exposedAreaVec = meta_data.get_field<GenericFieldType>(meta_data.side_rank(), "exposed_area_vector");
+  GenericFieldType *exposedAreaVec = meta_data.get_field<double>(meta_data.side_rank(), "exposed_area_vector");
 
   // current weights
   double weight = currentWeight_;

--- a/src/property_evaluator/EnthalpyPropertyEvaluator.C
+++ b/src/property_evaluator/EnthalpyPropertyEvaluator.C
@@ -119,7 +119,7 @@ EnthalpyTYkPropertyEvaluator::EnthalpyTYkPropertyEvaluator(
     massFraction_(NULL)
 {
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 }
 
 //--------------------------------------------------------------------------
@@ -231,7 +231,7 @@ EnthalpyConstCpkPropertyEvaluator::EnthalpyConstCpkPropertyEvaluator(
     massFraction_(NULL)
 {
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 
   // save off Cp_k as vector
   cpVec_.resize(cpVecSize_);

--- a/src/property_evaluator/HDF5TablePropAlgorithm.C
+++ b/src/property_evaluator/HDF5TablePropAlgorithm.C
@@ -47,7 +47,7 @@ HDF5TablePropAlgorithm::HDF5TablePropAlgorithm(
 
   indVar_.resize(indVarSize_);
   for ( size_t k = 0; k < indVarSize_; ++k) {
-    ScalarFieldType *indVar = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, indVarNameVec[k]);
+    ScalarFieldType *indVar = meta_data.get_field<double>(stk::topology::NODE_RANK, indVarNameVec[k]);
     if ( NULL == indVar ) {
       throw std::runtime_error("HDF5TablePropAlgorithm: independent variable not registered:");
     }

--- a/src/property_evaluator/IdealGasPropertyEvaluator.C
+++ b/src/property_evaluator/IdealGasPropertyEvaluator.C
@@ -95,7 +95,7 @@ IdealGasPrefTYkPropertyEvaluator::IdealGasPrefTYkPropertyEvaluator(
   }
 
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 }
  
 //--------------------------------------------------------------------------
@@ -156,7 +156,7 @@ IdealGasPTYkrefPropertyEvaluator::IdealGasPTYkrefPropertyEvaluator(
 {
 
   // save off mass fraction field
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  pressure_ = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
 
   // compute mixture mw
   double sum = 0.0;
@@ -219,7 +219,7 @@ IdealGasPrefTrefYkPropertyEvaluator::IdealGasPrefTrefYkPropertyEvaluator(
   }
 
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 
 }
  

--- a/src/property_evaluator/InverseDualVolumePropAlgorithm.C
+++ b/src/property_evaluator/InverseDualVolumePropAlgorithm.C
@@ -30,7 +30,7 @@ InverseDualVolumePropAlgorithm::InverseDualVolumePropAlgorithm(
 {
   // extract dual volume
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 InverseDualVolumePropAlgorithm::~InverseDualVolumePropAlgorithm() {

--- a/src/property_evaluator/SpecificHeatPropertyEvaluator.C
+++ b/src/property_evaluator/SpecificHeatPropertyEvaluator.C
@@ -118,7 +118,7 @@ SpecificHeatTYkPropertyEvaluator::SpecificHeatTYkPropertyEvaluator(
     massFraction_(NULL)
 {
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 
 }
 
@@ -190,7 +190,7 @@ SpecificHeatConstCpkPropertyEvaluator::SpecificHeatConstCpkPropertyEvaluator(
     massFraction_(NULL)
 {
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 
   // save off Cp_k as vector
   cpVec_.resize(cpVecSize_);

--- a/src/property_evaluator/SutherlandsPropertyEvaluator.C
+++ b/src/property_evaluator/SutherlandsPropertyEvaluator.C
@@ -196,7 +196,7 @@ SutherlandsYkPropertyEvaluator::SutherlandsYkPropertyEvaluator(
     massFraction_(NULL)
 { 
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 }
 
 //--------------------------------------------------------------------------
@@ -250,7 +250,7 @@ SutherlandsYkTrefPropertyEvaluator::SutherlandsYkTrefPropertyEvaluator(
     tRef_(tRef)
 {  
   // save off mass fraction field
-  massFraction_ = metaData.get_field<GenericFieldType>(stk::topology::NODE_RANK, "mass_fraction");
+  massFraction_ = metaData.get_field<double>(stk::topology::NODE_RANK, "mass_fraction");
 }
 
 //--------------------------------------------------------------------------

--- a/src/property_evaluator/TemperaturePropAlgorithm.C
+++ b/src/property_evaluator/TemperaturePropAlgorithm.C
@@ -34,7 +34,7 @@ TemperaturePropAlgorithm::TemperaturePropAlgorithm(
 {
   // extract temperature field
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  temperature_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, tempName);
+  temperature_ = meta_data.get_field<double>(stk::topology::NODE_RANK, tempName);
   if ( NULL == temperature_ ) {
     throw std::runtime_error("Realm::setup_property: TemperaturePropAlgorithm requires temperature/bc:");
   }

--- a/src/user_functions/BoussinesqNonIsoEnthalpySrcNodeSuppAlg.C
+++ b/src/user_functions/BoussinesqNonIsoEnthalpySrcNodeSuppAlg.C
@@ -37,8 +37,8 @@ BoussinesqNonIsoEnthalpySrcNodeSuppAlg::BoussinesqNonIsoEnthalpySrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/BoussinesqNonIsoMomentumSrcNodeSuppAlg.C
+++ b/src/user_functions/BoussinesqNonIsoMomentumSrcNodeSuppAlg.C
@@ -40,8 +40,8 @@ BoussinesqNonIsoMomentumSrcNodeSuppAlg::BoussinesqNonIsoMomentumSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // extract user parameters from solution options
   gravity = realm_.solutionOptions_->gravity_;

--- a/src/user_functions/SteadyTaylorVortexContinuitySrcElemKernel.C
+++ b/src/user_functions/SteadyTaylorVortexContinuitySrcElemKernel.C
@@ -46,8 +46,7 @@ SteadyTaylorVortexContinuitySrcElemKernel<AlgTraits>::SteadyTaylorVortexContinui
     projTimeScale_(1.0)
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);

--- a/src/user_functions/SteadyTaylorVortexMomentumSrcElemKernel.C
+++ b/src/user_functions/SteadyTaylorVortexMomentumSrcElemKernel.C
@@ -38,8 +38,7 @@ SteadyTaylorVortexMomentumSrcElemKernel<AlgTraits>::SteadyTaylorVortexMomentumSr
     pi_(acos(-1.0))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);

--- a/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
@@ -38,8 +38,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::SteadyThermal3dContactSrcElemKer
     pi_(std::acos(-1.0))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = metaData.get_field<double>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);

--- a/src/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.C
+++ b/src/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.C
@@ -40,8 +40,8 @@ SteadyThermalContact3DSrcNodeSuppAlg::SteadyThermalContact3DSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/SteadyThermalContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermalContactSrcElemSuppAlg.C
@@ -43,7 +43,7 @@ SteadyThermalContactSrcElemSuppAlg::SteadyThermalContactSrcElemSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // scratch vecs
   scvCoords_.resize(nDim_);

--- a/src/user_functions/SteadyThermalContactSrcNodeSuppAlg.C
+++ b/src/user_functions/SteadyThermalContactSrcNodeSuppAlg.C
@@ -40,8 +40,8 @@ SteadyThermalContactSrcNodeSuppAlg::SteadyThermalContactSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/VariableDensityContinuitySrcElemSuppAlg.C
+++ b/src/user_functions/VariableDensityContinuitySrcElemSuppAlg.C
@@ -49,7 +49,7 @@ VariableDensityContinuitySrcElemSuppAlg::VariableDensityContinuitySrcElemSuppAlg
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // scratch vecs
   scvCoords_.resize(nDim_);

--- a/src/user_functions/VariableDensityContinuitySrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityContinuitySrcNodeSuppAlg.C
@@ -47,8 +47,8 @@ VariableDensityContinuitySrcNodeSuppAlg::VariableDensityContinuitySrcNodeSuppAlg
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/VariableDensityMixFracSrcElemSuppAlg.C
+++ b/src/user_functions/VariableDensityMixFracSrcElemSuppAlg.C
@@ -51,7 +51,7 @@ VariableDensityMixFracSrcElemSuppAlg::VariableDensityMixFracSrcElemSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // scratch vecs
   scvCoords_.resize(nDim_);

--- a/src/user_functions/VariableDensityMixFracSrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityMixFracSrcNodeSuppAlg.C
@@ -49,8 +49,8 @@ VariableDensityMixFracSrcNodeSuppAlg::VariableDensityMixFracSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/VariableDensityMomentumSrcElemSuppAlg.C
+++ b/src/user_functions/VariableDensityMomentumSrcElemSuppAlg.C
@@ -56,7 +56,7 @@ VariableDensityMomentumSrcElemSuppAlg::VariableDensityMomentumSrcElemSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
  
   // scratch vecs
   scvCoords_.resize(nDim_);

--- a/src/user_functions/VariableDensityMomentumSrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityMomentumSrcNodeSuppAlg.C
@@ -54,8 +54,8 @@ VariableDensityMomentumSrcNodeSuppAlg::VariableDensityMomentumSrcNodeSuppAlg(
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // internal source
   srcXi_.resize(nDim_);

--- a/src/user_functions/VariableDensityNonIsoContinuitySrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityNonIsoContinuitySrcNodeSuppAlg.C
@@ -51,8 +51,8 @@ VariableDensityNonIsoContinuitySrcNodeSuppAlg::VariableDensityNonIsoContinuitySr
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/VariableDensityNonIsoEnthalpySrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityNonIsoEnthalpySrcNodeSuppAlg.C
@@ -51,8 +51,8 @@ VariableDensityNonIsoEnthalpySrcNodeSuppAlg::VariableDensityNonIsoEnthalpySrcNod
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 }
 
 //--------------------------------------------------------------------------

--- a/src/user_functions/VariableDensityNonIsoMomentumSrcNodeSuppAlg.C
+++ b/src/user_functions/VariableDensityNonIsoMomentumSrcNodeSuppAlg.C
@@ -57,8 +57,8 @@ VariableDensityNonIsoMomentumSrcNodeSuppAlg::VariableDensityNonIsoMomentumSrcNod
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  coordinates_ = meta_data.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
   // internal source
   srcXi_.resize(nDim_);

--- a/unit_tests/UnitTest1ElemCoordCheck.C
+++ b/unit_tests/UnitTest1ElemCoordCheck.C
@@ -22,8 +22,8 @@ unsigned count_locally_owned_elems(const stk::mesh::BulkData& bulk)
 
 void verify_elems_are_unit_cubes(const stk::mesh::BulkData & bulk)
 {
-    typedef stk::mesh::Field<double,stk::mesh::Cartesian> CoordFieldType;
-    CoordFieldType* coordField = bulk.mesh_meta_data().get_field<CoordFieldType>(stk::topology::NODE_RANK, "coordinates");
+    typedef stk::mesh::Field<double> CoordFieldType;
+    CoordFieldType* coordField = bulk.mesh_meta_data().get_field<double>(stk::topology::NODE_RANK, "coordinates");
     EXPECT_TRUE(coordField != nullptr);
 
     stk::mesh::EntityVector elems;
@@ -62,6 +62,7 @@ TEST(Basic, CheckCoords1Elem)
     stk::mesh::MeshBuilder meshBuilder(comm);
     meshBuilder.set_spatial_dimension(spatialDimension);
     auto bulk = meshBuilder.create();
+    bulk->mesh_meta_data().use_simple_fields();
 
     unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
 

--- a/unit_tests/UnitTestHex27FaceNodeOrdering.C
+++ b/unit_tests/UnitTestHex27FaceNodeOrdering.C
@@ -97,6 +97,7 @@ TEST(Hex27,creation)
   stk::mesh::MeshBuilder meshBuilder(comm);
   meshBuilder.set_spatial_dimension(spatialDimension);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEX_27);
   check_Hex27_creation(*bulk);
@@ -113,6 +114,7 @@ TEST(Hex27, face_node_ordering)
   stk::mesh::MeshBuilder meshBuilder(comm);
   meshBuilder.set_spatial_dimension(spatialDimension);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEX_27);
   check_Hex27_face_ip_node_ordering(*bulk);

--- a/unit_tests/UnitTestHexMasterElements.C
+++ b/unit_tests/UnitTestHexMasterElements.C
@@ -243,6 +243,7 @@ protected:
       meshBuilder.set_spatial_dimension(spatialDimension);
       bulk = meshBuilder.create();
       meta = &bulk->mesh_meta_data();
+      meta->use_simple_fields();
     }
 
     void setup_poly_order_1_hex_8() {

--- a/unit_tests/UnitTestHexSCVDeterminant.C
+++ b/unit_tests/UnitTestHexSCVDeterminant.C
@@ -28,8 +28,8 @@ namespace {
 
 void check_HexSCV_determinant(const stk::mesh::BulkData& bulk)
 {
-    typedef stk::mesh::Field<double,stk::mesh::Cartesian> CoordFieldType;
-    CoordFieldType* coordField = bulk.mesh_meta_data().get_field<CoordFieldType>(stk::topology::NODE_RANK, "coordinates");
+    typedef stk::mesh::Field<double> CoordFieldType;
+    CoordFieldType* coordField = bulk.mesh_meta_data().get_field<double>(stk::topology::NODE_RANK, "coordinates");
     EXPECT_TRUE(coordField != nullptr);
 
     stk::mesh::EntityVector elems;
@@ -79,6 +79,7 @@ TEST(HexSCV, determinant)
     stk::mesh::MeshBuilder meshBuilder(comm);
     meshBuilder.set_spatial_dimension(spatialDimension);
     auto bulk = meshBuilder.create();
+    bulk->mesh_meta_data().use_simple_fields();
 
     unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
 
@@ -93,6 +94,7 @@ TEST(HexSCV, grandyvol)
   stk::mesh::MeshBuilder meshBuilder(comm);
   meshBuilder.set_spatial_dimension(spatialDimension);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
   const auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -33,6 +33,7 @@ public:
     meshBuilder.set_spatial_dimension(AlgTraits::nDim_);
     bulk_ = meshBuilder.create();
     meta_ = &bulk_->mesh_meta_data();
+    meta_->use_simple_fields();
     if (doInit)
       fill_mesh_and_init_data(doPerturb);
   }

--- a/unit_tests/UnitTestKokkosMEBC.h
+++ b/unit_tests/UnitTestKokkosMEBC.h
@@ -34,6 +34,7 @@ public:
      meshBuilder.set_spatial_dimension(BcAlgTraits::nDim_);
      bulk_ = meshBuilder.create();
      meta_ = &bulk_->mesh_meta_data();
+     meta_->use_simple_fields();
      if (doInit)
        fill_mesh_and_init_data(doPerturb);
    }

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -21,7 +21,7 @@
 
 namespace {
 
-using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
+using VectorFieldType = stk::mesh::Field<double>;
 //-------------------------------------------------------------------------
 double linear_scalar_value(int dim, double a, const double* b, const double* x)
 {
@@ -512,6 +512,7 @@ protected:
       meshBuilder.set_spatial_dimension(topo.dimension());
       bulk = meshBuilder.create();
       meta = &bulk->mesh_meta_data();
+      meta->use_simple_fields();
       elem = unit_test_utils::create_one_reference_element(*bulk, topo);
       meSS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
       meSV = sierra::nalu::MasterElementRepo::get_volume_master_element(topo);

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -45,7 +45,7 @@ calculate_metric_tensor(sierra::nalu::MasterElement& me, const std::vector<doubl
   return {contravariant_metric_tensor, covariant_metric_tensor};
 }
 
-using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
+using VectorFieldType = stk::mesh::Field<double>;
 
 void test_metric_for_topo_2D(stk::topology topo, double tol) {
   int dim = topo.dimension();
@@ -54,6 +54,7 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(dim);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto* mescs = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
@@ -102,6 +103,7 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(dim);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto* mescs = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
@@ -198,6 +200,7 @@ TEST(MetricTensorNGP, hex27)
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(dim);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   sierra::nalu::Hex27SCS mescs;

--- a/unit_tests/UnitTestMovingAverage.C
+++ b/unit_tests/UnitTestMovingAverage.C
@@ -35,10 +35,11 @@ public:
     meshBuilder.set_spatial_dimension(numberOfDimensions);
     bulk_ = meshBuilder.create();
     auto& meta_ = bulk_->mesh_meta_data();
+    meta_.use_simple_fields();
 
-    temperature_ = &meta_.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
+    temperature_ = &meta_.declare_field<double>(stk::topology::NODE_RANK, "temperature");
 
-    raTemperature_ = &meta_.declare_field<ScalarFieldType>(
+    raTemperature_ = &meta_.declare_field<double>(
         stk::topology::NODE_RANK,
         sierra::nalu::MovingAveragePostProcessor::filtered_field_name("temperature")
     );

--- a/unit_tests/UnitTestNGPMasterElements.C
+++ b/unit_tests/UnitTestNGPMasterElements.C
@@ -22,7 +22,7 @@
 #include <UnitTestUtils.h>
 
 using clock_type = std::chrono::steady_clock;
-using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
+using VectorFieldType = stk::mesh::Field<double>;
 //-------------------------------------------------------------------------
 
 namespace {
@@ -39,6 +39,7 @@ TEST(MasterElementFunctions, generic_grad_op_3d_hex_27)
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(3);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
   const auto* node_rels = bulk->begin_nodes(elem);
@@ -191,6 +192,7 @@ TEST(Hex27SCV, detj)
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(3);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
   const auto* node_rels = bulk->begin_nodes(elem);
@@ -272,6 +274,7 @@ TEST(Hex27SCS, area_vec)
   stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
   meshBuilder.set_spatial_dimension(3);
   auto bulk = meshBuilder.create();
+  bulk->mesh_meta_data().use_simple_fields();
 
   stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
   const auto* node_rels = bulk->begin_nodes(elem);

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -157,6 +157,7 @@ NaluTest::create_realm(const YAML::Node& realm_node, const std::string realm_typ
   stk::mesh::MeshBuilder meshBuilder(comm_);
   meshBuilder.set_spatial_dimension(spatialDim_);
   realm->bulkData_ = meshBuilder.create();
+  realm->bulkData_->mesh_meta_data().use_simple_fields();
 
   sim_.realms_->realmVector_.push_back(realm);
 
@@ -194,7 +195,7 @@ TEST(NaluMock, test_nalu_mock)
 
   // 4. Create necessary fields...
   ScalarFieldType& maxLengthScaleField =
-      realm.meta_data().declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "sst_max_length_scale");
+      realm.meta_data().declare_field<double>(stk::topology::NODE_RANK, "sst_max_length_scale");
   double zero = 0.0;
   stk::mesh::put_field_on_mesh(maxLengthScaleField, realm.meta_data().universal_part(), &zero);
 

--- a/unit_tests/UnitTestSideIsInElement.C
+++ b/unit_tests/UnitTestSideIsInElement.C
@@ -25,7 +25,7 @@
 
 namespace
 {
-  using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
+  using VectorFieldType = stk::mesh::Field<double>;
 
   void randomly_perturb_element_coords(
     std::mt19937& rng,
@@ -74,6 +74,7 @@ namespace
       meshBuilder.set_spatial_dimension(dim);
       auto bulk = meshBuilder.create();
       auto& meta = bulk->mesh_meta_data();
+      meta.use_simple_fields();
 
       auto elem = unit_test_utils::create_one_reference_element(*bulk, topo);
       const VectorFieldType& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());

--- a/unit_tests/UnitTestSidePCoords.C
+++ b/unit_tests/UnitTestSidePCoords.C
@@ -39,12 +39,13 @@ namespace
     meshBuilder.set_spatial_dimension(dim);
     auto bulk = meshBuilder.create();
     auto& meta = bulk->mesh_meta_data();
+    meta.use_simple_fields();
 
     auto elem = unit_test_utils::create_one_reference_element(*bulk, topo);
     const stk::mesh::Entity* elem_node_rels = bulk->begin_nodes(elem);
     auto* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
-    using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
+    using VectorFieldType = stk::mesh::Field<double>;
     const VectorFieldType& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
 
     // perturb the reference element

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -150,12 +150,12 @@ private:
 
 TEST_F(Hex8Mesh, supp_alg_data_sharing)
 {
-    ScalarFieldType& nodalScalarField = meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
-    VectorFieldType& nodalVectorField = meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "nodalVectorField");
-    TensorFieldType& nodalTensorField = meta->declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
-    ScalarFieldType& elemScalarField = meta->declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
-    VectorFieldType& elemVectorField = meta->declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemVectorField");
-    TensorFieldType& elemTensorField = meta->declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+    ScalarFieldType& nodalScalarField = meta->declare_field<double>(stk::topology::NODE_RANK, "nodalScalarField");
+    VectorFieldType& nodalVectorField = meta->declare_field<double>(stk::topology::NODE_RANK, "nodalVectorField");
+    TensorFieldType& nodalTensorField = meta->declare_field<double>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta->declare_field<double>(stk::topology::ELEM_RANK, "elemScalarField");
+    VectorFieldType& elemVectorField = meta->declare_field<double>(stk::topology::ELEM_RANK, "elemVectorField");
+    TensorFieldType& elemTensorField = meta->declare_field<double>(stk::topology::ELEM_RANK, "elemTensorField");
 
     const stk::mesh::Part& wholemesh = meta->universal_part();
 
@@ -187,10 +187,10 @@ TEST_F(Hex8Mesh, supp_alg_data_sharing)
 
 TEST_F(Hex8Mesh, inconsistent_field_requests)
 {
-    ScalarFieldType& nodalScalarField = meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
-    TensorFieldType& nodalTensorField = meta->declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
-    ScalarFieldType& elemScalarField = meta->declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
-    TensorFieldType& elemTensorField = meta->declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+    ScalarFieldType& nodalScalarField = meta->declare_field<double>(stk::topology::NODE_RANK, "nodalScalarField");
+    TensorFieldType& nodalTensorField = meta->declare_field<double>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta->declare_field<double>(stk::topology::ELEM_RANK, "elemScalarField");
+    TensorFieldType& elemTensorField = meta->declare_field<double>(stk::topology::ELEM_RANK, "elemTensorField");
 
     const stk::mesh::Part& wholemesh = meta->universal_part();
 

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -122,10 +122,9 @@ stk::mesh::Entity create_one_element(
    }
 
    // set a coordinate field
-   using vector_field_type = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
-   auto& coordField = meta.declare_field<vector_field_type>(stk::topology::NODE_RANK, "coordinates");
-   stk::mesh::put_field_on_mesh(coordField, block_1, nullptr);
-   stk::mesh::put_field_on_mesh(coordField, stk::mesh::selectUnion(allSurfaces), nullptr);
+   auto& coordField = meta.declare_field<double>(stk::topology::NODE_RANK, "coordinates");
+   stk::mesh::put_field_on_mesh(coordField, block_1, meta.spatial_dimension(), nullptr);
+   stk::mesh::put_field_on_mesh(coordField, stk::mesh::selectUnion(allSurfaces), meta.spatial_dimension(), nullptr);
    meta.set_coordinate_field(&coordField);
    meta.commit();
 

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -24,9 +24,9 @@
 
 typedef stk::mesh::Field<double> IdFieldType;
 typedef stk::mesh::Field<double> ScalarFieldType;
-typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
-typedef stk::mesh::Field<double,stk::mesh::Cartesian,stk::mesh::Cartesian> TensorFieldType;
-typedef stk::mesh::Field<double, stk::mesh::SimpleArrayTag>  GenericFieldType;
+typedef stk::mesh::Field<double> VectorFieldType;
+typedef stk::mesh::Field<double> TensorFieldType;
+typedef stk::mesh::Field<double>  GenericFieldType;
 typedef sierra::nalu::DoubleType DoubleType;
 
 namespace stk { namespace mesh { class FieldBase; } }
@@ -82,23 +82,24 @@ protected:
     meshBuilder.set_spatial_dimension(spatialDimension);
     bulk = meshBuilder.create();
     meta = &bulk->mesh_meta_data();
+    meta->use_simple_fields();
 
-    elemCentroidField = &meta->declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemCentroid");
-    nodalPressureField = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalPressure");
-    discreteLaplacianOfPressure = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "discreteLaplacian");
-    scalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalarQ");
-    diffFluxCoeff = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "diffFluxCoeff");
-    idField = &meta->declare_field<IdFieldType>(stk::topology::NODE_RANK, "idField");
+    elemCentroidField = &meta->declare_field<double>(stk::topology::ELEM_RANK, "elemCentroid");
+    nodalPressureField = &meta->declare_field<double>(stk::topology::NODE_RANK, "nodalPressure");
+    discreteLaplacianOfPressure = &meta->declare_field<double>(stk::topology::NODE_RANK, "discreteLaplacian");
+    scalarQ = &meta->declare_field<double>(stk::topology::NODE_RANK, "scalarQ");
+    diffFluxCoeff = &meta->declare_field<double>(stk::topology::NODE_RANK, "diffFluxCoeff");
+    idField = &meta->declare_field<double>(stk::topology::NODE_RANK, "idField");
 
     stk::mesh::put_field_on_mesh(*elemCentroidField, meta->universal_part(), spatialDimension, (double*)nullptr);
 
     double one = 1.0;
     double zero = 0.0;
-    stk::mesh::put_field_on_mesh(*nodalPressureField, meta->universal_part(), 1, &one);
-    stk::mesh::put_field_on_mesh(*discreteLaplacianOfPressure, meta->universal_part(), 1, &zero);
-    stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), 1, &zero);
-    stk::mesh::put_field_on_mesh(*diffFluxCoeff, meta->universal_part(), 1, &zero);
-    stk::mesh::put_field_on_mesh(*idField, meta->universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*nodalPressureField, meta->universal_part(), &one);
+    stk::mesh::put_field_on_mesh(*discreteLaplacianOfPressure, meta->universal_part(), &zero);
+    stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), &zero);
+    stk::mesh::put_field_on_mesh(*diffFluxCoeff, meta->universal_part(), &zero);
+    stk::mesh::put_field_on_mesh(*idField, meta->universal_part(), nullptr);
   }
 
   ~Hex8Mesh() {}
@@ -146,13 +147,13 @@ class Hex8MeshWithNSOFields : public Hex8Mesh
 protected:
  Hex8MeshWithNSOFields() : Hex8Mesh()
  {
-   massFlowRate = &meta->declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "mass_flow_rate_scs");
-   Gju = &meta->declare_field<GenericFieldType>(stk::topology::NODE_RANK, "Gju", 1);
-   velocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", 3);
-   dpdx = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx", 3);
-   density = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", 3);
-   viscosity = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-   pressure = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+   massFlowRate = &meta->declare_field<double>(stk::topology::ELEM_RANK, "mass_flow_rate_scs");
+   Gju = &meta->declare_field<double>(stk::topology::NODE_RANK, "Gju", 1);
+   velocity = &meta->declare_field<double>(stk::topology::NODE_RANK, "velocity", 3);
+   dpdx = &meta->declare_field<double>(stk::topology::NODE_RANK, "dpdx", 3);
+   density = &meta->declare_field<double>(stk::topology::NODE_RANK, "density", 3);
+   viscosity = &meta->declare_field<double>(stk::topology::NODE_RANK, "viscosity");
+   pressure = &meta->declare_field<double>(stk::topology::NODE_RANK, "pressure");
 
    double one = 1.0;
    double oneVecThree[3] = {one, one, one};
@@ -192,29 +193,30 @@ class Hex8ElementWithBCFields : public ::testing::Test
     meshBuilder.set_spatial_dimension(3);
     bulk = meshBuilder.create();
     meta = &bulk->mesh_meta_data();
+    meta->use_simple_fields();
 
-    velocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-    bcVelocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
-    density = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-    viscosity = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-    bcHeatFlux = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc");
-    specificHeat = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
-    exposedAreaVec = &meta->declare_field<GenericFieldType>(meta->side_rank(), "exposed_area_vector");
-    wallFrictionVelocityBip = &meta->declare_field<GenericFieldType>(meta->side_rank(), "wall_friction_velocity_bip");
-    wallNormalDistanceBip = &meta->declare_field<GenericFieldType>(meta->side_rank(), "wall_normal_distance_bip");
-    bcVelocityOpen = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
-    openMdot = &meta->declare_field<GenericFieldType>(meta->side_rank(), "open_mass_flow_rate");
-    Gjui = &meta->declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
-    scalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_q");
-    bcScalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "bc_scalar_q");
-    Gjq = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "Gjq");
+    velocity = &meta->declare_field<double>(stk::topology::NODE_RANK, "velocity");
+    bcVelocity = &meta->declare_field<double>(stk::topology::NODE_RANK, "wall_velocity_bc");
+    density = &meta->declare_field<double>(stk::topology::NODE_RANK, "density");
+    viscosity = &meta->declare_field<double>(stk::topology::NODE_RANK, "viscosity");
+    bcHeatFlux = &meta->declare_field<double>(stk::topology::NODE_RANK, "heat_flux_bc");
+    specificHeat = &meta->declare_field<double>(stk::topology::NODE_RANK, "specific_heat");
+    exposedAreaVec = &meta->declare_field<double>(meta->side_rank(), "exposed_area_vector");
+    wallFrictionVelocityBip = &meta->declare_field<double>(meta->side_rank(), "wall_friction_velocity_bip");
+    wallNormalDistanceBip = &meta->declare_field<double>(meta->side_rank(), "wall_normal_distance_bip");
+    bcVelocityOpen = &meta->declare_field<double>(stk::topology::NODE_RANK, "open_velocity_bc");
+    openMdot = &meta->declare_field<double>(meta->side_rank(), "open_mass_flow_rate");
+    Gjui = &meta->declare_field<double>(stk::topology::NODE_RANK, "dudx");
+    scalarQ = &meta->declare_field<double>(stk::topology::NODE_RANK, "scalar_q");
+    bcScalarQ = &meta->declare_field<double>(stk::topology::NODE_RANK, "bc_scalar_q");
+    Gjq = &meta->declare_field<double>(stk::topology::NODE_RANK, "Gjq");
 
     stk::mesh::put_field_on_mesh(*velocity, meta->universal_part(), 3, oneVecThree);
     stk::mesh::put_field_on_mesh(*bcVelocity, meta->universal_part(), 3, oneVecThree);
-    stk::mesh::put_field_on_mesh(*density, meta->universal_part(), 1, nullptr);
-    stk::mesh::put_field_on_mesh(*viscosity, meta->universal_part(), 1, &one);
-    stk::mesh::put_field_on_mesh(*bcHeatFlux, meta->universal_part(), 1, nullptr);
-    stk::mesh::put_field_on_mesh(*specificHeat, meta->universal_part(), 1, nullptr);    
+    stk::mesh::put_field_on_mesh(*density, meta->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*viscosity, meta->universal_part(), &one);
+    stk::mesh::put_field_on_mesh(*bcHeatFlux, meta->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*specificHeat, meta->universal_part(), nullptr);
     
     const sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::QUAD_4);
     stk::mesh::put_field_on_mesh(*exposedAreaVec, meta->universal_part(), 3*meFC->numIntPoints_, oneVecTwelve);
@@ -225,8 +227,8 @@ class Hex8ElementWithBCFields : public ::testing::Test
     stk::mesh::put_field_on_mesh(*openMdot, meta->universal_part(), 4, oneVecFour);
     stk::mesh::put_field_on_mesh(*Gjui, meta->universal_part(), 3*3, oneVecNine);
     
-    stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), 1, &one);    
-    stk::mesh::put_field_on_mesh(*bcScalarQ, meta->universal_part(), 1, &one);    
+    stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), &one);
+    stk::mesh::put_field_on_mesh(*bcScalarQ, meta->universal_part(), &one);
     stk::mesh::put_field_on_mesh(*Gjq, meta->universal_part(), 3, oneVecThree);    
     
     unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_8);

--- a/unit_tests/algorithms/UnitTestAlgorithm.C
+++ b/unit_tests/algorithms/UnitTestAlgorithm.C
@@ -42,79 +42,79 @@ TestTurbulenceAlgorithm::declare_fields()
   auto spatialDim = meta.spatial_dimension();
 
   density_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "density"));
   viscosity_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "viscosity"));
   tke_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "turbulent_ke"));
   sdr_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "specific_dissipation_rate"));
   minDistance_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "minimum_distance_to_wall"));
   dudx_ = (
-    &meta.declare_field<GenericFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "dudx"));
   tvisc_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "turbulent_viscosity"));
   maxLengthScale_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "sst_max_length_scale"));
   fOneBlend_ = (
-    &meta.declare_field<ScalarFieldType>(
+    &meta.declare_field<double>(
       stk::topology::NODE_RANK, "sst_f_one_blending"));
   evisc_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "effective_viscosity"));
   evisc_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "effective_viscosity"));
   dualNodalVolume_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "dual_nodal_volume"));
   dkdx_ = (
-     &meta.declare_field<VectorFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "dkdx"));
   dwdx_ = (
-     &meta.declare_field<VectorFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "dwdx"));
   dhdx_ = (
-     &meta.declare_field<VectorFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "dhdx"));
   specificHeat_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "specific_heat"));
   cEps_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "c_epsilon"));
   cmuEps_ = (
-     &meta.declare_field<ScalarFieldType>(
+     &meta.declare_field<double>(
        stk::topology::NODE_RANK, "c_mu_epsilon"));
 
-  stk::mesh::put_field_on_mesh(*density_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*viscosity_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*tke_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*sdr_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*minDistance_, meta.universal_part(), 1, nullptr);
+  stk::mesh::put_field_on_mesh(*density_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*viscosity_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*tke_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*sdr_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*minDistance_, meta.universal_part(), nullptr);
   stk::mesh::put_field_on_mesh(*dudx_, meta.universal_part(), spatialDim*spatialDim, nullptr);
-  stk::mesh::put_field_on_mesh(*tvisc_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*maxLengthScale_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*fOneBlend_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*evisc_, meta.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(*dualNodalVolume_, meta.universal_part(), 1, nullptr);
+  stk::mesh::put_field_on_mesh(*tvisc_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*maxLengthScale_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*fOneBlend_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*evisc_, meta.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*dualNodalVolume_, meta.universal_part(), nullptr);
   stk::mesh::put_field_on_mesh(*dkdx_, meta.universal_part(), spatialDim, nullptr);
   stk::mesh::put_field_on_mesh(*dwdx_, meta.universal_part(), spatialDim, nullptr);
   stk::mesh::put_field_on_mesh(*dhdx_, meta.universal_part(), spatialDim, nullptr);
-  stk::mesh::put_field_on_mesh(*specificHeat_, meta.universal_part(), 1, nullptr);
+  stk::mesh::put_field_on_mesh(*specificHeat_, meta.universal_part(), nullptr);
   const double cEps = realm().get_turb_model_constant(sierra::nalu::TM_cEps);
-  stk::mesh::put_field_on_mesh(*cEps_, meta.universal_part(), 1, &cEps);
+  stk::mesh::put_field_on_mesh(*cEps_, meta.universal_part(), &cEps);
   const double cmuEps = realm().get_turb_model_constant(sierra::nalu::TM_cmuEps);
-  stk::mesh::put_field_on_mesh(*cmuEps_, meta.universal_part(), 1, &cmuEps);
+  stk::mesh::put_field_on_mesh(*cmuEps_, meta.universal_part(), &cmuEps);
 }
 
 void

--- a/unit_tests/algorithms/UnitTestMomentumBoussinesqSrcNodeSuppAlg.C
+++ b/unit_tests/algorithms/UnitTestMomentumBoussinesqSrcNodeSuppAlg.C
@@ -28,11 +28,11 @@ TEST(MomentumBoussinesqSrcNodeSuppAlg, single_value)
   NodeSuppHelper helper;
   auto& meta = helper.realm.meta_data();
 
-  auto& dnv = meta.declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  stk::mesh::put_field_on_mesh(dnv, meta.universal_part(), 1, nullptr);
+  auto& dnv = meta.declare_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  stk::mesh::put_field_on_mesh(dnv, meta.universal_part(), nullptr);
 
-  auto& temperature = meta.declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, "temperature");
-  stk::mesh::put_field_on_mesh(temperature, meta.universal_part(), 1, nullptr);
+  auto& temperature = meta.declare_field<double>(stk::topology::NODE_RANK, "temperature");
+  stk::mesh::put_field_on_mesh(temperature, meta.universal_part(), nullptr);
 
   meta.commit();
 

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -627,7 +627,7 @@ void calc_mass_flow_rate_scs(
     });
 }
 
-void calc_projected_nodal_gradient_interior(
+void calc_scalar_projected_nodal_gradient_interior(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -704,7 +704,7 @@ void calc_projected_nodal_gradient_interior(
   });
 }
 
-void calc_projected_nodal_gradient_interior(
+void calc_vector_projected_nodal_gradient_interior(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -783,7 +783,7 @@ void calc_projected_nodal_gradient_interior(
   });
 }
 
-void calc_projected_nodal_gradient_boundary(
+void calc_scalar_projected_nodal_gradient_boundary(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -855,7 +855,7 @@ void calc_projected_nodal_gradient_boundary(
   });
 }
 
-void calc_projected_nodal_gradient_boundary(
+void calc_vector_projected_nodal_gradient_boundary(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -984,7 +984,7 @@ void calc_dual_nodal_volume(
   });
 }
 
-void calc_projected_nodal_gradient(
+void calc_scalar_projected_nodal_gradient(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -1002,15 +1002,15 @@ void calc_projected_nodal_gradient(
     stk::mesh::parallel_sum(bulk, {&dnv});
   }
 
-  calc_projected_nodal_gradient_interior(bulk, topo, coordinates, dnv, scalarField, gradField);
-  calc_projected_nodal_gradient_boundary(bulk, topo.side_topology(0), coordinates, dnv, scalarField, gradField);
+  calc_scalar_projected_nodal_gradient_interior(bulk, topo, coordinates, dnv, scalarField, gradField);
+  calc_scalar_projected_nodal_gradient_boundary(bulk, topo.side_topology(0), coordinates, dnv, scalarField, gradField);
   if (bulk.parallel_size() > 1) {
     stk::mesh::parallel_sum(bulk, {&gradField});
   }
 
 }
 
-void calc_projected_nodal_gradient(
+void calc_vector_projected_nodal_gradient(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
@@ -1028,8 +1028,8 @@ void calc_projected_nodal_gradient(
   }
 
   stk::mesh::field_fill(0.0, gradField);
-  calc_projected_nodal_gradient_interior(bulk, topo, coordinates, dnv, vectorField, gradField);
-  calc_projected_nodal_gradient_boundary(bulk, topo.side_topology(0), coordinates, dnv, vectorField, gradField);
+  calc_vector_projected_nodal_gradient_interior(bulk, topo, coordinates, dnv, vectorField, gradField);
+  calc_vector_projected_nodal_gradient_boundary(bulk, topo.side_topology(0), coordinates, dnv, vectorField, gradField);
   if (bulk.parallel_size() > 1) {
     stk::mesh::parallel_sum(bulk, {&gradField});
   }


### PR DESCRIPTION
STK Mesh is in the process of simplifying how Fields are registered and managed, to remove a perpetual source of user errors, inconsistency, and confusion.  The change essentially involves removing the extra template parameters beyond the datatype from Fields.  For example, setting up and using a 3-component vector Field used to look like this:

```
  using VectorField = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
  VectorField & field = meta.declare_field<VectorField>(stk::topology::NODE_RANK, "velocity");
  stk::mesh::put_field_on_mesh(field, meta.universal_part(), 3);

  // ... (later retrieval for usage)
  VectorField & field = *meta.get_field<VectorField>(stk::topology::NODE_RANK, "velocity");
```

Now, it looks like this:

```
  using VectorField = stk::mesh::Field<double>;
  VectorField & field = meta.declare_field<double>(stk::topology::NODE_RANK, "velocity");
  stk::mesh::put_field_on_mesh(field, meta.universal_part(), 3);
  stk::io::set_field_output_type(field, "Vector_3D");

  // ... (later retrieval for usage)
  VectorField & field = *meta.get_field<double>(stk::topology::NODE_RANK, "velocity");
```

Notable differences:
  - Fields are now *only* templated on their datatype
  - Sizing is done *only* in the `put_field_on_mesh()` call.  (This was optional and redundant before.)
  - `declare_field()` and `get_field()` functions are *only* templated on the datatype of the Field and not the Field itself.
  - If you care about variable component subscripting in an output Exodus file, call `set_field_output_type()`.  The above example will subscript the Field components as `[_x, _y, _z]`.  If this is omitted, the subscripts will default to `[_1, _2, _3]`.  Scalar Fields are unaffected.

As a migration aid, `MetaData::use_simple_fields()` is called early in construction.  This changes any mistaken use of old-style calls to a run-time error, until the old APIs are eventually deprecated and removed.