### PR TITLE
Add one-d table support

### DIFF
--- a/include/user_functions/TableAuxFunction.h
+++ b/include/user_functions/TableAuxFunction.h
@@ -1,0 +1,52 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef TableAuxFunction_h
+#define TableAuxFunction_h
+
+#include <AuxFunction.h>
+
+#include <string>
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class TableAuxFunction : public AuxFunction
+{
+public:
+
+  TableAuxFunction(
+    const unsigned beginPos,
+    const unsigned endPos,
+    std::vector<double> params);
+
+  virtual ~TableAuxFunction();
+  
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+  double interp(const std::pair<double,double> &x) const;
+
+private:
+  int fieldComp_;
+  int interpComp_;
+  int tableOffset_;
+  std::vector<std::pair<double,double> > table_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/reg_tests/test_files/ductElemWedge/ductElemWedge.i
+++ b/reg_tests/test_files/ductElemWedge/ductElemWedge.i
@@ -69,7 +69,12 @@ realms:
     - inflow_boundary_condition: bc_inflow
       target_name: surface_1
       inflow_user_data:
-        velocity: [0.0,0.0,2.0]
+        user_function_name:
+         velocity: table
+        user_function_parameters:
+         velocity: [2, 1, 
+                    0.0, 2.0, 
+                    2.0, 2.0]
 
     - open_boundary_condition: bc_open
       target_name: surface_2

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -196,6 +196,8 @@
 
 #include "user_functions/LinearAuxFunction.h"
 
+#include "user_functions/TableAuxFunction.h"
+
 // stk_util
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_util/parallel/ParallelReduce.hpp>
@@ -1561,6 +1563,9 @@ MomentumEquationSystem::register_inflow_bc(
     else if ( fcnName == "pulse" ) {
       theAuxFunc = new PulseVelocityAuxFunction(0,nDim,theParams);
     }
+    else if ( fcnName == "table" ) {
+      theAuxFunc = new TableAuxFunction(0,nDim,theParams);
+    }
     else {
       throw std::runtime_error("MomentumEquationSystem::register_inflow_bc: limited functions supported");
     }
@@ -2733,6 +2738,9 @@ ContinuityEquationSystem::register_inflow_bc(
     }
     else if ( fcnName == "pulse" ) {
       theAuxFunc = new PulseVelocityAuxFunction(0,nDim,theParams);
+    }
+    else if ( fcnName == "table" ) {
+      theAuxFunc = new TableAuxFunction(0,nDim,theParams);
     }
     else {
       throw std::runtime_error("ContEquationSystem::register_inflow_bc: limited functions supported");

--- a/src/user_functions/TableAuxFunction.C
+++ b/src/user_functions/TableAuxFunction.C
@@ -1,0 +1,114 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/TableAuxFunction.h>
+#include <MeshMotionInfo.h>
+#include <PecletFunction.h>
+#include <SolutionOptions.h>
+
+// basic c++
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+TableAuxFunction::TableAuxFunction(
+  const unsigned beginPos,
+  const unsigned endPos,
+  std::vector<double> params) :
+  AuxFunction(beginPos, endPos),
+  fieldComp_(0),
+  interpComp_(0),
+  tableOffset_(2)
+{
+  /* sample: 0, 1, 
+     0.0, 0.0, --> first two entries taken
+     1.0, 2.0  --> begin table data; in pairs 
+  */
+  fieldComp_ = params[0];
+  interpComp_ = params[1];
+  for ( size_t k = tableOffset_; k < params.size(); k += 2 ) {
+    table_.push_back(std::make_pair(params[k+0],params[k+1]));
+  }
+
+  // sort the table - just in case
+  std::sort(table_.begin(), table_.end());
+  
+  // make sure it's more than one entry
+  if ( table_.size() < 2 )
+    throw std::runtime_error("TableAuxFunction::Error() Table must hold at least two entries");
+}
+
+TableAuxFunction::~TableAuxFunction()
+{
+  // nothing
+}
+
+void
+TableAuxFunction::do_evaluate(
+  const double *coords,
+  const double time,
+  const unsigned spatialDimension,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+  for(unsigned p=0; p < numPoints; ++p) {
+
+    // create the pair, coordinates or time
+    const std::pair<double,double> cPair = (interpComp_ < 3 )
+      ? std::make_pair(coords[interpComp_],0.0) 
+      : std::make_pair(time,0.0);
+
+    // interpolate
+    const double interpValue = interp(cPair);
+    
+    // first assign to zero
+    for ( unsigned i = 0; i < fieldSize; ++i )
+      fieldPtr[i] = 0.0;
+    
+    // assign
+    fieldPtr[fieldComp_] = interpValue;
+    
+    fieldPtr += fieldSize;
+    coords += spatialDimension;
+  }
+}
+
+double
+TableAuxFunction::interp(const std::pair<double,double> &x) const
+{
+  double returnValue = 0.0;
+  if ( x.first <= table_[0].first ) {
+    returnValue = table_[0].second;
+  }
+  else if ( x.first >= table_[table_.size()-1].first ) {
+    returnValue = table_[table_.size()-1].second;
+  }
+  else {
+    // find the lower bound
+    std::vector<std::pair<double, double> >::const_iterator it = std::lower_bound( table_.begin(), table_.end(), x );    
+    if ( it == table_.end() ) {
+      throw std::runtime_error("TableAuxFunction::Error() Table entry not found....");
+    }
+    else {
+      const double dx = (*it).first - (*(it-1)).first;
+      const double dy = (*it).second - (*(it-1)).second;
+      returnValue = (*(it-1)).second + (x.first  - (*(it-1)).first) * dy / dx;
+    }
+  }
+  return returnValue;
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
* velocity and tke table support via:

        user_function_name:
         velocity: table

        user_function_parameters:
         velocity: [0, 1, ---> component (0,1,2), and interpolate in x,y,z-direction (0,1,2) or time (3)
                    0.00000000, 0.00000,
                    0.01437268, 0.39153,
                    0.04087776, 0.44427,
                    0.07042084, 0.46362,
                    0.09905644, 0.50683,
                    0.13407968, 0.51429,
                    0.20199564, 0.51727,
                    0.23793224, 0.51758,
                    1.00000000, 0.51758]

   For now, use a simple pair, or 2D table; can generalize as needed.

* modified ductElemWedge rtest to use table

Notes:

a) I tried a simple n interpolation, STL-based, and binary search. STL was
   only a factor of 2-ish for even large tables (like 100K). As such,
   proceeded with the STL-based since the code was so simple.

   See the Nalu 1.0 release (TablePropsAlg for a historic binary search)