### PR TITLE
explicitly filtered residual support

### DIFF
--- a/include/ExplicitFiltering.h
+++ b/include/ExplicitFiltering.h
@@ -37,9 +37,15 @@ struct ExplicitFilteringNames {
   std::string fieldName_;
   std::string expFieldName_;
   int fieldSize_;
+  int fieldStateSize_;
 
-ExplicitFilteringNames(std::string fieldName, std::string expFieldName, int fieldSize) 
-: fieldName_(fieldName), expFieldName_(expFieldName), fieldSize_(fieldSize) {}
+ExplicitFilteringNames(std::string fieldName, std::string expFieldName, int fieldSize, int fieldStateSize) 
+: fieldName_(fieldName), expFieldName_(expFieldName), fieldSize_(fieldSize), fieldStateSize_(fieldStateSize) 
+  {
+    if ( fieldStateSize_ > 3 ) {
+      throw std::runtime_error("ExplicitFiltering::error() Only three state schemes are supported");
+    } 
+  }
 };
 
 struct ExplicitFilteringFields {
@@ -112,6 +118,19 @@ public:
     const int &nodesPerElement,
     const double &elemVolume);
 
+  void compute_scv_residual(
+    const stk::mesh::FieldBase *velocityNp1_,
+    const stk::mesh::FieldBase *velocityN_,
+    const stk::mesh::FieldBase *velocityNm1_,
+    const stk::mesh::FieldBase *densityNp1_,
+    const stk::mesh::FieldBase *densityN_,
+    const stk::mesh::FieldBase *densityNm1_,
+    const stk::mesh::FieldBase *viscosity_,
+    const stk::mesh::FieldBase *pressure_,
+    const stk::mesh::FieldBase *dudx_,
+    const stk::mesh::FieldBase *coordinates_,
+    stk::mesh::FieldBase *residual_);
+
   // hold the realm
   Realm &realm_;
 
@@ -129,12 +148,17 @@ public:
 
   // provide debug output
   bool debugOutput_;
+  
+  // do we normalize by dual nodal volume?
+  bool normalizeResidual_;
 
-  // vector of Names struct
+  // vector of explicit/residual Names struct
   std::vector<ExplicitFilteringNames> explicitFilteringNamesVec_;
+  std::vector<ExplicitFilteringNames> residualNamesVec_;
 
-  // vector of Fields struct
+  // vector of explicit/residual Fields struct
   std::vector<ExplicitFilteringFields> explicitFilteringFieldsVec_;
+  std::vector<ExplicitFilteringFields> residualFieldsVec_;
 
   // vector of elements/poit processor to ghost
   stk::mesh::EntityProcVec elemsToGhost_;

--- a/include/FieldFunctions.h
+++ b/include/FieldFunctions.h
@@ -91,6 +91,15 @@ void field_index_copy(
   const bool auraIsActive,
   const stk::topology::rank_t entityRankValue=stk::topology::NODE_RANK);
 
+// y[i] = y[i]/x
+void field_normalize(
+  const stk::mesh::MetaData & metaData,
+  const stk::mesh::BulkData & bulkData,
+  const stk::mesh::FieldBase & xField,
+  const stk::mesh::FieldBase & yField,
+  const bool auraIsActive,
+  const stk::topology::rank_t entityRankValue=stk::topology::NODE_RANK);
+
 } // namespace nalu
 } // namespace Sierra
 

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -56,6 +56,14 @@ public:
     double *areav,
     double * error );
 
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error );
+
 private:
   void set_interior_info();
 

--- a/reg_tests/test_files/laboratory/2d_quad9_helium/2d_quad9_helium.i
+++ b/reg_tests/test_files/laboratory/2d_quad9_helium/2d_quad9_helium.i
@@ -154,21 +154,64 @@ realms:
       filter_size: [0.05, 0.05]
       debug_output: no
 
-      specifications:
+      explicit_specifications:
 
         - field_name: velocity
           explicit_field_name: explicit_velocity
           field_size: 2
           field_type: node_rank
+          field_state_size: 3
+
+        - field_name: dudx
+          explicit_field_name: explicit_dudx
+          field_size: 4
+          field_type: node_rank
+          field_state_size: 1
+
+        - field_name: pressure
+          explicit_field_name: explicit_pressure
+          field_size: 1
+          field_type: node_rank
+          field_state_size: 1
+
+        - field_name: dpdx
+          explicit_field_name: explicit_dpdx
+          field_size: 2
+          field_type: node_rank
+          field_state_size: 1
 
         - field_name: mixture_fraction
           explicit_field_name: explicit_mixture_fraction
           field_size: 1
           field_type: node_rank
