### PR TITLE
Add average start time

### DIFF
--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -182,7 +182,8 @@ public:
   double currentTimeFilter_; /* provided by restart */
   double timeFilterInterval_; /* user supplied */
 
-  bool forcedReset_; /* allows forhard reset */
+  double startTime_; /* specifies start time */
+  bool forcedReset_; /* allows for a hard reset */
 
   AveragingType averagingType_;
   MovingAveragePostProcessor *movingAvgPP_;

--- a/reg_tests/test_files/heliumPlume/heliumPlume.i
+++ b/reg_tests/test_files/heliumPlume/heliumPlume.i
@@ -152,6 +152,7 @@ realms:
 
     turbulence_averaging:
       time_filter_interval: 10.0
+      start_time: 0.1
       specifications:
         - name: one
           target_name: block_1

--- a/reg_tests/test_files/heliumPlume/heliumPlume_rst.i
+++ b/reg_tests/test_files/heliumPlume/heliumPlume_rst.i
@@ -163,6 +163,7 @@ realms:
 
     turbulence_averaging:
       time_filter_interval: 10.0
+      forced_reset: yes
       specifications:
         - name: one
           target_name: block_1

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -58,6 +58,7 @@ TurbulenceAveragingPostProcessing::TurbulenceAveragingPostProcessing(
   : realm_(realm),
     currentTimeFilter_(0.0),
     timeFilterInterval_(1.0e8),
+    startTime_(0.0),
     forcedReset_(false),
     averagingType_(NALU_CLASSIC),
     movingAvgPP_(NULL)
@@ -88,6 +89,7 @@ TurbulenceAveragingPostProcessing::load(
   // output for results
   const YAML::Node y_average = y_node["turbulence_averaging"];
   if (y_average) {    
+    get_if_present(y_average, "start_time", startTime_, startTime_);
     get_if_present(y_average, "forced_reset", forcedReset_, forcedReset_);
     get_if_present(y_average, "time_filter_interval", timeFilterInterval_, timeFilterInterval_);
     if (y_average["averaging_type"]) {
@@ -632,6 +634,10 @@ TurbulenceAveragingPostProcessing::review(
 void
 TurbulenceAveragingPostProcessing::execute()
 {
+  // proceed only if current time is greater than requested start time
+  if ( !(realm_.get_current_time() >= startTime_) )
+    return;
+  
   stk::mesh::MetaData &metaData = realm_.meta_data();
 
   const double dt = realm_.get_time_step();


### PR DESCRIPTION
* allow for a start time, start_time: {default==0}

* modifed heliumPlume rtest; tested and all looks well; no diffs expected