### PR TITLE
Clean-up logical comparisons as per intel-one-api

### DIFF
--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -49,17 +49,17 @@ public:
 
   inline bool has_mesh_deformation() const
   {
-    return externalMeshDeformation_ | meshDeformation_;
+    return externalMeshDeformation_ || meshDeformation_;
   }
 
   inline bool does_mesh_move() const
   {
-    return has_mesh_motion() | has_mesh_deformation();
+    return has_mesh_motion() || has_mesh_deformation();
   }
 
   inline std::string get_coordinates_name() const
   {
-    return ( (meshMotion_ | meshDeformation_ | externalMeshDeformation_ | initialMeshDisplacement_) 
+    return ( (meshMotion_ || meshDeformation_ || externalMeshDeformation_ || initialMeshDisplacement_) 
 	     ? "current_coordinates" : "coordinates");    
   }
   

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2111,8 +2111,7 @@ Realm::initialize_post_processing_algorithms()
 std::string
 Realm::get_coordinates_name()
 {
-  return ( (solutionOptions_->meshMotion_ | solutionOptions_->meshDeformation_ | solutionOptions_->externalMeshDeformation_ | solutionOptions_->initialMeshDisplacement_) 
-           ? "current_coordinates" : "coordinates");
+  return solutionOptions_->get_coordinates_name();
 }
 
 //--------------------------------------------------------------------------
@@ -2121,7 +2120,7 @@ Realm::get_coordinates_name()
 bool
 Realm::has_mesh_motion() const
 {
-  return solutionOptions_->meshMotion_;
+  return solutionOptions_->has_mesh_motion();
 }
 
 //--------------------------------------------------------------------------
@@ -2130,7 +2129,7 @@ Realm::has_mesh_motion() const
 bool
 Realm::has_mesh_deformation() const
 {
-  return solutionOptions_->externalMeshDeformation_ | solutionOptions_->meshDeformation_;
+  return solutionOptions_->has_mesh_deformation();
 }
 
 //--------------------------------------------------------------------------
@@ -2139,7 +2138,7 @@ Realm::has_mesh_deformation() const
 bool
 Realm::does_mesh_move() const
 {
-  return has_mesh_motion() | has_mesh_deformation();
+  return solutionOptions_->does_mesh_move();
 }
 
 //--------------------------------------------------------------------------
@@ -2148,7 +2147,7 @@ Realm::does_mesh_move() const
 bool
 Realm::has_non_matching_boundary_face_alg() const
 {
-  return hasNonConformal_ | hasOverset_; 
+  return hasNonConformal_ || hasOverset_; 
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
* Avoid bitwise comparisons for bools.

* Avoid duplicate logic in Realm and SolutionOptions

Resolves https://github.com/NaluCFD/Nalu/issues/667 in addition to cleaning up compiler warnings