+          field_state_size: 3
+
+        - field_name: density
+          explicit_field_name: explicit_density
+          field_size: 1
+          field_type: node_rank
+          field_state_size: 3
+
+        - field_name: viscosity
+          explicit_field_name: explicit_viscosity
+          field_size: 1
+          field_type: node_rank
+          field_state_size: 1
 
         - field_name: density_ra_one
           explicit_field_name: explicit_density_ra_one
           field_size: 1
+          field_type: node_rank
+          field_state_size: 1
+
+      residual_specifications:
+
+        - field_name: residual
+          field_size: 2
+          field_type: node_rank
+
+        - field_name: explicit_residual
+          field_size: 2
           field_type: node_rank
 
     output:
@@ -177,6 +220,7 @@ realms:
       output_node_set: no
       output_variables:
        - velocity
+       - dudx
        - pressure
        - mixture_fraction
        - density
@@ -185,10 +229,19 @@ realms:
        - velocity_fa_one
        - mixture_fraction_ra_one
        - mixture_fraction_fa_one
-       - explicit_filter
        - explicit_velocity
+       - explicit_dudx
+       - explicit_pressure
+       - explicit_dpdx
        - explicit_mixture_fraction
+       - explicit_density
+       - explicit_viscosity
        - explicit_density_ra_one
+       - residual
+       - explicit_residual
+       - explicit_filter
+       - dual_nodal_volume
+
 
 Time_Integrators:
   - StandardTimeIntegrator:

--- a/src/ExplicitFiltering.C
+++ b/src/ExplicitFiltering.C
@@ -12,6 +12,7 @@
 #include <NaluParsing.h>
 #include <NaluEnv.h>
 #include <Realm.h>
+#include <SolutionOptions.h>
 
 // master elements
 #include <master_element/MasterElement.h>
