### PR TITLE
Elevate clipping option to the input file

### DIFF
--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -107,6 +107,7 @@ public:
   bool isTurbulent_;
   TurbulenceModel turbulenceModel_;
   bool dynamicTurbulenceProcedure_;
+  double dynamicTurbulenceClippingFac_;
   bool meshMotion_;
   bool meshMotionIncludesSixDof_;
   bool meshDeformation_;

--- a/reg_tests/test_files/milestoneRunConsolidated/milestoneRunConsolidated.i
+++ b/reg_tests/test_files/milestoneRunConsolidated/milestoneRunConsolidated.i
@@ -117,6 +117,7 @@ realms:
       name: myOptions
       turbulence_model: ksgs
       activate_dynamic_turbulence_procedure: yes
+      dynamic_turbulence_clipping_factor: 0.5
 
       use_consolidated_solver_algorithm: yes
       use_consolidated_face_elem_bc_algorithm: yes

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -50,6 +50,7 @@ SolutionOptions::SolutionOptions()
     isTurbulent_(false),
     turbulenceModel_(LAMINAR),
     dynamicTurbulenceProcedure_(false),
+    dynamicTurbulenceClippingFac_(0.0),
     meshMotion_(false),
     meshMotionIncludesSixDof_(false),
     meshDeformation_(false),
@@ -224,9 +225,12 @@ SolutionOptions::load(const YAML::Node & y_node)
                    "activate_dynamic_turbulence_procedure", dynamicTurbulenceProcedure_, dynamicTurbulenceProcedure_);
     if ( dynamicTurbulenceProcedure_ ) {
       if ( turbulenceModel_ != KSGS && turbulenceModel_ != LRKSGS ) {
-        throw std::runtime_error("Error: Dynamic procedure is only implemented for the kSGS family of turbuelnce models");
+        throw std::runtime_error("Error: Dynamic procedure is only implemented for the kSGS family of turbulence models");
       }
     }
+
+    get_if_present(y_solution_options,
+                   "dynamic_turbulence_clipping_factor", dynamicTurbulenceClippingFac_, dynamicTurbulenceClippingFac_);
 
     // extract possible copy from input fields restoration time
     get_if_present(y_solution_options, "input_variables_from_file_restoration_time",

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -793,8 +793,8 @@ TurbKineticEnergyEquationSystem::register_wall_bc(
   }
 
   // limited support for Neumann bc
-  if ( neumannActivated && !(turbulenceModel_ == KSGS) ) {
-    throw std::runtime_error("apply_neumann_condition is only valid for kSGS models");
+  if ( neumannActivated && !(turbulenceModel_ == KSGS || turbulenceModel_ == LRKSGS) ) {
+    throw std::runtime_error("apply_neumann_condition is only valid for kSGS-based models");
   }
 
   // warn the user if a Neumann for kSGS has not been applied (utau^2/sqrt(Cmu) inconsistency)
@@ -807,7 +807,7 @@ TurbKineticEnergyEquationSystem::register_wall_bc(
   bool processDirichlet = true;
   if ( anyWallFunctionActivated ) {
 
-    // for ksgs, we may want a simple Nuemann bc: d(kSGS)/dn = 0
+    // for ksgs, we may want a simple Neumann bc: d(kSGS)/dn = 0
     if ( neumannActivated ) {
       processDirichlet = false;
       NaluEnv::self().naluOutputP0() << "Neumann boundary condition is active...." << std::endl;
@@ -1178,7 +1178,7 @@ TurbKineticEnergyEquationSystem::compute_filtered_quantities()
   const double invNdim = 1.0/nDim;
 
   // clipping algorithm lamFraction defines how negative tvisc can become
-  const double lamFraction = 0.50;
+  const double lamFraction = realm_.solutionOptions_->dynamicTurbulenceClippingFac_;
 
   // manage du_k/dx_k
   const double includeDivU = 1.0; //realm_.get_divU();


### PR DESCRIPTION
* added:

	dynamic_turbulence_clipping_factor: {double lamFac}

  This option clips dynamic coefficeints to a fraction of the laminar
  viscosity. A value of 0 allows for no negativity, while that of unity
  allows for a tvisc to be -visc. Default is zero (a change from the hard-coded
  0.5 value).

* Modify rtest to ensure pass; specifically, added the new line command for the previous defalut of 0.5 (the test first diffed without this line)