### PR TITLE
Minor clean-up on new STK field registration

### DIFF
--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -19,15 +19,15 @@
 namespace sierra{
 namespace nalu{
 
-// define scalar field typedef
+// define scalar field typedef; just for clarity
 typedef stk::mesh::Field<double>  ScalarFieldType;
 typedef stk::mesh::Field<stk::mesh::EntityId> GlobalIdFieldType;
 typedef stk::mesh::Field<int>  ScalarIntFieldType;
 
-// define vector field typedef; however, what is the value of Cartesian?
+// define vector field typedef; just for clarity
 typedef stk::mesh::Field<double>  VectorFieldType;
 
-// define generic
+// define generic; just for clarity
 typedef stk::mesh::Field<double>  GenericFieldType;
 
 // field type for local ids

--- a/src/ExplicitFiltering.C
+++ b/src/ExplicitFiltering.C
@@ -174,7 +174,7 @@ ExplicitFiltering::setup()
   }
 
   // volume for all variables
-  stk::mesh::Field<double> *filter =  &(metaData.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "explicit_filter"));
+  stk::mesh::Field<double> *filter =  &(metaData.declare_field<double>(stk::topology::NODE_RANK, "explicit_filter"));
   stk::mesh::put_field_on_mesh(*filter, stk::mesh::selectUnion(searchParts_), 1, nullptr);
 
   // provide output for the names to be registered under STK (and, therefore, available for IO)
@@ -260,11 +260,11 @@ ExplicitFiltering::execute()
 
   // extract fields
   VectorFieldType *coordinates
-    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+    = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // extract filter
   stk::mesh::Field<double> *explicitFilter 
-    = metaData.get_field<stk::mesh::Field<double> >(stk::topology::NODE_RANK, "explicit_filter");
+    = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_filter");
 
   // zero assembled field(s)
   field_fill( metaData, bulkData, 0.0, *explicitFilter, realm_.get_activate_aura());  
@@ -419,7 +419,7 @@ ExplicitFiltering::populate_candidate_elements()
   const int nDim = metaData.spatial_dimension();
 
   // fields
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // point data structures
   Point minCorner, maxCorner;
@@ -537,7 +537,7 @@ ExplicitFiltering::create_explicit_filter_point_info_map() {
     filterSizeAbstract[2] = filterSize_.z_;
   
   // fields
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *coordinates = metaData.get_field<double>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // define a point that will hold the min/max
   Point minCorner, maxCorner;

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -295,7 +295,6 @@ LowMachEquationSystem::register_nodal_fields(
 
   // add properties; density needs to be a restart field
   const int numStates = realm_.number_of_states();
-  //density_ =  &(meta_data.declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, "density", numStates));
   density_ =  &(meta_data.declare_field<double>(stk::topology::NODE_RANK, "density", numStates));
   stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
   realm_.augment_restart_variable_list("density");


### PR DESCRIPTION
* small things here and there, really. 2d_quad9_helium now back with us again.

Notes:

a) FieldBase... What is that now?

stk::mesh::FieldBase *theField = metaData.get_field(stk::topology::NODE_RANK, fieldName);

vs

stk::mesh::Field<double> *theField = metaData.get_field<double>(stk::topology::NODE_RANK, fieldName);

Does the FieldBase call work since the field was registered elsewhere with a specific type?