@@ -59,7 +60,8 @@ ExplicitFiltering::ExplicitFiltering(
     searchMethod_(stk::search::KDTREE),
     explicitFilteringGhosting_(NULL),
     needToGhostCount_(0),
-    debugOutput_(false)
+    debugOutput_(false),
+    normalizeResidual_(false)
 {
   // load the data
   load(node);
@@ -110,19 +112,28 @@ ExplicitFiltering::load(
       debugOutput_ = debugOutput.as<bool>();
       NaluEnv::self().naluOutputP0() << "ExplicitFiltering::debugOutput_: ACTIVE" << std::endl;
     }
+    
+    // extract information from this specification
+    const YAML::Node normalizeResidual = y_explicit["normalize_residual"];
+    if ( normalizeResidual ) {
+      normalizeResidual_ = normalizeResidual.as<bool>();
+      NaluEnv::self().naluOutputP0() << "Normalization active? "  << normalizeResidual_ << std::endl;
+    }
+
   }
 
   // extract the sequence of types
-  const YAML::Node y_specs = expect_sequence(y_explicit, "specifications", true);
-  if (y_specs) {
-    for (size_t ispec = 0; ispec < y_specs.size(); ++ispec) {
-      const YAML::Node y_spec = y_specs[ispec] ;
+  const YAML::Node y_especs = expect_sequence(y_explicit, "explicit_specifications", true);
+  if (y_especs) {
+    for (size_t ispec = 0; ispec < y_especs.size(); ++ispec) {
+      const YAML::Node y_espec = y_especs[ispec] ;
       
       // find the name, size and type
-      const YAML::Node fieldNameNode = y_spec["field_name"];
-      const YAML::Node expFieldNameNode = y_spec["explicit_field_name"];
-      const YAML::Node fieldSizeNode = y_spec["field_size"];
-      const YAML::Node fieldTypeNode = y_spec["field_type"];
+      const YAML::Node fieldNameNode = y_espec["field_name"];
+      const YAML::Node expFieldNameNode = y_espec["explicit_field_name"];
+      const YAML::Node fieldSizeNode = y_espec["field_size"];
+      const YAML::Node fieldTypeNode = y_espec["field_type"];
+      const YAML::Node fieldStateSizeNode = y_espec["field_state_size"];
       
       if ( !fieldNameNode ) 
         throw std::runtime_error("ExplicitFiltering::load():error(), field_name must be provided");
@@ -139,19 +150,69 @@ ExplicitFiltering::load(
           throw std::runtime_error("ExplicitFiltering::load():error() only supports nodal_rank types");
       }
 
+      // extract field state size; optional with a default of unity
+      int fieldStateSize = 1;
+      if ( fieldStateSizeNode ) {
+        fieldStateSize = fieldStateSizeNode.as<int>();
+      }
+      
       // create the struct and push back
       ExplicitFilteringNames nameStruct(fieldNameNode.as<std::string>(), 
                                         expFieldNameNode.as<std::string>(),
-                                        fieldSizeNode.as<int>());
+                                        fieldSizeNode.as<int>(),
+                                        fieldStateSize);
       explicitFilteringNamesVec_.push_back(nameStruct);
     }
   }
 
-  // provide output for the names to be registered under STK (and, therefore, available for IO)
-  NaluEnv::self().naluOutputP0() << "A number of explicitly filter quantities will be created: " << std::endl;
-  NaluEnv::self().naluOutputP0() << "  " << "explicit_filter" << std::endl;
-  for ( size_t k = 0; k < explicitFilteringNamesVec_.size(); ++k ) {
-    NaluEnv::self().naluOutputP0() << "  " << explicitFilteringNamesVec_[k].expFieldName_ << std::endl;
+  const YAML::Node y_rspecs = expect_sequence(y_explicit, "residual_specifications", true);
+
+  // extract the sequence of types
+  if (y_rspecs) {
+    for (size_t ispec = 0; ispec < y_rspecs.size(); ++ispec) {
+      const YAML::Node y_rspec = y_rspecs[ispec] ;
+      
+      // find the name, size and type
+      const YAML::Node fieldNameNode = y_rspec["field_name"];
+      const YAML::Node fieldSizeNode = y_rspec["field_size"];
+      const YAML::Node fieldTypeNode = y_rspec["field_type"];
+      
+      if ( !fieldNameNode ) 
+        throw std::runtime_error("ExplicitFiltering::load():error(), field_name must be provided");
+      
+      if ( !fieldSizeNode ) 
+        throw std::runtime_error("ExplicitFiltering::load():error(), field_size must be provided");
+      
+      if ( fieldTypeNode ) {
+        std::string fieldType = fieldTypeNode.as<std::string>();
+        if ( fieldType != "node_rank" )
+          throw std::runtime_error("ExplicitFiltering::load():error() only supports nodal_rank types");
+      }
+      
+      // create the struct and push back
+      ExplicitFilteringNames nameStruct(fieldNameNode.as<std::string>(), 
+                                        "na",
+                                        fieldSizeNode.as<int>(),
+                                        1);
+      residualNamesVec_.push_back(nameStruct);
+    }
+  }
+  
+  // provide output for the explicit names to be registered under STK (and, therefore, available for IO)
+  if ( explicitFilteringNamesVec_.size() > 0 ) {
+    NaluEnv::self().naluOutputP0() << "A number of explicitly filter quantities will be created: " << std::endl;
+    NaluEnv::self().naluOutputP0() << "  " << "explicit_filter" << std::endl;
+    for ( size_t k = 0; k < explicitFilteringNamesVec_.size(); ++k ) {
+      NaluEnv::self().naluOutputP0() << "  " << explicitFilteringNamesVec_[k].expFieldName_ << std::endl;
+    }
+  }
+  
+  // provide output for the residual names to be registered under STK (and, therefore, available for IO)
+  if ( residualNamesVec_.size() > 0 ) {
+    NaluEnv::self().naluOutputP0() << "A number of residual quantities will be created: " << std::endl;
+    for ( size_t k = 0; k < residualNamesVec_.size(); ++k ) {
+      NaluEnv::self().naluOutputP0() << "  " << residualNamesVec_[k].fieldName_ << std::endl;
+    }
   }
 
 }
@@ -182,20 +243,62 @@ ExplicitFiltering::setup()
     const std::string fieldName = explicitFilteringNamesVec_[k].fieldName_;
     const std::string expFieldName = explicitFilteringNamesVec_[k].expFieldName_;
     const int fieldSize = explicitFilteringNamesVec_[k].fieldSize_;
-    stk::mesh::Field<double> *expField =  &(metaData.declare_field<double>(stk::topology::NODE_RANK, expFieldName));
+    const int fieldStateSize = explicitFilteringNamesVec_[k].fieldStateSize_;
+    stk::mesh::Field<double> *expField =  &(metaData.declare_field<double>(stk::topology::NODE_RANK, expFieldName, fieldStateSize));
     stk::mesh::put_field_on_mesh(*expField, stk::mesh::selectUnion(searchParts_), fieldSize, nullptr);
     stk::mesh::Field<double> *theField = metaData.get_field<double>(stk::topology::NODE_RANK, fieldName);
     if ( NULL != theField ) {
-      // create the struct and push back
+      // create the Np1 struct and push back
       ExplicitFilteringFields fieldStruct(theField, 
                                           expField,
                                           fieldSize);
       explicitFilteringFieldsVec_.push_back(fieldStruct);
+
+      NaluEnv::self().naluOutputP0() << "Explicitly filter quantities with state will be created: " << expField->name() << std::endl;
+
+      // We need to filter states as well, while later accessing 
+      // the field under the general field_of_state() interface
+      if ( fieldStateSize > 1 ) {
+        // create the N struct and push back
+        ExplicitFilteringFields fieldStructN(&(theField->field_of_state(stk::mesh::StateN)), 
+                                             &(expField->field_of_state(stk::mesh::StateN)),
+                                             fieldSize);
+        explicitFilteringFieldsVec_.push_back(fieldStructN);
+
+        NaluEnv::self().naluOutputP0() << "Explicitly filter quantities with state will be created: " 
+                                       << (expField->field_of_state(stk::mesh::StateN)).name() << std::endl;
+      }
+
+      if ( fieldStateSize > 2 ) {        
+        // create the Nm1 struct and push back
+        ExplicitFilteringFields fieldStructNm1(&(theField->field_of_state(stk::mesh::StateNM1)), 
+                                               &(expField->field_of_state(stk::mesh::StateNM1)),
+                                               fieldSize);
+        explicitFilteringFieldsVec_.push_back(fieldStructNm1);
+
+        NaluEnv::self().naluOutputP0() << "Explicitly filter quantities with state will be created: " 
+                                       << (expField->field_of_state(stk::mesh::StateNM1)).name() << std::endl;
+      }      
     }
     else {
       throw std::runtime_error("ExplicitFiltering::error() no underlying field by the name of: " + fieldName);
     } 
   }
+
+  // now residuals
+  for ( size_t k = 0; k < residualNamesVec_.size(); ++k ) {
+    const std::string fieldName = residualNamesVec_[k].fieldName_;
+    const int fieldSize = residualNamesVec_[k].fieldSize_;
+    stk::mesh::Field<double> *theField =  &(metaData.declare_field<double>(stk::topology::NODE_RANK, fieldName));
+    stk::mesh::put_field_on_mesh(*theField, stk::mesh::selectUnion(searchParts_), fieldSize, nullptr);
+
+    // create the Np1 struct and push back
+    ExplicitFilteringFields fieldStruct(theField, 
+                                        nullptr,
+                                        fieldSize);
+    residualFieldsVec_.push_back(fieldStruct);     
+  }
+  
 }
 
 //--------------------------------------------------------------------------
@@ -254,8 +357,8 @@ void
 ExplicitFiltering::execute()
 {
   // meta/bulk data and nDim
-  stk::mesh::MetaData & metaData = realm_.meta_data();
-  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  stk::mesh::MetaData &metaData = realm_.meta_data();
+  stk::mesh::BulkData &bulkData = realm_.bulk_data();
   const int nDim = metaData.spatial_dimension();
 
   // extract fields
@@ -405,16 +508,65 @@ ExplicitFiltering::execute()
     }
   }
   
-}
+  // residual-based calculation is currently in a very specific state
+  if ( residualNamesVec_.size() > 0 ) {
+    // compute the non-filtered residuals
+    VectorFieldType *velocity = metaData.get_field<double>(stk::topology::NODE_RANK, "velocity");
+    ScalarFieldType *density = metaData.get_field<double>(stk::topology::NODE_RANK, "density");
+    ScalarFieldType *viscosity = metaData.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+    VectorFieldType *residual = metaData.get_field<double>(stk::topology::NODE_RANK, "residual");
+    
+    ScalarFieldType *pressure = metaData.get_field<double>(stk::topology::NODE_RANK, "pressure");
+    VectorFieldType *dudx = metaData.get_field<double>(stk::topology::NODE_RANK, "dudx");
+    compute_scv_residual(&(velocity->field_of_state(stk::mesh::StateNP1)),
+                         &(velocity->field_of_state(stk::mesh::StateN)),
+                         &(velocity->field_of_state(stk::mesh::StateNM1)),
+                         &(density->field_of_state(stk::mesh::StateNP1)),
+                         &(density->field_of_state(stk::mesh::StateN)),
+                         &(density->field_of_state(stk::mesh::StateNM1)),
+                         viscosity,
+                         pressure,
+                         dudx,
+                         coordinates,
+                         residual);
+  }
+  
+  if ( residualNamesVec_.size() > 1 ) {
+    // compute the filtered residuals
+    VectorFieldType *evelocity = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_velocity");
+    ScalarFieldType *edensity = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_density");
+    ScalarFieldType *eviscosity = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_viscosity");
+    VectorFieldType *eresidual = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_residual");    
+    ScalarFieldType *epressure = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_pressure");
+    VectorFieldType *edudx = metaData.get_field<double>(stk::topology::NODE_RANK, "explicit_dudx");
+    compute_scv_residual(&(evelocity->field_of_state(stk::mesh::StateNP1)),
+                         &(evelocity->field_of_state(stk::mesh::StateN)),
+                         &(evelocity->field_of_state(stk::mesh::StateNM1)),
+                         &(edensity->field_of_state(stk::mesh::StateNP1)),
+                         &(edensity->field_of_state(stk::mesh::StateN)),
+                         &(edensity->field_of_state(stk::mesh::StateNM1)),
+                         eviscosity,
+                         epressure,
+                         edudx,
+                         coordinates,
+                         eresidual);
+    
+  }
+  
+  if ( residualNamesVec_.size() > 2 ) {
+    throw std::runtime_error("ExplicitFiltering::execute() only two entries supported");
+  }
 
+}
+  
 //--------------------------------------------------------------------------
 //-------- populate_candidate_elements -------------------------------------
 //--------------------------------------------------------------------------
 void
 ExplicitFiltering::populate_candidate_elements()
 {
-  stk::mesh::MetaData & metaData = realm_.meta_data();
-  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  stk::mesh::MetaData &metaData = realm_.meta_data();
+  stk::mesh::BulkData &bulkData = realm_.bulk_data();
 
   const int nDim = metaData.spatial_dimension();
 
@@ -524,8 +676,8 @@ ExplicitFiltering::determine_elems_to_ghost()
 void
 ExplicitFiltering::create_explicit_filter_point_info_map() {
 
-  stk::mesh::MetaData & metaData = realm_.meta_data();
-  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  stk::mesh::MetaData &metaData = realm_.meta_data();
+  stk::mesh::BulkData &bulkData = realm_.bulk_data();
 
   const int nDim = metaData.spatial_dimension();
 
@@ -763,6 +915,328 @@ ExplicitFiltering::increment_elem_mean(
   }
 }
 
+//--------------------------------------------------------------------------
+//-------- compute_scv_residual --------------------------------------------
+//--------------------------------------------------------------------------
+void
+ExplicitFiltering::compute_scv_residual(
+  const stk::mesh::FieldBase *velocityNp1_,
+  const stk::mesh::FieldBase *velocityN_,
+  const stk::mesh::FieldBase *velocityNm1_,
+  const stk::mesh::FieldBase *densityNp1_,
+  const stk::mesh::FieldBase *densityN_,
+  const stk::mesh::FieldBase *densityNm1_,
+  const stk::mesh::FieldBase *viscosity_,
+  const stk::mesh::FieldBase *pressure_,
+  const stk::mesh::FieldBase *Gjui_,
+  const stk::mesh::FieldBase *coordinates_,
+  stk::mesh::FieldBase *residual_)
+{
+  NaluEnv::self().naluOutputP0() << "Nalu residual acting on: " << residual_->name() << " using: " << std::endl;
+  NaluEnv::self().naluOutputP0() << velocityNp1_->name() << " " 
+                                 << velocityN_->name() << " "
+                                 << velocityNm1_->name() << " "
+                                 << densityNp1_->name() << " "
+                                 << densityN_->name() << " "
+                                 << densityNm1_->name() << " "
+                                 << viscosity_->name() << " "
+                                 << pressure_->name() << " " 
+                                 << Gjui_->name() << std::endl;
+  
+  // compute assembled residual to nodes for momentum system 
+  stk::mesh::MetaData &metaData = realm_.meta_data();
+  stk::mesh::BulkData &bulkData = realm_.bulk_data();
+  const int nDim = metaData.spatial_dimension();
+
+  // extract constants
+  const double rhoRef = realm_.solutionOptions_->referenceDensity_;
+  const std::array<double,3>& gravity = realm_.solutionOptions_->get_gravity_vector();
+  const double gamma1 = realm_.get_gamma1();
+  const double gamma2 = realm_.get_gamma2();
+  const double gamma3 = realm_.get_gamma3();
+  const double dt = realm_.get_time_step();
+  const double includeDivU = realm_.get_divU();
+  const double twoThirds = 2.0/3.0;
+  
+  // subtract out continuity factor and kd
+  const double ncFac = 1.0;
+  double w_kd[3][3] = {0};
+  w_kd[0][0] = w_kd[1][1] = w_kd[2][2] = 1.0;
+
+  // zero residual
+  field_fill( metaData, bulkData, 0.0, *residual_, realm_.get_activate_aura());  
+
+  std::vector<double> ws_residual;
+  std::vector<double> ws_velocityNp1;
+  std::vector<double> ws_velocityN;
+  std::vector<double> ws_velocityNm1;
+  std::vector<double> ws_coordinates;
+  std::vector<double> ws_densityNp1;
+  std::vector<double> ws_densityN;
+  std::vector<double> ws_densityNm1;
+  std::vector<double> ws_viscosity;
+  std::vector<double> ws_pressure;
+  std::vector<double> ws_Gjui;
+
+  // geometry related to populate
+  std::vector<double> ws_dndx;
+  std::vector<double> ws_deriv;
+  std::vector<double> ws_det_j;
+  std::vector<double> ws_shape_function;
+  std::vector<double> ws_scvol;
+
+  // ip values
+  std::vector<double> uNp1Ip(nDim);
+  std::vector<double> uNIp(nDim);
+  std::vector<double> uNm1Ip(nDim);
+  std::vector<double> dpdxIp(nDim);
+  std::vector<double> dFdxAdv(nDim);
+  std::vector<double> dFdxDiff(nDim);
+
+  // pointers for fast access
+  double *p_uNp1Ip = &uNp1Ip[0];
+  double *p_uNIp = &uNIp[0];
+  double *p_uNm1Ip = &uNm1Ip[0];
+  double *p_dpdxIp = &dpdxIp[0];
+  double *p_dFdxAdv = &dFdxAdv[0];
+  double *p_dFdxDiff = &dFdxDiff[0];
+  
+  stk::mesh::Selector s_locally_owned_union = metaData.locally_owned_part()
+    & stk::mesh::selectUnion(searchParts_) 
+    & !(realm_.get_inactive_selector());
+
+  stk::mesh::BucketVector const& elem_buckets =
+    realm_.get_buckets( stk::topology::ELEMENT_RANK, s_locally_owned_union );
+  for ( stk::mesh::BucketVector::const_iterator ib = elem_buckets.begin();
+        ib != elem_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    // extract master element
+    MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(b.topology());
+
+    // extract master element specifics
+    const int nodesPerElement = meSCV->nodesPerElement_;
+    const int numScvIp = meSCV->numIntPoints_;
+    const int *ipNodeMap = meSCV->ipNodeMap();
+
+    // algorithm related
+    ws_residual.resize(nodesPerElement*nDim);
+    ws_velocityNp1.resize(nodesPerElement*nDim);
+    ws_velocityN.resize(nodesPerElement*nDim);
+    ws_velocityNm1.resize(nodesPerElement*nDim);
+    ws_coordinates.resize(nodesPerElement*nDim);
+    ws_Gjui.resize(nDim*nDim*nodesPerElement);
+    ws_pressure.resize(nodesPerElement);
+    ws_densityNp1.resize(nodesPerElement);
+    ws_densityN.resize(nodesPerElement);
+    ws_densityNm1.resize(nodesPerElement);
+    ws_viscosity.resize(nodesPerElement);
+    ws_dndx.resize(nDim*numScvIp*nodesPerElement);
+    ws_deriv.resize(nDim*numScvIp*nodesPerElement);
+    ws_det_j.resize(numScvIp);
+    ws_shape_function.resize(numScvIp*nodesPerElement);
+
+    ws_scvol.resize(numScvIp);
+
+    // pointer to residual
+    double *p_residual = &ws_residual[0];
+
+    double *p_velocityNp1 = &ws_velocityNp1[0];
+    double *p_velocityN = &ws_velocityN[0];
+    double *p_velocityNm1 = &ws_velocityNm1[0];
+    double *p_coordinates = &ws_coordinates[0];
+    double *p_Gjui = &ws_Gjui[0];
+    double *p_pressure = &ws_pressure[0];
+    double *p_densityNp1 = &ws_densityNp1[0];
+    double *p_densityN = &ws_densityN[0];
+    double *p_densityNm1 = &ws_densityNm1[0];
+    double *p_viscosity = &ws_viscosity[0];
+    double *p_dndx = &ws_dndx[0];
+    double *p_shape_function = &ws_shape_function[0];
+
+    double *p_scvol = &ws_scvol[0];
+    
+    // extract shape function
+    meSCV->shape_fcn(&p_shape_function[0]);
+       
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      
+      //===============================================
+      // gather nodal data; this is how we do it now..
+      //===============================================
+      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
+
+      // sanity check on num nodes
+      ThrowAssert( num_nodes == nodesPerElement );
+
+      for ( int ni = 0; ni < num_nodes; ++ni ) {
+        stk::mesh::Entity node = node_rels[ni];
+
+        // pointers to real data
+        const double * uNp1     =  (double*)stk::mesh::field_data(*velocityNp1_, node);
+        const double * uN       =  (double*)stk::mesh::field_data(*velocityN_, node);
+        const double * uNm1     =  (double*)stk::mesh::field_data(*velocityNm1_, node);
+        const double * coords   =  (double*)stk::mesh::field_data(*coordinates_, node);
+        const double * Gjui     =  (double*)stk::mesh::field_data(*Gjui_, node);
+        const double pressure   = *(double*)stk::mesh::field_data(*pressure_, node);
+        const double rhoNp1     = *((double*)stk::mesh::field_data(*densityNp1_, node));
+        const double rhoN       = *((double*)stk::mesh::field_data(*densityN_, node));
+        const double rhoNm1     = *((double*)stk::mesh::field_data(*densityNm1_, node));
+        const double mu         = *((double*)stk::mesh::field_data(*viscosity_, node));
+
+        // gather scalars
+        p_densityNp1[ni] = rhoNp1;
+        p_densityN[ni] = rhoN;
+        p_densityNm1[ni] = rhoNm1;
+        p_viscosity[ni] = mu;
+        p_pressure[ni] = pressure;
+
+        // gather vectors
+        const int niNdim = ni*nDim;
+        const int niNdimNdim = niNdim*nDim;
+        for ( int i = 0; i < nDim; ++i ) {
+          p_velocityNp1[niNdim+i] = uNp1[i];
+          p_velocityN[niNdim+i] = uN[i];
+          p_velocityNm1[niNdim+i] = uNm1[i];
+          p_coordinates[niNdim+i] = coords[i];
+          // gather tensor
+          const int iNdim = i*nDim;
+          for ( int j = 0; j < nDim; ++j ) {
+            p_Gjui[niNdimNdim+iNdim+j] = Gjui[iNdim+j];
+          }
+        }
+      }
+      
+      // compute geometry
+      double scv_error = 0.0;
+      meSCV->determinant(1, &p_coordinates[0], &p_scvol[0], &scv_error);
+
+      // compute dndx
+      meSCV->grad_op(1, &p_coordinates[0], &p_dndx[0], &ws_deriv[0], &ws_det_j[0], &scv_error);
+
+      // zero residual for this element; residual follows matrix assembly rules
+      for ( int j = 0; j < nodesPerElement*nDim; ++j )
+        p_residual[j] = 0.0;
+      
+      // loop over SCV only; time, advection, duffusion, pressure gradient, and buoyancy accumulation
+      for ( int ip = 0; ip < numScvIp; ++ip ) {
+
+        // save off some offsets
+        const int nn = ipNodeMap[ip];
+        const int ipNpe = ip*nodesPerElement;
+
+        // zero everything that we will need at the IP
+        double rhoNp1Ip = 0.0;
+        double rhoNIp = 0.0;
+        double rhoNm1Ip = 0.0;
+        double divU = 0.0;
+        double dFdxCont = 0.0;
+        for ( int j = 0; j < nDim; ++j ) {
+          p_uNp1Ip[j] = 0.0;
+          p_uNIp[j] = 0.0;
+          p_uNm1Ip[j] = 0.0;
+          p_dFdxAdv[j] = 0.0;
+          p_dFdxDiff[j] = 0.0;
+          p_dpdxIp[j] = 0.0;
+        }
+
+        // compute everything other than diffusion
+        for ( int ic = 0; ic < nodesPerElement; ++ic ) {  
+          const double r = p_shape_function[ipNpe+ic];        
+          
+          rhoNp1Ip += r*p_densityNp1[ic];
+          rhoNIp += r*p_densityN[ic];
+          rhoNm1Ip += r*p_densityNm1[ic];
+
+          const double pIc = p_pressure[ic];
+          const double rhoNp1Ic = p_densityNp1[ic];
+          const int icNdim = ic*nDim;
+          const int offSetDnDx = nDim*nodesPerElement*ip + icNdim;
+          for ( int j = 0; j < nDim; ++j ) {
+            // interpolation
+            const double uNp1j =p_velocityNp1[icNdim+j]; 
+            p_uNp1Ip[j] += r*uNp1j;
+            p_uNIp[j] += r*p_velocityN[icNdim+j];
+            p_uNm1Ip[j] += r*p_velocityNm1[icNdim+j];
+            // derivatives
+            const double dnj = p_dndx[offSetDnDx+j];
+            p_dpdxIp[j] += pIc*dnj;
+            divU += uNp1j*dnj;
+            dFdxCont += rhoNp1Ic*uNp1j*dnj;
+          }
+        }
+        
+        // full continuity residual
+        const double contRes = (gamma1*rhoNp1Ip + gamma2*rhoNIp + gamma3*rhoNm1Ip)/dt + dFdxCont;
+        
+        // advection and diffusion terms
+        for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+          const int icNdim = ic*nDim;
+          const int icNdimNdim = icNdim*nDim;
+          const int offSetDnDx = nDim*nodesPerElement*ip + icNdim;
+          const double rhoNp1Ic = p_densityNp1[ic];
+          const double muIc = p_viscosity[ic];
+          for ( int i = 0; i < nDim; ++i ) {
+            for ( int j = 0; j < nDim; ++j ) {
+              const double dnj = p_dndx[offSetDnDx+j];
+              p_dFdxAdv[i] += rhoNp1Ic*p_velocityNp1[icNdim+j]*p_velocityNp1[icNdim+i]*dnj;
+              p_dFdxDiff[i] += muIc*(p_Gjui[icNdimNdim+i*nDim+j] + p_Gjui[icNdimNdim+j*nDim+i] 
+                                     - twoThirds*divU*w_kd[i][j]*includeDivU)*dnj;
+            }
+          }
+        }
+        
+        // offset
+        const int nnNdim = nn*nDim;
+        
+        // save off scvol
+        const double scvIp = p_scvol[nn];
+
+        for ( int i = 0; i < nDim; ++i ) {
+          const int indexNN = nnNdim + i;
+          const double time = (gamma1*rhoNp1Ip*p_uNp1Ip[i] 
+                               + gamma2*rhoNIp*p_uNIp[i] 
+                               + gamma3*rhoNm1Ip*p_uNm1Ip[i])/dt;
+          const double buoyancy = (rhoNp1Ip-rhoRef)*gravity[i];
+          p_residual[indexNN] += 
+            (time + p_dFdxAdv[i] - p_dFdxDiff[i] + p_dpdxIp[i] - buoyancy - ncFac*contRes*p_uNp1Ip[i])*scvIp;
+        }
+      }
+       
+      // scatter residual
+      for ( int ni = 0; ni < num_nodes; ++ni ) {
+        stk::mesh::Entity node = node_rels[ni];
+
+        // off set
+        const int niNdim = ni*nDim;
+        
+        // pointer to the node
+        double * residual =  (double*)stk::mesh::field_data(*residual_, node);
+        for ( int i = 0; i < nDim; ++i ) {
+          residual[i] -= p_residual[niNdim+i];
+        }
+      } 
+    }
+  }
+  
+  // parallel assemble; first
+  std::vector<const stk::mesh::FieldBase*> sumFieldVecFirst;
+  sumFieldVecFirst.push_back(residual_);
+  stk::mesh::parallel_sum(bulkData, sumFieldVecFirst);
+  
+  // periodic sum
+  if ( realm_.hasPeriodic_) {
+    realm_.periodic_field_update(residual_, nDim);
+  }
+
+  // choice to normalize
+  if ( normalizeResidual_ ) {
+    ScalarFieldType *dualNodalVolume = metaData.get_field<double>(stk::topology::NODE_RANK, "dual_nodal_volume");
+    field_normalize(metaData, bulkData, *dualNodalVolume, *residual_, realm_.get_activate_aura());
+  }
+}
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -105,9 +105,6 @@
 // stk_util
 #include <stk_util/parallel/ParallelReduce.hpp>
 
-// Ioss for propertManager (io)
-#include <Ioss_PropertyManager.h>
-
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
 #include <NaluParsing.h>
@@ -812,7 +809,7 @@ Realm::setup_post_processing_algorithms()
       throw std::runtime_error("Post Processing Error: only  surface-based is supported");
     }
   }
-
+  
   // check for turbulence averaging fields
   if ( NULL != turbulenceAveragingPostProcessing_ )
     turbulenceAveragingPostProcessing_->setup();
@@ -825,13 +822,14 @@ Realm::setup_post_processing_algorithms()
   if ( NULL != actuator_ )
     actuator_->setup();
 
+  // check for norm nodal fields
+  if ( NULL != solutionNormPostProcessing_ )
+    solutionNormPostProcessing_->setup();
+
   // check for explicit filtering
   if ( NULL != explicitFiltering_ )
     explicitFiltering_->setup();
 
-  // check for norm nodal fields
-  if ( NULL != solutionNormPostProcessing_ )
-    solutionNormPostProcessing_->setup();
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Quad92DCVFEM.C
+++ b/src/master_element/Quad92DCVFEM.C
@@ -248,6 +248,33 @@ void Quad92DSCV::determinant(
 
 }
 
+void Quad92DSCV::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  int lerr = 0;
+
+  constexpr int numShapeDerivs = Traits::numScvIp_*Traits::nodesPerElement_*Traits::nDim_;
+  for (int j = 0; j < numShapeDerivs; ++j) {
+    deriv[j] = shapeDerivs_[j];
+  }
+
+  SIERRA_FORTRAN(quad_gradient_operator)
+    ( &nelem,
+      &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gradop, det_j, error, &lerr );
+
+  if ( lerr )
+    NaluEnv::self().naluOutput() << "sorry, negative area.." << std::endl;
+
+}
+
 //--------------------------------------------------------------------------
 //-------- jacobian_determinant --------------------------------------------
 //--------------------------------------------------------------------------


### PR DESCRIPTION
* add scv residual for momentum.

* allow for dual nodal volume normalization; new field function field_normalize() via a scalar normalization: y[i] = y[i]/x

* code scv grad op for quad9 (non-ngp was missing and required)

Notes:

a) deprecate scs residual as it would require boundary contributions (stashed).